### PR TITLE
Make the kernel actually boot: long mode, interrupts, paging, preemption, ring 3

### DIFF
--- a/.github/workflows/boot.yml
+++ b/.github/workflows/boot.yml
@@ -1,0 +1,48 @@
+name: build-and-boot
+
+# The gate that would have caught this project's core problem: it is not enough
+# for the kernel to compile, it has to actually boot and say so on the serial
+# port. Every PR must keep the boot markers alive.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  boot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust nightly
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rust-src, llvm-tools-preview
+
+      - name: Install GRUB and QEMU
+        run: |
+          sudo apt-get update -qq
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 grub-pc-bin grub-common xorriso mtools
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}
+
+      - name: Build, boot and assert serial markers
+        run: ./scripts/run.sh --check
+
+      - name: Upload boot logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: boot-logs
+          path: |
+            build/serial.txt
+            build/qemu.log

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -41,13 +41,21 @@ The ELF entry point (`ENTRY(_start32)` in `linker.ld`). In order:
 | Bring COM1 up by hand | So a failure *before* Rust is visible instead of a silent reboot |
 | Check magic == `0x36D76289` | Confirms a Multiboot2-compliant loader |
 | CPUID leaf `0x80000001`, EDX bit 29 | Confirms the CPU has long mode at all |
-| Build PML4 / PDPT / PD | Identity-maps the first 1 GiB with 2 MiB pages |
+| Build PML4 / PDPT / PD / PT | Identity-maps the first 1 GiB (see the null guard note below) |
 | CR3, CR4.PAE, EFER.LME, CR0.PG | The actual mode switch |
 | `lgdt` + `ljmp $0x08` | Loads a 64-bit GDT and reloads CS — this is the moment we become 64-bit |
 
 The identity map covers the kernel at 1 MiB, the frame bitmap, the heap, VGA at
 `0xB8000` and QEMU's default RAM. It is deliberately a *bootstrap* map: the
 kernel replaces it with a proper higher-half address space in Phase 3.
+
+**Null guard page.** The first 2 MiB is mapped with 4 KiB pages rather than one
+2 MiB huge page, purely so that page 0 can be left *unmapped*. With a flat
+huge-page map a null pointer dereference silently reads real memory instead of
+faulting — which is exactly the class of bug a kernel most needs to catch. This
+was found by testing: the first version of the trampoline used a huge page for
+0..2 MiB, and a deliberate `read_volatile(0)` returned successfully. Everything
+from 2 MiB up still uses 2 MiB pages.
 
 ### 3. `long_mode_start`
 
@@ -111,12 +119,47 @@ QEMU's `-d int,cpu_reset` output lands in `build/qemu.log`. A `Triple fault`
 line there means an exception fired with no IDT to catch it — which is every
 exception, until Phase 2 installs one.
 
+## Interrupts (Phase 2)
+
+`kernel/src/interrupts/` splits into four pieces:
+
+| File | Role |
+|---|---|
+| `mod.rs` | Builds and loads the IDT; `init()` vs `enable_hardware_interrupts()` |
+| `exceptions.rs` | Vectors 0..31. Print a dump and halt. `#PF` decodes CR2 and the error code; `#BP`/`#DB` return so debuggers work |
+| `pic.rs` | Remaps the 8259 pair to vectors 32..47 |
+| `timer.rs` | PIT channel 0 at 100 Hz, `TICKS` counter, `uptime_ms()`, `sleep_ms()` |
+| `keyboard.rs` | IRQ1 -> port 0x60 -> `pc-keyboard` decode -> SPSC ring buffer |
+
+Two things worth knowing:
+
+**Why the PIC remap is not optional.** On a freshly-booted PC the PICs deliver
+IRQ0..15 on vectors 8..15 and 0x70..0x77. Vector 8 is `#DF Double Fault` — so
+without remapping, the very first timer tick after `sti` arrives as a double
+fault.
+
+**Why `init()` and `enable_hardware_interrupts()` are separate.** The IDT is
+installed immediately after the GDT, so a fault during memory-manager init is
+reported rather than silently fatal. Hardware interrupts are enabled at the very
+end of `init_kernel`, so a timer tick cannot arrive mid-initialisation.
+
+Interrupt handlers use `try_lock`, never `lock`. Blocking on a spinlock held by
+the code you just interrupted is a guaranteed deadlock; dropping a keystroke is
+the correct trade.
+
+Self-test: `init_kernel` raises an `int3` right after loading the IDT and expects
+to resume. If the IDT were missing or malformed, that would triple-fault instead
+of printing `returned from int3 handler`.
+
 ## What is deliberately still missing
 
-- **No IDT.** Any fault is an instant triple fault and reboot. Phase 2.
-- **No timer, no interrupts enabled.** The kernel halts after init. Phase 2.
+- **No preemption.** The timer increments a counter and prints a heartbeat;
+  `scheduler::handle_timer_tick()` is still not called. Phase 4.
+- **No ring 3, no syscall entry.** Phase 5.
 - **`PHYSICAL_MEMORY_OFFSET` is 0**, because the map is flat identity. It
   becomes `0xFFFF_8000_0000_0000` when the kernel builds its own page tables in
   Phase 3.
 - **Swap and power management are disabled** in `init_kernel`. Both were
   simulated, and swap tried to allocate 8 MiB from a 1 MiB heap.
+- **Only IRQ0 and IRQ1 are unmasked.** Everything else on the PIC has a
+  handler that acknowledges and returns.

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -1,0 +1,122 @@
+# How Kosh boots
+
+## The problem this solves
+
+Multiboot2 hands control to the kernel in **32-bit protected mode, paging
+disabled, EFER.LME clear**. The rest of Kosh is compiled as 64-bit code. Before
+this was fixed, GRUB jumped straight into the Rust `_start`, the CPU decoded
+64-bit opcodes as 32-bit instructions, and the machine wandered off into an
+infinite loop with no output — for 27 commits.
+
+Nothing in the kernel had ever executed. Everything below is what closed that gap.
+
+## The chain
+
+```
+BIOS
+ └─> GRUB2  (reads the multiboot2 header in .multiboot2)
+      └─> _start32          kernel/src/boot32.rs   [32-bit protected mode]
+           └─> long_mode_start                     [64-bit long mode]
+                └─> _start   kernel/src/main.rs    [Rust]
+                     └─> boot::init_kernel         kernel/src/boot.rs
+```
+
+### 1. `.multiboot2` header — `kernel/src/main.rs`
+
+A 24-byte header (magic `0xE85250D6`, architecture 0, length, checksum, END
+tag), placed in its own section which `linker.ld` puts first, at 1 MiB. GRUB
+scans the first 32 KiB of the file for it.
+
+`header_length` must cover the END tag — it is `size_of::<Multiboot2Header>()`,
+not a hardcoded constant. Verify with `grub-file --is-x86-multiboot2`.
+
+### 2. `_start32` — the trampoline, `kernel/src/boot32.rs`
+
+The ELF entry point (`ENTRY(_start32)` in `linker.ld`). In order:
+
+| Step | Why |
+|---|---|
+| Stash EAX/EBX into memory | CPUID clobbers EBX, and we need EBX free for serial output |
+| Set up a 64 KiB boot stack | GRUB's stack is not ours to keep |
+| Bring COM1 up by hand | So a failure *before* Rust is visible instead of a silent reboot |
+| Check magic == `0x36D76289` | Confirms a Multiboot2-compliant loader |
+| CPUID leaf `0x80000001`, EDX bit 29 | Confirms the CPU has long mode at all |
+| Build PML4 / PDPT / PD | Identity-maps the first 1 GiB with 2 MiB pages |
+| CR3, CR4.PAE, EFER.LME, CR0.PG | The actual mode switch |
+| `lgdt` + `ljmp $0x08` | Loads a 64-bit GDT and reloads CS — this is the moment we become 64-bit |
+
+The identity map covers the kernel at 1 MiB, the frame bitmap, the heap, VGA at
+`0xB8000` and QEMU's default RAM. It is deliberately a *bootstrap* map: the
+kernel replaces it with a proper higher-half address space in Phase 3.
+
+### 3. `long_mode_start`
+
+Reloads the data segments, resets RSP, then **enables SSE** — rustc emits SSE
+instructions for x86-64 unconditionally, so `CR0.EM` must be clear, `CR0.MP`
+set, and `CR4.OSFXSR | CR4.OSXMMEXCPT` set before any Rust code runs. Finally it
+moves the saved multiboot info pointer into RDI (System V AMD64 puts the first
+argument there) and calls `_start`.
+
+## Memory layout at hand-off
+
+```
+0x00000000  ─┬─ low memory, BIOS, VGA at 0xB8000    (reserved, never allocated)
+0x00100000  ─┼─ __kernel_start
+             │    .multiboot2
+             │    .text     (.text.boot32 first)
+             │    .rodata
+             │    .data
+             │    .bss      ← PML4/PDPT/PD + 64 KiB boot stack live here
+0x00144000  ─┼─ __kernel_end
+             │    physical frame bitmap
+             ├─ kernel heap (1 MiB)
+             └─ free frames
+```
+
+`__kernel_start` / `__kernel_end` are emitted by `linker.ld` and consumed by
+`memory/physical.rs`, which excludes that range from the free list. Without it
+the allocator would happily hand out the frames holding the running kernel — and
+the boot page tables with it.
+
+## Running it
+
+```bash
+./scripts/run.sh           # build, ISO, boot, stream serial to your terminal
+./scripts/run.sh --debug   # same, plus a gdb stub on :1234
+./scripts/run.sh --check   # headless, asserts the boot markers (this is CI)
+```
+
+Expected first two lines:
+
+```
+[boot] 32-bit protected mode entry OK
+[boot] long mode OK, entering Rust
+```
+
+If you see the first and not the second, the mode switch failed — check
+`build/qemu.log` for `Triple fault`. If you see neither, GRUB never reached the
+kernel; check the multiboot2 header.
+
+## Debugging
+
+```bash
+./scripts/run.sh --debug     # terminal 1
+gdb target/x86_64-kosh/release/kosh-kernel
+  (gdb) target remote :1234
+  (gdb) break long_mode_start
+  (gdb) continue
+```
+
+QEMU's `-d int,cpu_reset` output lands in `build/qemu.log`. A `Triple fault`
+line there means an exception fired with no IDT to catch it — which is every
+exception, until Phase 2 installs one.
+
+## What is deliberately still missing
+
+- **No IDT.** Any fault is an instant triple fault and reboot. Phase 2.
+- **No timer, no interrupts enabled.** The kernel halts after init. Phase 2.
+- **`PHYSICAL_MEMORY_OFFSET` is 0**, because the map is flat identity. It
+  becomes `0xFFFF_8000_0000_0000` when the kernel builds its own page tables in
+  Phase 3.
+- **Swap and power management are disabled** in `init_kernel`. Both were
+  simulated, and swap tried to allocate 8 MiB from a 1 MiB heap.

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -65,19 +65,20 @@ set, and `CR4.OSFXSR | CR4.OSXMMEXCPT` set before any Rust code runs. Finally it
 moves the saved multiboot info pointer into RDI (System V AMD64 puts the first
 argument there) and calls `_start`.
 
-## Memory layout at hand-off
+## Memory layout
+
+Physical, at hand-off:
 
 ```
 0x00000000  ─┬─ low memory, BIOS, VGA at 0xB8000    (reserved, never allocated)
 0x00100000  ─┼─ __kernel_start
              │    .multiboot2
-             │    .text     (.text.boot32 first)
-             │    .rodata
+             │    .text     (.text.boot32 first)   __text_start/__text_end
+             │    .rodata                          __rodata_start/__rodata_end
              │    .data
-             │    .bss      ← PML4/PDPT/PD + 64 KiB boot stack live here
+             │    .bss      ← bootstrap page tables + 64 KiB boot stack
 0x00144000  ─┼─ __kernel_end
              │    physical frame bitmap
-             ├─ kernel heap (1 MiB)
              └─ free frames
 ```
 
@@ -85,6 +86,21 @@ argument there) and calls `_start`.
 `memory/physical.rs`, which excludes that range from the free list. Without it
 the allocator would happily hand out the frames holding the running kernel — and
 the boot page tables with it.
+
+Virtual, once `memory::paging` has installed the kernel's own tables:
+
+```
+0x0000_0000_0000_0000   unmapped                    null guard
+0x0000_0000_0000_1000 ┬ identity window, 4 KiB pages, W^X
+                      │   .text            R-X
+                      │   .rodata          R--  NX
+                      │   .data/.bss       RW-  NX
+                      │   VGA, frame bitmap RW- NX
+0x0000_0000_0040_0000 ┘
+        ...
+0xFFFF_8000_0000_0000   physmap: all of RAM, 2 MiB pages, RW+NX
+0xFFFF_9000_0000_0000   kernel heap window, 4 KiB pages, RW+NX
+```
 
 ## Running it
 
@@ -150,6 +166,53 @@ the correct trade.
 Self-test: `init_kernel` raises an `int3` right after loading the IDT and expects
 to resume. If the IDT were missing or malformed, that would triple-fault instead
 of printing `returned from int3 handler`.
+
+## Page tables (Phase 3)
+
+`kernel/src/memory/paging.rs` replaces the bootstrap map with tables the kernel
+builds itself. `Cr3::write` appeared nowhere in the tree before this — the
+"virtual memory manager" was reading the bootloader's CR3 and describing it.
+
+What it sets up:
+
+- **W^X on the kernel image.** `.text` is R-X, `.rodata` is R-- NX, everything
+  else is RW- NX. Nothing is both writable and executable.
+- **A physmap** at `0xFFFF_8000_0000_0000` covering all of RAM in 2 MiB pages.
+  `vmm.rs`'s `PHYSICAL_MEMORY_OFFSET` had always claimed this existed; now it
+  does, so the constant is back to its intended value.
+- **A heap window** at `0xFFFF_9000_0000_0000`. The heap used to take the raw
+  physical address of a contiguous frame run and use it as a pointer.
+- **Page 0 still unmapped.**
+
+Two flags that are easy to miss, both of which this code got wrong first time:
+
+| Flag | Without it |
+|---|---|
+| `EFER.NXE` | The NX bit is *reserved*. Setting it turns every NX mapping into a reserved-bit page fault instead of a protection. |
+| `CR0.WP` | Read-only pages do not apply to ring 0. The kernel can write straight through a read-only PTE, and W^X is decorative. A deliberate write to `.text` succeeded until this was set. |
+
+`paging::self_test()` checks that the physmap aliases the identity map, that
+`translate()` round-trips, and that page 0 is unmapped.
+
+## Heap (Phase 3)
+
+Three fixes in `memory/heap.rs`, all verified by `heap::stress_test()` — 2000
+mixed-size, mixed-alignment allocations, freed out of order:
+
+- **Alignment is honoured.** `find_free_block` ignored `layout.align()`
+  entirely: it aligned to `PAGE_SIZE` regardless of the request, then returned
+  the *unaligned* pointer anyway. It now carves a leading free block off the
+  front when the payload needs to move.
+- **Every block base is 16-aligned.** `BlockHeader` is `#[repr(C, align(16))]`
+  and allocation sizes round up to 16, so splitting preserves the invariant.
+  Without this, payloads drifted onto odd offsets and even an 8-byte alignment
+  request failed after the first split.
+- **Coalescing exists.** `coalesce_free_blocks` was an empty function with a
+  comment describing what it would do, so the heap fragmented monotonically. It
+  now walks the block chain in address order and merges adjacent free runs.
+
+The stress test asserts the heap collapses back to exactly one free block of its
+original size — which is the only way to prove coalescing works.
 
 ## What is deliberately still missing
 

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -291,9 +291,125 @@ exist until ring 3 arrives in Phase 5. When they do, the intended shape is for
 `task` to ask `process::scheduler` which process to run next — not for
 `process::scheduler` to grow its own switch.
 
-## What is deliberately still missing
+## Ring 3 and syscalls (Phase 5)
 
-- **No ring 3, no syscall entry.** Phase 5.
+`iretq`, `sysretq`, `swapgs` and `user_code_segment` had **zero occurrences** in
+this repository before Phase 5. For a microkernel — an architecture whose whole
+premise is that services run outside the kernel — that was the biggest gap in
+the project.
+
+| File | Role |
+|---|---|
+| `gdt.rs` | GDT with ring-3 descriptors, TSS with RSP0 |
+| `syscall/entry.rs` | MSR setup and the `syscall` assembly stub |
+| `syscall/uaccess.rs` | `copy_from_user` / `copy_to_user` and range validation |
+| `usermode.rs` | Maps the payload, drops to ring 3 via `iretq` |
+| `user_program.rs` | The ring-3 payload, in position-independent assembly |
+
+### The GDT order is not arbitrary
+
+`syscall` loads CS from `STAR[47:32]` and SS from `STAR[47:32] + 8`. `sysretq`
+loads CS from `STAR[63:48] + 16` and SS from `STAR[63:48] + 8`. The CPU just
+adds those offsets, so the table has to match:
+
+```
+  0x00  null
+  0x08  kernel code   <- STAR[47:32]
+  0x10  kernel data       (= 0x08 + 8)        <- STAR[63:48]
+  0x18  user data         (= 0x10 + 8)   sysret SS, RPL 3 -> 0x1B
+  0x20  user code (64)    (= 0x10 + 16)  sysret CS, RPL 3 -> 0x23
+  0x28  TSS (two slots)
+```
+
+User *data* comes before user *code*. That reads backwards until you write out
+the `sysret` arithmetic, and getting it the intuitive way round is a classic
+route to a #GP the first time a process returns to ring 3.
+
+`TSS.RSP0` is the stack the CPU switches to when an interrupt arrives in ring 3.
+Without it, the first timer tick after entering user mode is a triple fault.
+
+### Getting to ring 3
+
+There is no "jump to user mode" instruction. You fake a return from one: push
+the five words `iretq` expects — SS, RSP, RFLAGS, CS, RIP — with ring-3
+selectors, and execute it.
+
+The user program enters with IF set, so the timer can still preempt it. A ring-3
+thread that cannot be preempted is a ring-3 thread that can hang the machine
+with `for {}`.
+
+### The syscall path
+
+`syscall` is fast because it does almost nothing: CS/SS from `STAR`, RIP from
+`LSTAR`, RFLAGS masked by `SFMASK`, caller's RIP into RCX and RFLAGS into R11 —
+and **RSP still points at the user stack**. The stack switch is the kernel's job
+and is the first thing the stub does.
+
+Argument 4 travels in R10 rather than RCX precisely because `syscall` destroys
+RCX.
+
+`SFMASK` masks IF, so a syscall cannot be interrupted. That is what makes the
+single static kernel syscall stack safe for now; multiple user threads will need
+`swapgs` and a per-CPU block.
+
+### Trusting nothing from ring 3
+
+`syscall/uaccess.rs` does two checks, both necessary:
+
+1. **Range** — the whole span must lie in the lower canonical half.
+2. **Mapping** — every page must be present *and* `USER_ACCESSIBLE`. Range
+   checking alone is not enough; a kernel-only page can sit at a low address.
+
+This is what `sys_write` was missing. It used to return the byte count without
+reading the buffer; `sys_read` returned a length without writing one; and
+`sys_send_message` discarded the user pointer and sent a `format!` string
+instead. All of them "worked" because nothing could call them.
+
+One subtlety worth knowing: `SyscallError::to_errno()` already returns
+*negative* numbers (-22 for EINVAL). Negating it in the handler — the obvious
+thing to write, since the Linux convention is "negative means error" — flips
+every failure positive, and userspace then reads all errors as success. The
+handler normalises rather than assuming.
+
+### A userspace fault must not be fatal
+
+The page-fault handler checks `USER_MODE` in the error code. If the fault came
+from ring 3 it terminates that thread and returns to the scheduler instead of
+halting. Any other behaviour would mean a userspace bug takes the whole system
+down — which is the thing a microkernel exists to prevent.
+
+### Proving it
+
+Two payloads run, back to back:
+
+```
+--- ring 3 output ---
+hello from ring 3
+Process 1 syscall write failed: InvalidArgument
+kernel rejected my out-of-bounds pointer
+Process 1 terminated with exit code 0
+--- back in ring 0 ---
+
+--- ring 3 output ---
+about to dereference a kernel address directly
+
+==================== PAGE FAULT ====================
+  accessed address : 0xffff800000000000
+  cause            : protection violation while reading in user mode
+  error code       : PageFaultErrorCode(PROTECTION_VIOLATION | USER_MODE)
+  action           : ring 3 fault — terminating the process
+  rip              : 0x00000000400000c4
+====================================================
+--- kernel survived a ring 3 fault ---
+```
+
+The first payload asks the kernel to `write` from a kernel address and reports
+back whether it was refused — the validation is tested *from the user side*, not
+by the kernel checking itself. The second bypasses syscalls entirely and touches
+kernel memory directly, so page protection rather than argument validation has
+to stop it.
+
+## What is deliberately still missing
 - **`PHYSICAL_MEMORY_OFFSET` is 0**, because the map is flat identity. It
   becomes `0xFFFF_8000_0000_0000` when the kernel builds its own page tables in
   Phase 3.

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -214,10 +214,85 @@ mixed-size, mixed-alignment allocations, freed out of order:
 The stress test asserts the heap collapses back to exactly one free block of its
 original size — which is the only way to prove coalescing works.
 
+## Scheduling (Phase 4)
+
+`kernel/src/task/` is the first thing in Kosh that actually schedules.
+
+| File | Role |
+|---|---|
+| `switch.rs` | `kosh_switch_context(prev_rsp, next_rsp)` — the whole switch, in `global_asm!` |
+| `mod.rs` | Thread table, round-robin picker, `spawn` / `schedule` / `on_tick` / `exit_current` |
+
+**The switch is a plain `extern "C"` call, not interrupt machinery.** It follows
+the System V AMD64 ABI, so the caller has already spilled its caller-saved
+registers; the function only preserves RBX, RBP, R12-R15 and RFLAGS. It pushes
+those, stores RSP in the outgoing TCB, loads RSP from the incoming TCB, pops
+them back, and returns.
+
+The consequence is the part worth internalising: **the incoming thread resumes
+by returning out of its own earlier call to this function.** Thread B returns
+into B's `schedule()`, which returns into B's timer handler, whose `iretq`
+resumes whatever B was doing. Nothing reconstructs an interrupt frame, because
+B's frame never left B's stack.
+
+A brand-new thread has no such history, so `Thread::prepare_stack` fabricates
+one. From low address to high: RFLAGS, R15, R14, R13, R12, RBX, RBP, return
+address, and one dummy word. The dummy is for ABI alignment — after `ret` pops
+the return address, RSP must be 8 mod 16, which is the state a function sees
+right after a real `call`. The synthesised RFLAGS has IF *clear*, because a new
+thread is first entered from inside the timer handler; `thread_bootstrap`
+enables interrupts itself once it is on its own stack and holds no locks.
+
+Three rules the code follows, each of which is a hang if broken:
+
+1. **Every scheduler access runs with interrupts disabled.** The timer handler
+   takes the same lock.
+2. **The lock is released before the switch.** Holding a spinlock across a
+   context switch parks it in the outgoing thread; the incoming thread spins on
+   it forever.
+3. **EOI before scheduling.** `on_tick` may not return to the handler for a long
+   time, and until the PIC is acknowledged it delivers no further timer
+   interrupts to anybody.
+
+`serial::_print` and `vga_buffer::_print` now disable interrupts while holding
+their port locks, for the same reason as rule 2 — a thread preempted mid-print
+would otherwise deadlock the next thread that prints.
+
+### Proving it
+
+`init_scheduler` spawns three threads that each print a letter and then busy-wait
+on the tick counter. They never yield, never sleep, never block. The only thing
+that can interleave them is the timer taking the CPU away:
+
+```
+Expect A/B/C to interleave — none of them ever yields:
+  A B C A B C A B C A B C A B C A B C A B C A B C
+Thread table:
+  [0] kmain      Running  18 ticks
+  [1] worker-A   Finished  16 ticks
+  [2] worker-B   Finished  16 ticks
+  [3] worker-C   Finished  17 ticks
+  context switches: 36
+Scheduler: PASS — 36 real context switches
+```
+
+If those letters ever come out as `A A A ... B B B ...`, scheduling has become
+cooperative and something is broken.
+
+### What about `process/scheduler.rs`?
+
+It stays. It is scheduling *policy* — round-robin, priorities, a simplified CFS —
+over a process table, and it is real code. What it is not is wired to anything:
+`handle_timer_tick` still has no caller.
+
+`task` covers **kernel** threads, which share the kernel address space and run
+in ring 0. `process` is meant to govern **userspace** processes, which do not
+exist until ring 3 arrives in Phase 5. When they do, the intended shape is for
+`task` to ask `process::scheduler` which process to run next — not for
+`process::scheduler` to grow its own switch.
+
 ## What is deliberately still missing
 
-- **No preemption.** The timer increments a counter and prints a heartbeat;
-  `scheduler::handle_timer_tick()` is still not called. Phase 4.
 - **No ring 3, no syscall entry.** Phase 5.
 - **`PHYSICAL_MEMORY_OFFSET` is 0**, because the map is flat identity. It
   becomes `0xFFFF_8000_0000_0000` when the kernel builds its own page tables in

--- a/kernel/build.rs
+++ b/kernel/build.rs
@@ -1,7 +1,17 @@
+use std::path::PathBuf;
+
 fn main() {
-    // Use our custom linker script
-    println!("cargo:rustc-link-arg=-Tkernel/linker.ld");
-    
-    // Rerun if the linker script changes
+    // Use an absolute path for the linker script. A relative path is resolved
+    // against the *linker's* working directory, so `-Tkernel/linker.ld` only
+    // worked when cargo happened to be invoked from the workspace root — and
+    // failed silently (dropping the multiboot2 header) otherwise.
+    let manifest_dir = PathBuf::from(
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR not set"),
+    );
+    let linker_script = manifest_dir.join("linker.ld");
+
+    println!("cargo:rustc-link-arg=-T{}", linker_script.display());
+
     println!("cargo:rerun-if-changed=linker.ld");
+    println!("cargo:rerun-if-changed=build.rs");
 }

--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -35,6 +35,17 @@ SECTIONS
     . = ALIGN(4K);
     __rodata_end = .;
 
+    /* Ring-3 payload. Its own page-aligned section so it can be mapped into
+       user space independently of anything the kernel keeps to itself. */
+    . = ALIGN(4K);
+    __user_start = .;
+    .user ALIGN(4K) :
+    {
+        KEEP(*(.user))
+    }
+    . = ALIGN(4K);
+    __user_end = .;
+
     .data ALIGN(4K) :
     {
         *(.data .data.*)

--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -17,17 +17,23 @@ SECTIONS
         KEEP(*(.multiboot2))
     }
 
+    __text_start = .;
     .text ALIGN(4K) :
     {
         KEEP(*(.text.boot32))
         *(.text .text.*)
     }
+    . = ALIGN(4K);
+    __text_end = .;
 
+    __rodata_start = .;
     .rodata ALIGN(4K) :
     {
         KEEP(*(.rodata.boot32))
         *(.rodata .rodata.*)
     }
+    . = ALIGN(4K);
+    __rodata_end = .;
 
     .data ALIGN(4K) :
     {

--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -1,8 +1,16 @@
-ENTRY(_start)
+/* Kosh kernel link script.
+ *
+ * The ELF entry point is the 32-bit trampoline in src/boot32.rs, NOT the Rust
+ * `_start` — Multiboot2 hands off in 32-bit protected mode.
+ */
+
+ENTRY(_start32)
 
 SECTIONS
 {
     . = 1M;
+
+    __kernel_start = .;
 
     .multiboot2 ALIGN(8) :
     {
@@ -11,29 +19,36 @@ SECTIONS
 
     .text ALIGN(4K) :
     {
-        *(.text)
+        KEEP(*(.text.boot32))
+        *(.text .text.*)
     }
 
     .rodata ALIGN(4K) :
     {
-        *(.rodata)
+        KEEP(*(.rodata.boot32))
+        *(.rodata .rodata.*)
     }
 
     .data ALIGN(4K) :
     {
-        *(.data)
+        *(.data .data.*)
+        *(.got .got.plt)
     }
 
     .bss ALIGN(4K) :
     {
         *(COMMON)
-        *(.bss)
+        *(.bss .bss.*)
     }
+
+    . = ALIGN(4K);
+    __kernel_end = .;
 
     /DISCARD/ :
     {
         *(.comment)
         *(.eh_frame)
-        *(.note.gnu.build-id)
+        *(.eh_frame_hdr)
+        *(.note .note.*)
     }
 }

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -76,14 +76,20 @@ pub fn init_kernel(boot_info: BootInformation) {
     // Initialize physical memory manager
     init_physical_memory(&boot_info);
     
+    // Initialize kernel heap allocator.
+    //
+    // ORDER MATTERS: this must come *before* init_virtual_memory(), which
+    // pushes region descriptors into a Vec and therefore allocates. Running it
+    // first meant allocating against a null heap on every boot.
+    init_heap_allocator();
+    
     // Initialize virtual memory management
     init_virtual_memory();
     
-    // Initialize kernel heap allocator
-    init_heap_allocator();
-    
-    // Initialize swap space management
-    init_swap_management();
+    // DISABLED (Phase 1): init_swap_management() allocates an 8 MiB Vec as a
+    // "swap file" out of a 1 MiB kernel heap whose MAX_ALLOC_SIZE is 1 MiB.
+    // It cannot succeed. Re-enable once there is a real block device.
+    // init_swap_management();
     
     // Initialize process management
     init_process_management();
@@ -94,8 +100,10 @@ pub fn init_kernel(boot_info: BootInformation) {
     // Initialize system call interface
     init_syscall_interface();
     
-    // Initialize power management framework
-    init_power_management();
+    // DISABLED (Phase 1): the power management subsystem is entirely simulated
+    // (no ACPI, no MSRs, constant battery level) and test_power_management()
+    // is 236 lines of printing those simulated results during boot.
+    // init_power_management();
     
     // Initialize early console output (already done in main, but ensure it's working)
     test_console_output();

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -126,6 +126,10 @@ pub fn init_kernel(boot_info: BootInformation) {
     // Deliberately last, so a timer tick cannot arrive mid-initialisation.
     crate::interrupts::enable_hardware_interrupts();
     
+    // Kernel threads. Needs a live timer, so it has to come after the line
+    // above.
+    init_scheduler();
+    
     serial_println!("Kernel initialization complete");
 }
 
@@ -746,6 +750,68 @@ fn test_virtual_memory() {
     }
     
     serial_println!("Virtual memory management test complete");
+}
+
+/// Bring up preemptive kernel threading and prove it works.
+#[cfg(target_arch = "x86_64")]
+fn init_scheduler() {
+    serial_println!("Initializing kernel threads...");
+    crate::task::init();
+
+    for (i, name) in ["worker-A", "worker-B", "worker-C"].iter().enumerate() {
+        if let Err(e) = crate::task::spawn(name, scheduler_demo_thread, i) {
+            serial_println!("Failed to spawn {}: {}", name, e);
+            return;
+        }
+    }
+
+    serial_println!("Starting preemptive scheduling...");
+    serial_println!("Expect A/B/C to interleave — none of them ever yields:");
+    crate::serial_print!("  ");
+
+    crate::task::start();
+
+    // Wait for the workers. `hlt` parks the CPU until the next interrupt, which
+    // is what lets the timer preempt us into the workers in the first place.
+    while crate::task::live_threads() > 0 {
+        x86_64::instructions::hlt();
+    }
+
+    serial_println!();
+    crate::task::print_threads();
+    crate::task::reap_finished();
+
+    let switches = crate::task::switch_count();
+    if switches > 10 {
+        serial_println!("Scheduler: PASS — {} real context switches", switches);
+    } else {
+        serial_println!("Scheduler: FAIL — only {} context switches", switches);
+    }
+}
+
+/// Body of each demo thread.
+///
+/// The busy-wait is the point. These threads never call `yield_now`, never
+/// sleep, and never block on anything — so the *only* way their output can
+/// interleave is if the timer interrupt takes the CPU away from them. If the
+/// letters come out as `A A A ... B B B ... C C C`, scheduling is cooperative
+/// and something is wrong.
+#[cfg(target_arch = "x86_64")]
+fn scheduler_demo_thread(index: usize) {
+    const NAMES: [&str; 3] = ["A", "B", "C"];
+    const ROUNDS: usize = 8;
+    const BUSY_TICKS: u64 = 5; // 50 ms of work per round, slice is 20 ms
+
+    let name = NAMES[index % NAMES.len()];
+
+    for _ in 0..ROUNDS {
+        crate::serial_print!("{} ", name);
+
+        let target = crate::interrupts::timer::ticks() + BUSY_TICKS;
+        while crate::interrupts::timer::ticks() < target {
+            core::hint::spin_loop();
+        }
+    }
 }
 
 /// Build and install the kernel page tables.

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -1,63 +1,11 @@
 #[cfg(target_arch = "x86_64")]
 use multiboot2::BootInformation;
-#[cfg(target_arch = "x86_64")]
-use x86_64::structures::gdt::{GlobalDescriptorTable, Descriptor, SegmentSelector};
-#[cfg(target_arch = "x86_64")]
-use x86_64::structures::tss::TaskStateSegment;
-#[cfg(target_arch = "x86_64")]
-use x86_64::instructions::segmentation::Segment;
-#[cfg(target_arch = "x86_64")]
-use x86_64::VirtAddr;
-use lazy_static::lazy_static;
 use crate::{println, serial_println};
 use crate::memory;
 
-#[cfg(target_arch = "x86_64")]
-/// IST slot used for the double-fault handler's stack. A double fault caused
-/// by a bad kernel stack cannot push its exception frame onto that same stack,
-/// so it needs a known-good one.
-pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
-
-#[cfg(target_arch = "x86_64")]
-lazy_static! {
-    static ref TSS: TaskStateSegment = {
-        let mut tss = TaskStateSegment::new();
-        tss.interrupt_stack_table[DOUBLE_FAULT_IST_INDEX as usize] = {
-            const STACK_SIZE: usize = 4096 * 5;
-            static mut STACK: [u8; STACK_SIZE] = [0; STACK_SIZE];
-
-            let stack_start = VirtAddr::from_ptr(&raw const STACK);
-            let stack_end = stack_start + STACK_SIZE;
-            stack_end
-        };
-        tss
-    };
-}
-
-#[cfg(target_arch = "x86_64")]
-lazy_static! {
-    static ref GDT: (GlobalDescriptorTable, Selectors) = {
-        let mut gdt = GlobalDescriptorTable::new();
-        let code_selector = gdt.add_entry(Descriptor::kernel_code_segment());
-        let data_selector = gdt.add_entry(Descriptor::kernel_data_segment());
-        let tss_selector = gdt.add_entry(Descriptor::tss_segment(&TSS));
-        (
-            gdt,
-            Selectors {
-                code_selector,
-                data_selector,
-                tss_selector,
-            },
-        )
-    };
-}
-
-#[cfg(target_arch = "x86_64")]
-struct Selectors {
-    code_selector: SegmentSelector,
-    data_selector: SegmentSelector,
-    tss_selector: SegmentSelector,
-}
+// GDT, TSS and the double-fault IST now live in `crate::gdt`, which owns the
+// ring-3 descriptors and RSP0 as well. See that module for why the descriptor
+// order is load-bearing once SYSCALL/SYSRET exist.
 
 #[cfg(target_arch = "x86_64")]
 /// Initialize the kernel with multiboot2 information
@@ -70,8 +18,8 @@ pub fn init_kernel(boot_info: BootInformation) {
     // Set up basic CPU state first
     init_cpu_state();
     
-    // Set up GDT and TSS
-    init_gdt();
+    // Set up GDT and TSS (now including ring-3 descriptors and RSP0)
+    crate::gdt::init();
     
     // Install the IDT before anything else can fault. From here on a bad
     // pointer produces a legible dump instead of a silent triple fault.
@@ -129,6 +77,9 @@ pub fn init_kernel(boot_info: BootInformation) {
     // Kernel threads. Needs a live timer, so it has to come after the line
     // above.
     init_scheduler();
+    
+    // Ring 3.
+    init_usermode();
     
     serial_println!("Kernel initialization complete");
 }
@@ -471,29 +422,6 @@ fn test_power_management() {
 }
 
 /// Initialize Global Descriptor Table and Task State Segment
-fn init_gdt() {
-    serial_println!("Setting up GDT and TSS...");
-    
-    GDT.0.load();
-    
-    unsafe {
-        // Load code segment
-        x86_64::instructions::segmentation::CS::set_reg(GDT.1.code_selector);
-        
-        // Load data segments
-        x86_64::instructions::segmentation::DS::set_reg(GDT.1.data_selector);
-        x86_64::instructions::segmentation::ES::set_reg(GDT.1.data_selector);
-        x86_64::instructions::segmentation::FS::set_reg(GDT.1.data_selector);
-        x86_64::instructions::segmentation::GS::set_reg(GDT.1.data_selector);
-        x86_64::instructions::segmentation::SS::set_reg(GDT.1.data_selector);
-        
-        // Load TSS
-        x86_64::instructions::tables::load_tss(GDT.1.tss_selector);
-    }
-    
-    serial_println!("GDT and TSS initialized");
-}
-
 /// Parse and display memory map information from multiboot2
 fn parse_memory_map(boot_info: &BootInformation) {
     serial_println!("Parsing memory map...");
@@ -750,6 +678,45 @@ fn test_virtual_memory() {
     }
     
     serial_println!("Virtual memory management test complete");
+}
+
+/// Drop into ring 3 and run the user payload.
+#[cfg(target_arch = "x86_64")]
+fn init_usermode() {
+    crate::syscall::uaccess::self_test();
+
+    let before = crate::syscall::entry::syscall_count();
+
+    // Demo 1: syscalls from ring 3, including one the kernel must refuse.
+    if let Err(e) = crate::task::spawn("user-syscall", crate::usermode::run_user_demo, 0) {
+        serial_println!("Failed to spawn user thread: {}", e);
+        return;
+    }
+    while crate::task::live_threads() > 0 {
+        x86_64::instructions::hlt();
+    }
+    serial_println!("--- back in ring 0 ---");
+    crate::task::reap_finished();
+
+    // Demo 2: a ring-3 program that dereferences kernel memory. The kernel must
+    // kill it and survive.
+    serial_println!();
+    if let Err(e) = crate::task::spawn("user-fault", crate::usermode::run_user_demo, 1) {
+        serial_println!("Failed to spawn faulting user thread: {}", e);
+        return;
+    }
+    while crate::task::live_threads() > 0 {
+        x86_64::instructions::hlt();
+    }
+    serial_println!("--- kernel survived a ring 3 fault ---");
+    crate::task::reap_finished();
+
+    let serviced = crate::syscall::entry::syscall_count() - before;
+    if serviced >= 4 {
+        serial_println!("Ring 3: PASS — {} syscalls serviced from user mode", serviced);
+    } else {
+        serial_println!("Ring 3: FAIL — only {} syscalls serviced", serviced);
+    }
 }
 
 /// Bring up preemptive kernel threading and prove it works.

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -84,14 +84,20 @@ pub fn init_kernel(boot_info: BootInformation) {
     // Initialize physical memory manager
     init_physical_memory(&boot_info);
     
+    // Build and install the kernel's own page tables, replacing the crude
+    // identity map the boot trampoline set up. Needs only the frame allocator,
+    // so it can run before the heap exists.
+    init_paging();
+    
     // Initialize kernel heap allocator.
     //
-    // ORDER MATTERS: this must come *before* init_virtual_memory(), which
-    // pushes region descriptors into a Vec and therefore allocates. Running it
-    // first meant allocating against a null heap on every boot.
+    // ORDER MATTERS: after paging (the heap is now mapped into its own virtual
+    // window, so page tables must exist) and before init_virtual_memory(),
+    // which pushes region descriptors into a Vec and therefore allocates.
+    // Running the VMM first meant allocating against a null heap every boot.
     init_heap_allocator();
     
-    // Initialize virtual memory management
+    // Initialize virtual memory management bookkeeping
     init_virtual_memory();
     
     // DISABLED (Phase 1): init_swap_management() allocates an 8 MiB Vec as a
@@ -742,12 +748,29 @@ fn test_virtual_memory() {
     serial_println!("Virtual memory management test complete");
 }
 
+/// Build and install the kernel page tables.
+#[cfg(target_arch = "x86_64")]
+fn init_paging() {
+    let phys_end = memory::physical::physical_memory_end();
+
+    match memory::paging::init(phys_end) {
+        Ok(()) => {
+            memory::paging::self_test();
+        }
+        Err(e) => {
+            serial_println!("Failed to build kernel page tables: {}", e);
+            panic!("paging initialization failed");
+        }
+    }
+}
+
 /// Initialize kernel heap allocator
 fn init_heap_allocator() {
     serial_println!("Initializing kernel heap allocator...");
     
-    // Allocate 1MB (256 pages) for the kernel heap
-    const HEAP_SIZE_PAGES: usize = 256;
+    // 4 MiB of kernel heap. Frames no longer need to be physically contiguous,
+    // so this is just 1024 mapped pages.
+    const HEAP_SIZE_PAGES: usize = 1024;
     
     match memory::heap::init_kernel_heap(HEAP_SIZE_PAGES) {
         Ok(()) => {
@@ -769,6 +792,9 @@ fn test_heap_allocator() {
     
     // Test the heap allocator functionality
     memory::heap::test_heap_allocator();
+    
+    // Prove alignment and coalescing actually work.
+    memory::heap::stress_test();
     
     // Test Rust's built-in allocation using Vec
     {

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -13,7 +13,10 @@ use crate::{println, serial_println};
 use crate::memory;
 
 #[cfg(target_arch = "x86_64")]
-const DOUBLE_FAULT_IST_INDEX: u16 = 0;
+/// IST slot used for the double-fault handler's stack. A double fault caused
+/// by a bad kernel stack cannot push its exception frame onto that same stack,
+/// so it needs a known-good one.
+pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
 
 #[cfg(target_arch = "x86_64")]
 lazy_static! {
@@ -70,6 +73,11 @@ pub fn init_kernel(boot_info: BootInformation) {
     // Set up GDT and TSS
     init_gdt();
     
+    // Install the IDT before anything else can fault. From here on a bad
+    // pointer produces a legible dump instead of a silent triple fault.
+    crate::interrupts::init();
+    crate::interrupts::test_breakpoint_exception();
+    
     // Parse and display memory information
     parse_memory_map(&boot_info);
     
@@ -107,6 +115,10 @@ pub fn init_kernel(boot_info: BootInformation) {
     
     // Initialize early console output (already done in main, but ensure it's working)
     test_console_output();
+    
+    // Everything is up: remap the PIC, start the PIT and enable interrupts.
+    // Deliberately last, so a timer tick cannot arrive mid-initialisation.
+    crate::interrupts::enable_hardware_interrupts();
     
     serial_println!("Kernel initialization complete");
 }

--- a/kernel/src/boot32.rs
+++ b/kernel/src/boot32.rs
@@ -84,14 +84,20 @@ check_long_mode:
     ret
 
 /* --- bootstrap page tables --------------------------------------------- */
-/* Identity-maps 0..1GiB with 2 MiB pages. That covers the kernel image at
-   1 MiB, the frame bitmap, the heap, VGA at 0xB8000 and QEMU's default RAM. */
+/* Identity-maps 0..1GiB. That covers the kernel image at 1 MiB, the frame
+   bitmap, the heap, VGA at 0xB8000 and QEMU's default RAM.
+ *
+ * The first 2 MiB uses 4 KiB pages rather than one huge page, purely so that
+ * page 0 can be left unmapped as a null guard. With a flat huge-page map, a
+ * null pointer dereference silently reads real memory instead of faulting —
+ * which is precisely the class of bug an OS most needs to catch. Everything
+ * from 2 MiB up uses 2 MiB pages. */
 
 setup_page_tables:
-    /* Zero PML4, PDPT and PD (3 * 4096 bytes = 3072 dwords). */
+    /* Zero PML4, PDPT, PD and the first-2MiB PT (4 * 4096 = 4096 dwords). */
     movl    $p4_table, %edi
     xorl    %eax, %eax
-    movl    $3072, %ecx
+    movl    $4096, %ecx
     rep stosl
 
     /* PML4[0] -> PDPT, present + writable */
@@ -104,8 +110,27 @@ setup_page_tables:
     orl     $0x03, %eax
     movl    %eax, p3_table
 
-    /* PD[i] = (i * 2MiB) | present | writable | huge */
-    xorl    %ecx, %ecx
+    /* PD[0] -> PT (4 KiB pages), present + writable, NOT huge */
+    movl    $p1_table, %eax
+    orl     $0x03, %eax
+    movl    %eax, p2_table
+
+    /* PT[i] = (i * 4KiB) | present | writable, for i = 1..511.
+       PT[0] is deliberately left zero: unmapped null guard page. */
+    movl    $1, %ecx
+2:
+    movl    %ecx, %eax
+    shll    $12, %eax
+    orl     $0x03, %eax
+    movl    $p1_table, %edi
+    movl    %eax, (%edi, %ecx, 8)
+    movl    $0, 4(%edi, %ecx, 8)
+    incl    %ecx
+    cmpl    $512, %ecx
+    jne     2b
+
+    /* PD[i] = (i * 2MiB) | present | writable | huge, for i = 1..511. */
+    movl    $1, %ecx
 1:
     movl    $0x200000, %eax
     mull    %ecx                    /* EDX:EAX = 2MiB * i */
@@ -284,6 +309,8 @@ p4_table:
 p3_table:
     .skip   4096
 p2_table:
+    .skip   4096
+p1_table:
     .skip   4096
 mb_magic:
     .skip   4

--- a/kernel/src/boot32.rs
+++ b/kernel/src/boot32.rs
@@ -1,0 +1,298 @@
+//! 32-bit Multiboot2 entry trampoline.
+//!
+//! Multiboot2 hands control to the kernel in **32-bit protected mode with
+//! paging disabled**. The rest of the kernel is compiled as 64-bit code, so
+//! something has to bridge the gap. That is this file.
+//!
+//! Sequence:
+//!   1. `_start32` — stash the multiboot magic/info pointer, set up a stack,
+//!      bring COM1 up so we can talk even if everything else fails.
+//!   2. Validate the multiboot2 magic and check the CPU actually has long mode.
+//!   3. Build a bootstrap identity map of the first 1 GiB using 2 MiB pages.
+//!   4. CR3 <- PML4, CR4.PAE, EFER.LME, CR0.PG, load a 64-bit GDT, far jump.
+//!   5. `long_mode_start` — reload segments, enable SSE (rustc emits SSE for
+//!      x86-64 by default), then call the Rust `_start(mb_info_addr)`.
+//!
+//! Registers at Multiboot2 hand-off: EAX = 0x36D76289, EBX = &boot_info.
+//! The System V AMD64 ABI wants the first argument in RDI, so we marshal it.
+
+core::arch::global_asm!(
+    r#"
+.section .text.boot32, "ax"
+.code32
+.global _start32
+.type _start32, @function
+
+_start32:
+    cli
+    cld
+
+    /* Stash the Multiboot2 hand-off registers before anything can clobber
+       them (CPUID clobbers EBX, and we need EBX free for serial output). */
+    movl    %eax, mb_magic
+    movl    %ebx, mb_info
+
+    movl    $stack_top, %esp
+    xorl    %ebp, %ebp
+
+    call    serial_init32
+
+    movl    $msg_boot32, %esi
+    call    puts32
+
+    /* Verify we were actually loaded by a Multiboot2-compliant loader. */
+    movl    mb_magic, %eax
+    cmpl    $0x36D76289, %eax
+    jne     bad_magic
+
+    call    check_long_mode
+    call    setup_page_tables
+    call    enable_paging
+
+    lgdt    gdt64_ptr
+    ljmp    $0x08, $long_mode_start
+
+/* --- error paths ------------------------------------------------------- */
+
+bad_magic:
+    movl    $msg_badmagic, %esi
+    call    puts32
+    jmp     halt32
+
+no_long_mode:
+    movl    $msg_nolm, %esi
+    call    puts32
+    jmp     halt32
+
+halt32:
+    cli
+    hlt
+    jmp     halt32
+
+/* --- long mode capability check ---------------------------------------- */
+
+check_long_mode:
+    movl    $0x80000000, %eax
+    cpuid
+    cmpl    $0x80000001, %eax
+    jb      no_long_mode
+
+    movl    $0x80000001, %eax
+    cpuid
+    testl   $(1 << 29), %edx        /* LM bit */
+    jz      no_long_mode
+    ret
+
+/* --- bootstrap page tables --------------------------------------------- */
+/* Identity-maps 0..1GiB with 2 MiB pages. That covers the kernel image at
+   1 MiB, the frame bitmap, the heap, VGA at 0xB8000 and QEMU's default RAM. */
+
+setup_page_tables:
+    /* Zero PML4, PDPT and PD (3 * 4096 bytes = 3072 dwords). */
+    movl    $p4_table, %edi
+    xorl    %eax, %eax
+    movl    $3072, %ecx
+    rep stosl
+
+    /* PML4[0] -> PDPT, present + writable */
+    movl    $p3_table, %eax
+    orl     $0x03, %eax
+    movl    %eax, p4_table
+
+    /* PDPT[0] -> PD, present + writable */
+    movl    $p2_table, %eax
+    orl     $0x03, %eax
+    movl    %eax, p3_table
+
+    /* PD[i] = (i * 2MiB) | present | writable | huge */
+    xorl    %ecx, %ecx
+1:
+    movl    $0x200000, %eax
+    mull    %ecx                    /* EDX:EAX = 2MiB * i */
+    orl     $0x83, %eax
+    movl    $p2_table, %edi
+    movl    %eax, (%edi, %ecx, 8)
+    movl    %edx, 4(%edi, %ecx, 8)
+    incl    %ecx
+    cmpl    $512, %ecx
+    jne     1b
+    ret
+
+/* --- switch the CPU into long mode ------------------------------------- */
+
+enable_paging:
+    movl    $p4_table, %eax
+    movl    %eax, %cr3
+
+    movl    %cr4, %eax
+    orl     $(1 << 5), %eax         /* CR4.PAE */
+    movl    %eax, %cr4
+
+    movl    $0xC0000080, %ecx       /* IA32_EFER */
+    rdmsr
+    orl     $(1 << 8), %eax         /* EFER.LME */
+    wrmsr
+
+    movl    %cr0, %eax
+    orl     $(1 << 31), %eax        /* CR0.PG */
+    movl    %eax, %cr0
+    ret
+
+/* --- early COM1 output (32-bit) ---------------------------------------- */
+/* The uart_16550 crate re-initialises this later; we need output *now* so a
+   failure between here and Rust is visible rather than a silent reboot. */
+
+serial_init32:
+    movw    $0x3F9, %dx             /* IER: disable interrupts */
+    xorb    %al, %al
+    outb    %al, %dx
+    movw    $0x3FB, %dx             /* LCR: enable DLAB */
+    movb    $0x80, %al
+    outb    %al, %dx
+    movw    $0x3F8, %dx             /* divisor low = 3 (38400 baud) */
+    movb    $0x03, %al
+    outb    %al, %dx
+    movw    $0x3F9, %dx             /* divisor high = 0 */
+    xorb    %al, %al
+    outb    %al, %dx
+    movw    $0x3FB, %dx             /* LCR: 8N1, DLAB off */
+    movb    $0x03, %al
+    outb    %al, %dx
+    movw    $0x3FA, %dx             /* FCR: enable + clear FIFOs */
+    movb    $0xC7, %al
+    outb    %al, %dx
+    movw    $0x3FC, %dx             /* MCR: DTR + RTS + OUT2 */
+    movb    $0x0B, %al
+    outb    %al, %dx
+    ret
+
+putc32:                             /* char in AL */
+    pushl   %ebx
+    pushl   %edx
+    movb    %al, %bl
+1:
+    movw    $0x3FD, %dx             /* LSR */
+    inb     %dx, %al
+    testb   $0x20, %al              /* transmitter holding register empty */
+    jz      1b
+    movw    $0x3F8, %dx
+    movb    %bl, %al
+    outb    %al, %dx
+    popl    %edx
+    popl    %ebx
+    ret
+
+puts32:                             /* NUL-terminated string in ESI */
+    pushl   %esi
+1:
+    movzbl  (%esi), %eax
+    testb   %al, %al
+    je      2f
+    call    putc32
+    incl    %esi
+    jmp     1b
+2:
+    popl    %esi
+    ret
+
+/* --- 64-bit land -------------------------------------------------------- */
+
+.code64
+long_mode_start:
+    movw    $0x10, %ax
+    movw    %ax, %ss
+    movw    %ax, %ds
+    movw    %ax, %es
+    movw    %ax, %fs
+    movw    %ax, %gs
+
+    movq    $stack_top, %rsp
+    xorq    %rbp, %rbp
+
+    /* rustc emits SSE instructions for x86-64 unconditionally, so the FPU/SSE
+       state has to be usable before we enter any Rust code. */
+    movq    %cr0, %rax
+    andq    $-5, %rax               /* clear CR0.EM */
+    orq     $2, %rax                /* set CR0.MP */
+    movq    %rax, %cr0
+    movq    %cr4, %rax
+    orq     $(3 << 9), %rax         /* CR4.OSFXSR | CR4.OSXMMEXCPT */
+    movq    %rax, %cr4
+    fninit
+
+    leaq    msg_boot64(%rip), %rsi
+    call    puts64
+
+    /* System V AMD64: first argument goes in RDI. */
+    movl    mb_info(%rip), %edi
+    call    _start
+
+    /* _start is `-> !`, but be defensive. */
+1:
+    cli
+    hlt
+    jmp     1b
+
+putc64:                             /* char in AL */
+    movb    %al, %bl
+1:
+    movw    $0x3FD, %dx
+    inb     %dx, %al
+    testb   $0x20, %al
+    jz      1b
+    movw    $0x3F8, %dx
+    movb    %bl, %al
+    outb    %al, %dx
+    ret
+
+puts64:                             /* NUL-terminated string in RSI */
+1:
+    movzbl  (%rsi), %eax
+    testb   %al, %al
+    je      2f
+    call    putc64
+    incq    %rsi
+    jmp     1b
+2:
+    ret
+
+/* --- data --------------------------------------------------------------- */
+
+.section .rodata.boot32, "a"
+.balign 8
+gdt64:
+    .quad   0
+    .quad   0x00AF9A000000FFFF      /* 0x08: 64-bit code, ring 0 */
+    .quad   0x00CF92000000FFFF      /* 0x10: data, ring 0 */
+gdt64_ptr:
+    .word   gdt64_ptr - gdt64 - 1
+    .quad   gdt64
+
+msg_boot32:
+    .asciz  "[boot] 32-bit protected mode entry OK\r\n"
+msg_boot64:
+    .asciz  "[boot] long mode OK, entering Rust\r\n"
+msg_badmagic:
+    .asciz  "[boot] FATAL: bad Multiboot2 magic\r\n"
+msg_nolm:
+    .asciz  "[boot] FATAL: CPU does not support long mode\r\n"
+
+.section .bss.boot32, "aw", @nobits
+.balign 4096
+p4_table:
+    .skip   4096
+p3_table:
+    .skip   4096
+p2_table:
+    .skip   4096
+mb_magic:
+    .skip   4
+mb_info:
+    .skip   4
+.balign 16
+stack_bottom:
+    .skip   65536
+stack_top:
+"#,
+    options(att_syntax)
+);

--- a/kernel/src/gdt.rs
+++ b/kernel/src/gdt.rs
@@ -1,0 +1,156 @@
+//! GDT and TSS.
+//!
+//! Split out of `boot.rs` in Phase 5, because the descriptor *order* stops
+//! being arbitrary the moment `syscall`/`sysret` exist.
+//!
+//! ## Why the order is forced
+//!
+//! `syscall` loads CS from `STAR[47:32]` and SS from `STAR[47:32] + 8`.
+//! `sysretq` loads CS from `STAR[63:48] + 16` and SS from `STAR[63:48] + 8`.
+//! The CPU does not consult the GDT for the *contents* — it just adds those
+//! offsets — so the descriptors have to be laid out to match:
+//!
+//! ```text
+//!   0x00  null
+//!   0x08  kernel code   <- STAR[47:32]
+//!   0x10  kernel data       (= 0x08 + 8)          <- STAR[63:48]
+//!   0x18  user data         (= 0x10 + 8)   sysret SS, RPL 3 -> 0x1B
+//!   0x20  user code (64)    (= 0x10 + 16)  sysret CS, RPL 3 -> 0x23
+//!   0x28  TSS (two slots)
+//! ```
+//!
+//! Note user *data* comes before user *code*. That looks backwards until you
+//! write out the `sysret` arithmetic; getting it the intuitive way round is a
+//! classic way to land in a #GP the first time a process returns to ring 3.
+//!
+//! Before Phase 5 this table had three entries — kernel code, kernel data,
+//! TSS — so the `cs: 0x1B / ss: 0x23` values in `process/context.rs` pointed at
+//! descriptors that did not exist.
+
+use lazy_static::lazy_static;
+use x86_64::instructions::segmentation::{Segment, CS, DS, ES, FS, GS, SS};
+use x86_64::instructions::tables::load_tss;
+use x86_64::structures::gdt::{Descriptor, GlobalDescriptorTable, SegmentSelector};
+use x86_64::structures::tss::TaskStateSegment;
+use x86_64::VirtAddr;
+
+use crate::serial_println;
+
+/// IST slot for the double-fault handler.
+///
+/// A double fault caused by a bad kernel stack cannot push its exception frame
+/// onto that same stack, so it needs a known-good one.
+pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
+
+const DOUBLE_FAULT_STACK_SIZE: usize = 4096 * 5;
+const KERNEL_INTERRUPT_STACK_SIZE: usize = 4096 * 5;
+
+static mut DOUBLE_FAULT_STACK: [u8; DOUBLE_FAULT_STACK_SIZE] = [0; DOUBLE_FAULT_STACK_SIZE];
+
+/// The stack the CPU switches to when an interrupt arrives while running in
+/// ring 3. Without a valid RSP0, the first timer tick after entering user mode
+/// is a triple fault.
+static mut KERNEL_INTERRUPT_STACK: [u8; KERNEL_INTERRUPT_STACK_SIZE] =
+    [0; KERNEL_INTERRUPT_STACK_SIZE];
+
+lazy_static! {
+    static ref TSS: TaskStateSegment = {
+        let mut tss = TaskStateSegment::new();
+
+        tss.interrupt_stack_table[DOUBLE_FAULT_IST_INDEX as usize] = {
+            let start = VirtAddr::from_ptr(&raw const DOUBLE_FAULT_STACK);
+            start + DOUBLE_FAULT_STACK_SIZE
+        };
+
+        // RSP0: ring 3 -> ring 0 stack switch on interrupt.
+        tss.privilege_stack_table[0] = {
+            let start = VirtAddr::from_ptr(&raw const KERNEL_INTERRUPT_STACK);
+            start + KERNEL_INTERRUPT_STACK_SIZE
+        };
+
+        tss
+    };
+}
+
+pub struct Selectors {
+    pub kernel_code: SegmentSelector,
+    pub kernel_data: SegmentSelector,
+    pub user_data: SegmentSelector,
+    pub user_code: SegmentSelector,
+    pub tss: SegmentSelector,
+}
+
+lazy_static! {
+    static ref GDT: (GlobalDescriptorTable, Selectors) = {
+        let mut gdt = GlobalDescriptorTable::new();
+
+        // Order is load-bearing — see the module docs.
+        let kernel_code = gdt.add_entry(Descriptor::kernel_code_segment());
+        let kernel_data = gdt.add_entry(Descriptor::kernel_data_segment());
+        let user_data = gdt.add_entry(Descriptor::user_data_segment());
+        let user_code = gdt.add_entry(Descriptor::user_code_segment());
+        let tss = gdt.add_entry(Descriptor::tss_segment(&TSS));
+
+        (
+            gdt,
+            Selectors {
+                kernel_code,
+                kernel_data,
+                user_data,
+                user_code,
+                tss,
+            },
+        )
+    };
+}
+
+pub fn selectors() -> &'static Selectors {
+    &GDT.1
+}
+
+/// Load the GDT, reload every segment register, and install the TSS.
+pub fn init() {
+    serial_println!("Setting up GDT and TSS...");
+
+    GDT.0.load();
+
+    let sel = selectors();
+
+    unsafe {
+        CS::set_reg(sel.kernel_code);
+        DS::set_reg(sel.kernel_data);
+        ES::set_reg(sel.kernel_data);
+        FS::set_reg(sel.kernel_data);
+        GS::set_reg(sel.kernel_data);
+        SS::set_reg(sel.kernel_data);
+
+        load_tss(sel.tss);
+    }
+
+    serial_println!(
+        "  selectors: kcode 0x{:x}, kdata 0x{:x}, udata 0x{:x}, ucode 0x{:x}, tss 0x{:x}",
+        sel.kernel_code.0,
+        sel.kernel_data.0,
+        sel.user_data.0,
+        sel.user_code.0,
+        sel.tss.0
+    );
+    serial_println!(
+        "  TSS.RSP0 = 0x{:x} (ring 3 -> ring 0 interrupt stack)",
+        TSS.privilege_stack_table[0].as_u64()
+    );
+}
+
+/// Point RSP0 at a specific kernel stack.
+///
+/// Phase 5 runs exactly one ring-3 thread, so the static stack above is enough.
+/// Once several threads can be in user mode, this must be called on every
+/// context switch with the incoming thread's kernel stack — otherwise two
+/// threads share one interrupt stack and corrupt each other's frames.
+#[allow(dead_code)]
+pub fn set_kernel_stack(_top: VirtAddr) {
+    // Deliberately not implemented yet rather than silently doing nothing:
+    // the TSS is behind a `lazy_static` and needs interior mutability to
+    // update. Phase 6 turns the TSS into a `static mut` per CPU.
+    unimplemented!("per-thread RSP0 arrives with multiple user threads");
+}

--- a/kernel/src/interrupts/exceptions.rs
+++ b/kernel/src/interrupts/exceptions.rs
@@ -174,6 +174,17 @@ pub extern "x86-interrupt" fn page_fault_handler(
         serial_println!("                     like a null pointer dereference.");
     }
 
+    // A fault in ring 3 is the process's problem, not the kernel's. Killing the
+    // offending thread and carrying on is the entire point of running services
+    // outside the kernel — halting here would mean any userspace bug takes the
+    // whole system down, which is what a microkernel exists to avoid.
+    if error_code.contains(PageFaultErrorCode::USER_MODE) {
+        serial_println!("  action           : ring 3 fault — terminating the process");
+        serial_println!("  rip              : 0x{:016x}", frame.instruction_pointer.as_u64());
+        serial_println!("====================================================");
+        crate::task::exit_current();
+    }
+
     fault(14, "#PF Page Fault", Some(error_code.bits()), &frame)
 }
 

--- a/kernel/src/interrupts/exceptions.rs
+++ b/kernel/src/interrupts/exceptions.rs
@@ -1,0 +1,208 @@
+//! CPU exception handlers.
+//!
+//! Every handler prints a legible dump — vector, mnemonic, error code, faulting
+//! instruction pointer, stack pointer, flags and (for page faults) CR2 — and
+//! then halts. Halting rather than rebooting is deliberate: a frozen machine
+//! with a readable dump on the serial port is debuggable, a reboot loop is not.
+
+use x86_64::structures::idt::{InterruptStackFrame, PageFaultErrorCode};
+
+use crate::{println, serial_println};
+
+/// Print a uniform exception banner, then hang.
+fn fault(vector: u8, name: &str, error_code: Option<u64>, frame: &InterruptStackFrame) -> ! {
+    dump(vector, name, error_code, frame);
+    halt()
+}
+
+fn dump(vector: u8, name: &str, error_code: Option<u64>, frame: &InterruptStackFrame) {
+    serial_println!();
+    serial_println!("==================== CPU EXCEPTION ====================");
+    serial_println!("  vector      : {} (0x{:02x})  {}", vector, vector, name);
+
+    match error_code {
+        Some(code) => serial_println!("  error code  : 0x{:x}", code),
+        None => serial_println!("  error code  : (none)"),
+    }
+
+    serial_println!("  rip         : 0x{:016x}", frame.instruction_pointer.as_u64());
+    serial_println!("  cs          : 0x{:x}", frame.code_segment);
+    serial_println!("  rflags      : 0x{:016x}", frame.cpu_flags);
+    serial_println!("  rsp         : 0x{:016x}", frame.stack_pointer.as_u64());
+    serial_println!("  ss          : 0x{:x}", frame.stack_segment);
+    serial_println!("=======================================================");
+
+    // Mirror a one-liner to VGA so a headless-serial mistake still shows
+    // something on screen.
+    println!("CPU EXCEPTION {} ({}) at 0x{:x}", vector, name, frame.instruction_pointer.as_u64());
+}
+
+fn halt() -> ! {
+    serial_println!("System halted.");
+    loop {
+        x86_64::instructions::interrupts::disable();
+        x86_64::instructions::hlt();
+    }
+}
+
+// --- faults that cannot be resumed ---------------------------------------
+
+pub extern "x86-interrupt" fn divide_error_handler(frame: InterruptStackFrame) {
+    fault(0, "#DE Divide Error", None, &frame)
+}
+
+pub extern "x86-interrupt" fn nmi_handler(frame: InterruptStackFrame) {
+    // An NMI is usually a hardware problem (parity error, watchdog). Report it
+    // but do not pretend we can recover.
+    fault(2, "NMI Non-Maskable Interrupt", None, &frame)
+}
+
+pub extern "x86-interrupt" fn overflow_handler(frame: InterruptStackFrame) {
+    fault(4, "#OF Overflow", None, &frame)
+}
+
+pub extern "x86-interrupt" fn bound_range_handler(frame: InterruptStackFrame) {
+    fault(5, "#BR Bound Range Exceeded", None, &frame)
+}
+
+pub extern "x86-interrupt" fn invalid_opcode_handler(frame: InterruptStackFrame) {
+    fault(6, "#UD Invalid Opcode", None, &frame)
+}
+
+pub extern "x86-interrupt" fn device_not_available_handler(frame: InterruptStackFrame) {
+    // Almost always means CR0.TS/EM is wrong, i.e. the SSE setup in boot32.rs
+    // did not take effect.
+    fault(7, "#NM Device Not Available (FPU/SSE)", None, &frame)
+}
+
+pub extern "x86-interrupt" fn invalid_tss_handler(frame: InterruptStackFrame, error_code: u64) {
+    fault(10, "#TS Invalid TSS", Some(error_code), &frame)
+}
+
+pub extern "x86-interrupt" fn segment_not_present_handler(
+    frame: InterruptStackFrame,
+    error_code: u64,
+) {
+    fault(11, "#NP Segment Not Present", Some(error_code), &frame)
+}
+
+pub extern "x86-interrupt" fn stack_segment_handler(frame: InterruptStackFrame, error_code: u64) {
+    fault(12, "#SS Stack Segment Fault", Some(error_code), &frame)
+}
+
+pub extern "x86-interrupt" fn general_protection_handler(
+    frame: InterruptStackFrame,
+    error_code: u64,
+) {
+    serial_println!();
+    serial_println!("(#GP error code 0x{:x}: {})", error_code, gp_source(error_code));
+    fault(13, "#GP General Protection Fault", Some(error_code), &frame)
+}
+
+fn gp_source(error_code: u64) -> &'static str {
+    if error_code == 0 {
+        "not segment-related"
+    } else if error_code & 0b10 != 0 {
+        "IDT descriptor"
+    } else if error_code & 0b100 != 0 {
+        "LDT descriptor"
+    } else {
+        "GDT descriptor"
+    }
+}
+
+pub extern "x86-interrupt" fn x87_handler(frame: InterruptStackFrame) {
+    fault(16, "#MF x87 Floating-Point Error", None, &frame)
+}
+
+pub extern "x86-interrupt" fn alignment_check_handler(
+    frame: InterruptStackFrame,
+    error_code: u64,
+) {
+    fault(17, "#AC Alignment Check", Some(error_code), &frame)
+}
+
+pub extern "x86-interrupt" fn machine_check_handler(frame: InterruptStackFrame) -> ! {
+    fault(18, "#MC Machine Check", None, &frame)
+}
+
+pub extern "x86-interrupt" fn simd_handler(frame: InterruptStackFrame) {
+    fault(19, "#XM SIMD Floating-Point Exception", None, &frame)
+}
+
+pub extern "x86-interrupt" fn virtualization_handler(frame: InterruptStackFrame) {
+    fault(20, "#VE Virtualization Exception", None, &frame)
+}
+
+// --- page fault: the one worth decoding properly --------------------------
+
+pub extern "x86-interrupt" fn page_fault_handler(
+    frame: InterruptStackFrame,
+    error_code: PageFaultErrorCode,
+) {
+    use x86_64::registers::control::Cr2;
+
+    let accessed = Cr2::read();
+
+    serial_println!();
+    serial_println!("==================== PAGE FAULT ====================");
+    serial_println!("  accessed address : 0x{:016x}", accessed.as_u64());
+    serial_println!(
+        "  cause            : {} while {} in {} mode",
+        if error_code.contains(PageFaultErrorCode::PROTECTION_VIOLATION) {
+            "protection violation"
+        } else {
+            "page not present"
+        },
+        if error_code.contains(PageFaultErrorCode::CAUSED_BY_WRITE) {
+            "writing"
+        } else if error_code.contains(PageFaultErrorCode::INSTRUCTION_FETCH) {
+            "fetching an instruction"
+        } else {
+            "reading"
+        },
+        if error_code.contains(PageFaultErrorCode::USER_MODE) {
+            "user"
+        } else {
+            "kernel"
+        }
+    );
+    serial_println!("  error code       : {:?}", error_code);
+
+    if accessed.as_u64() < 0x1000 {
+        serial_println!("  note             : address is in the first page — this looks");
+        serial_println!("                     like a null pointer dereference.");
+    }
+
+    fault(14, "#PF Page Fault", Some(error_code.bits()), &frame)
+}
+
+// --- double fault ----------------------------------------------------------
+
+pub extern "x86-interrupt" fn double_fault_handler(
+    frame: InterruptStackFrame,
+    error_code: u64,
+) -> ! {
+    serial_println!();
+    serial_println!("A second exception fired while handling the first.");
+    serial_println!("Common causes: kernel stack overflow, or a fault inside a handler.");
+    fault(8, "#DF Double Fault", Some(error_code), &frame)
+}
+
+// --- resumable -------------------------------------------------------------
+
+/// `int3`. Prints and returns, so debuggers and self-tests can use it.
+pub extern "x86-interrupt" fn breakpoint_handler(frame: InterruptStackFrame) {
+    serial_println!(
+        "[#BP breakpoint at 0x{:016x}] — resuming",
+        frame.instruction_pointer.as_u64()
+    );
+}
+
+/// `#DB`. Single-step / hardware watchpoints. Resumable.
+pub extern "x86-interrupt" fn debug_handler(frame: InterruptStackFrame) {
+    serial_println!(
+        "[#DB debug at 0x{:016x}] — resuming",
+        frame.instruction_pointer.as_u64()
+    );
+}

--- a/kernel/src/interrupts/keyboard.rs
+++ b/kernel/src/interrupts/keyboard.rs
@@ -1,0 +1,154 @@
+//! PS/2 keyboard: IRQ1 -> scancode -> decoded key -> ring buffer.
+//!
+//! `drivers/keyboard` already had a correct 100-entry scancode table, but its
+//! port I/O was stubbed — `read_data()` returned 0 unconditionally, so the only
+//! way to inject a keystroke was a "simulate key press" control command. This
+//! is the real thing: an interrupt handler reading port 0x60.
+//!
+//! The handler does the minimum possible work — read the port, decode, push a
+//! byte — and never allocates or blocks. Everything else happens in
+//! `read_char()`, called from normal kernel context.
+
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use lazy_static::lazy_static;
+use pc_keyboard::{layouts, DecodedKey, HandleControl, Keyboard, ScancodeSet1};
+use spin::Mutex;
+use x86_64::instructions::port::Port;
+use x86_64::structures::idt::InterruptStackFrame;
+
+use crate::interrupts::{pic, InterruptIndex};
+use crate::serial_println;
+
+const PS2_DATA_PORT: u16 = 0x60;
+
+/// Capacity of the decoded-character ring. A power of two so the modulo is a
+/// mask. 128 characters is far more than a human can type between polls.
+const BUFFER_SIZE: usize = 128;
+
+lazy_static! {
+    static ref KEYBOARD: Mutex<Keyboard<layouts::Us104Key, ScancodeSet1>> = Mutex::new(
+        Keyboard::new(ScancodeSet1::new(), layouts::Us104Key, HandleControl::Ignore)
+    );
+}
+
+/// Lock-free-ish SPSC ring: the IRQ handler is the only producer, kernel
+/// context is the only consumer.
+struct KeyBuffer {
+    data: [u8; BUFFER_SIZE],
+    read: AtomicUsize,
+    write: AtomicUsize,
+}
+
+impl KeyBuffer {
+    const fn new() -> Self {
+        Self {
+            data: [0; BUFFER_SIZE],
+            read: AtomicUsize::new(0),
+            write: AtomicUsize::new(0),
+        }
+    }
+
+    fn push(&mut self, byte: u8) {
+        let write = self.write.load(Ordering::Relaxed);
+        let next = (write + 1) % BUFFER_SIZE;
+
+        // Drop on overflow rather than overwrite unread input — losing the
+        // newest keystroke is less confusing than losing the oldest.
+        if next == self.read.load(Ordering::Acquire) {
+            return;
+        }
+
+        self.data[write] = byte;
+        self.write.store(next, Ordering::Release);
+    }
+
+    fn pop(&self) -> Option<u8> {
+        let read = self.read.load(Ordering::Relaxed);
+        if read == self.write.load(Ordering::Acquire) {
+            return None;
+        }
+
+        let byte = self.data[read];
+        self.read.store((read + 1) % BUFFER_SIZE, Ordering::Release);
+        Some(byte)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.read.load(Ordering::Relaxed) == self.write.load(Ordering::Acquire)
+    }
+}
+
+static BUFFER: Mutex<KeyBuffer> = Mutex::new(KeyBuffer::new());
+
+pub fn init() {
+    // Drain anything the BIOS left in the controller's output buffer,
+    // otherwise the first real keystroke never generates an IRQ.
+    unsafe {
+        let mut port: Port<u8> = Port::new(PS2_DATA_PORT);
+        let _ = port.read();
+    }
+    serial_println!("  PS/2 keyboard: IRQ1 handler installed (US layout, set 1)");
+}
+
+/// Take one decoded character, if any is waiting. Non-blocking.
+pub fn read_char() -> Option<char> {
+    crate::interrupts::without_interrupts(|| BUFFER.lock().pop().map(|b| b as char))
+}
+
+/// Block until a character is available.
+///
+/// Uses `hlt` rather than a spin so an idle wait does not burn the CPU. This
+/// is the primitive the shell's line editor will sit on in Phase 7.
+pub fn read_char_blocking() -> char {
+    loop {
+        if let Some(c) = read_char() {
+            return c;
+        }
+        x86_64::instructions::hlt();
+    }
+}
+
+/// Whether any input is pending.
+pub fn has_input() -> bool {
+    crate::interrupts::without_interrupts(|| BUFFER.lock().is_empty()) == false
+}
+
+pub extern "x86-interrupt" fn keyboard_interrupt_handler(_frame: InterruptStackFrame) {
+    let scancode: u8 = unsafe {
+        let mut port: Port<u8> = Port::new(PS2_DATA_PORT);
+        port.read()
+    };
+
+    // `try_lock` rather than `lock`: this runs in interrupt context, and
+    // blocking on a lock held by interrupted kernel code would deadlock the
+    // machine. Dropping a keystroke is the correct trade.
+    if let Some(mut keyboard) = KEYBOARD.try_lock() {
+        if let Ok(Some(key_event)) = keyboard.add_byte(scancode) {
+            if let Some(key) = keyboard.process_keyevent(key_event) {
+                let byte = match key {
+                    DecodedKey::Unicode(c) => {
+                        if c.is_ascii() {
+                            Some(c as u8)
+                        } else {
+                            None
+                        }
+                    }
+                    // Arrow keys, function keys and friends have no ASCII
+                    // encoding. Phase 7 will map these to editor commands.
+                    DecodedKey::RawKey(_) => None,
+                };
+
+                if let Some(byte) = byte {
+                    if let Some(mut buffer) = BUFFER.try_lock() {
+                        buffer.push(byte);
+                    }
+                }
+            }
+        }
+    }
+
+    unsafe {
+        pic::notify_end_of_interrupt(InterruptIndex::Keyboard.as_u8());
+    }
+}

--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -1,0 +1,158 @@
+//! Interrupt handling: IDT, CPU exceptions, PIC, PIT timer, PS/2 keyboard.
+//!
+//! Before this module existed, the kernel had no IDT at all. Any fault —
+//! a null dereference, a stack overflow, a bad opcode — escalated straight to
+//! a triple fault and silently rebooted the machine, with no indication of
+//! what went wrong. That made every bug below this layer invisible.
+//!
+//! Split:
+//!   * `exceptions` — CPU-generated faults (vectors 0..31). Print a legible
+//!     dump and halt. Installed as early as possible.
+//!   * `pic`        — the legacy 8259 pair, remapped to vectors 32..47 so
+//!                    hardware IRQs stop colliding with CPU exceptions.
+//!   * `timer`      — PIT channel 0 at 100 Hz, driving the system tick.
+//!   * `keyboard`   — PS/2 IRQ1 -> scancode -> decoded char -> ring buffer.
+//!
+//! `init()` installs the IDT. `enable_hardware_interrupts()` brings the PIC
+//! and PIT up and executes `sti`. They are deliberately separate: exceptions
+//! should be catchable from the very start of boot, but hardware interrupts
+//! should not fire until the kernel is ready for them.
+
+pub mod exceptions;
+pub mod keyboard;
+pub mod pic;
+pub mod timer;
+
+use lazy_static::lazy_static;
+use x86_64::structures::idt::InterruptDescriptorTable;
+
+use crate::serial_println;
+
+/// Hardware interrupt vector numbers, after the PIC remap.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum InterruptIndex {
+    Timer = pic::PIC_1_OFFSET,
+    Keyboard,
+}
+
+impl InterruptIndex {
+    pub const fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    pub const fn as_usize(self) -> usize {
+        self as usize
+    }
+}
+
+lazy_static! {
+    static ref IDT: InterruptDescriptorTable = {
+        let mut idt = InterruptDescriptorTable::new();
+
+        // --- CPU exceptions (vectors 0..31) ------------------------------
+        idt.divide_error.set_handler_fn(exceptions::divide_error_handler);
+        idt.debug.set_handler_fn(exceptions::debug_handler);
+        idt.non_maskable_interrupt.set_handler_fn(exceptions::nmi_handler);
+        idt.breakpoint.set_handler_fn(exceptions::breakpoint_handler);
+        idt.overflow.set_handler_fn(exceptions::overflow_handler);
+        idt.bound_range_exceeded.set_handler_fn(exceptions::bound_range_handler);
+        idt.invalid_opcode.set_handler_fn(exceptions::invalid_opcode_handler);
+        idt.device_not_available.set_handler_fn(exceptions::device_not_available_handler);
+        idt.invalid_tss.set_handler_fn(exceptions::invalid_tss_handler);
+        idt.segment_not_present.set_handler_fn(exceptions::segment_not_present_handler);
+        idt.stack_segment_fault.set_handler_fn(exceptions::stack_segment_handler);
+        idt.general_protection_fault.set_handler_fn(exceptions::general_protection_handler);
+        idt.page_fault.set_handler_fn(exceptions::page_fault_handler);
+        idt.x87_floating_point.set_handler_fn(exceptions::x87_handler);
+        idt.alignment_check.set_handler_fn(exceptions::alignment_check_handler);
+        idt.machine_check.set_handler_fn(exceptions::machine_check_handler);
+        idt.simd_floating_point.set_handler_fn(exceptions::simd_handler);
+        idt.virtualization.set_handler_fn(exceptions::virtualization_handler);
+
+        // The double fault handler runs on its own stack via the IST. If a
+        // fault is caused by a bad kernel stack (guard-page hit, stack
+        // overflow), pushing the exception frame onto that same stack would
+        // fault again -> triple fault. The IST swaps in a known-good stack.
+        unsafe {
+            idt.double_fault
+                .set_handler_fn(exceptions::double_fault_handler)
+                .set_stack_index(crate::boot::DOUBLE_FAULT_IST_INDEX);
+        }
+
+        // --- hardware IRQs (vectors 32..47) ------------------------------
+        idt[InterruptIndex::Timer.as_usize()]
+            .set_handler_fn(timer::timer_interrupt_handler);
+        idt[InterruptIndex::Keyboard.as_usize()]
+            .set_handler_fn(keyboard::keyboard_interrupt_handler);
+
+        // Everything else on the PIC gets a handler that acknowledges and
+        // moves on. Without this, a spurious IRQ7/IRQ15 (which real hardware
+        // and some QEMU configurations do generate) would hit an absent IDT
+        // entry and become a general protection fault.
+        idt[pic::PIC_1_OFFSET as usize + 2].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_1_OFFSET as usize + 3].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_1_OFFSET as usize + 4].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_1_OFFSET as usize + 5].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_1_OFFSET as usize + 6].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_1_OFFSET as usize + 7].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_2_OFFSET as usize].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_2_OFFSET as usize + 1].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_2_OFFSET as usize + 2].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_2_OFFSET as usize + 3].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_2_OFFSET as usize + 4].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_2_OFFSET as usize + 5].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_2_OFFSET as usize + 6].set_handler_fn(pic::spurious_handler);
+        idt[pic::PIC_2_OFFSET as usize + 7].set_handler_fn(pic::spurious_handler);
+
+        idt
+    };
+}
+
+/// Install the IDT. Safe to call once, early — before memory management, so
+/// that faults during memory init are reported rather than silently fatal.
+pub fn init() {
+    serial_println!("Installing IDT...");
+    IDT.load();
+    serial_println!("IDT installed ({} exception vectors, 16 IRQ vectors)", 20);
+}
+
+/// Bring up the PIC and PIT and enable interrupts.
+///
+/// Separate from `init()` on purpose: exceptions must be catchable from the
+/// start of boot, but we do not want a timer tick arriving in the middle of
+/// memory-manager initialisation.
+pub fn enable_hardware_interrupts() {
+    serial_println!("Initializing PIC (remapping to vectors 32..47)...");
+    pic::init();
+
+    serial_println!("Initializing PIT at {} Hz...", timer::TIMER_HZ);
+    timer::init();
+
+    keyboard::init();
+
+    x86_64::instructions::interrupts::enable();
+    serial_println!("Interrupts enabled");
+}
+
+/// Run `f` with interrupts disabled, restoring the previous state afterwards.
+///
+/// Use this around anything that a handler also touches — otherwise an
+/// interrupt arriving mid-critical-section deadlocks against a spinlock the
+/// interrupted code already holds.
+pub fn without_interrupts<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R,
+{
+    x86_64::instructions::interrupts::without_interrupts(f)
+}
+
+/// Deliberately trigger a breakpoint (`int3`) to prove the IDT is live.
+///
+/// The handler prints and returns, so execution continues normally. If the
+/// IDT were missing or malformed this would triple-fault instead.
+pub fn test_breakpoint_exception() {
+    serial_println!("Testing IDT: raising int3 (execution should continue)...");
+    x86_64::instructions::interrupts::int3();
+    serial_println!("Testing IDT: returned from int3 handler, IDT is live");
+}

--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -147,6 +147,11 @@ where
     x86_64::instructions::interrupts::without_interrupts(f)
 }
 
+/// Whether the interrupt flag is currently set.
+pub fn interrupts_enabled() -> bool {
+    x86_64::instructions::interrupts::are_enabled()
+}
+
 /// Deliberately trigger a breakpoint (`int3`) to prove the IDT is live.
 ///
 /// The handler prints and returns, so execution continues normally. If the

--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -77,7 +77,7 @@ lazy_static! {
         unsafe {
             idt.double_fault
                 .set_handler_fn(exceptions::double_fault_handler)
-                .set_stack_index(crate::boot::DOUBLE_FAULT_IST_INDEX);
+                .set_stack_index(crate::gdt::DOUBLE_FAULT_IST_INDEX);
         }
 
         // --- hardware IRQs (vectors 32..47) ------------------------------

--- a/kernel/src/interrupts/pic.rs
+++ b/kernel/src/interrupts/pic.rs
@@ -1,0 +1,71 @@
+//! The legacy 8259 PIC pair.
+//!
+//! On a freshly-booted PC the two PICs deliver IRQ0..15 on vectors 8..15 and
+//! 0x70..0x77. Vectors 8..15 collide head-on with CPU exceptions — IRQ0 (the
+//! timer) arrives as vector 8, which is #DF Double Fault. So the very first
+//! timer tick after `sti` would look like a double fault.
+//!
+//! Remapping is therefore not optional. We move them to 32..47, immediately
+//! after the 32 architecturally-reserved exception vectors.
+
+use pic8259::ChainedPics;
+use spin::Mutex;
+use x86_64::structures::idt::InterruptStackFrame;
+
+use crate::serial_println;
+
+/// First vector used by the primary PIC (IRQ0..7 -> 32..39).
+pub const PIC_1_OFFSET: u8 = 32;
+/// First vector used by the secondary PIC (IRQ8..15 -> 40..47).
+pub const PIC_2_OFFSET: u8 = PIC_1_OFFSET + 8;
+
+static PICS: Mutex<ChainedPics> =
+    Mutex::new(unsafe { ChainedPics::new(PIC_1_OFFSET, PIC_2_OFFSET) });
+
+/// Remap both PICs and unmask only the IRQs we actually handle.
+pub fn init() {
+    unsafe {
+        let mut pics = PICS.lock();
+        pics.initialize();
+
+        // Mask everything except IRQ0 (timer) and IRQ1 (keyboard). IRQ2 is the
+        // cascade line to the secondary PIC and must stay unmasked for IRQ8..15
+        // to work at all — but we mask the secondary entirely for now.
+        //
+        // primary mask: bit set = masked. 0b1111_1000 leaves IRQ0,1,2 enabled.
+        pics.write_masks(0b1111_1000, 0b1111_1111);
+    }
+
+    serial_println!(
+        "  PIC remapped: IRQ0..7 -> vectors {}..{}, IRQ8..15 -> vectors {}..{}",
+        PIC_1_OFFSET,
+        PIC_1_OFFSET + 7,
+        PIC_2_OFFSET,
+        PIC_2_OFFSET + 7
+    );
+    serial_println!("  IRQ0 (timer) and IRQ1 (keyboard) unmasked, rest masked");
+}
+
+/// Acknowledge an interrupt so the PIC will deliver the next one.
+///
+/// Forgetting this is the classic "the timer fires exactly once" bug.
+///
+/// # Safety
+/// Must be called with the vector of the interrupt currently being serviced.
+pub unsafe fn notify_end_of_interrupt(vector: u8) {
+    PICS.lock().notify_end_of_interrupt(vector);
+}
+
+/// Catch-all for IRQs we do not handle yet.
+///
+/// Real hardware and some QEMU configurations generate spurious IRQ7/IRQ15.
+/// Without an IDT entry those become a #GP; with one, we simply acknowledge
+/// and carry on.
+pub extern "x86-interrupt" fn spurious_handler(_frame: InterruptStackFrame) {
+    // Nothing sensible to do but acknowledge. Deliberately silent: logging
+    // here would flood the console if a device latched an IRQ line high.
+    unsafe {
+        // IRQ7 is the usual spurious vector on the primary PIC.
+        notify_end_of_interrupt(PIC_1_OFFSET + 7);
+    }
+}

--- a/kernel/src/interrupts/timer.rs
+++ b/kernel/src/interrupts/timer.rs
@@ -1,0 +1,87 @@
+//! PIT (8254) channel 0 as the system tick.
+//!
+//! This is the first thing in Kosh that makes time pass. Until now
+//! `get_system_time()` returned a counter nobody incremented and
+//! `scheduler::handle_timer_tick()` had zero callers, so nothing in the kernel
+//! could ever be preempted or timed.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use x86_64::instructions::port::Port;
+use x86_64::structures::idt::InterruptStackFrame;
+
+use crate::interrupts::{pic, InterruptIndex};
+use crate::serial_println;
+
+/// Tick rate. 100 Hz gives a 10 ms granularity — fine for a scheduler time
+/// slice, cheap enough not to drown the machine in interrupts.
+pub const TIMER_HZ: u32 = 100;
+
+/// The PIT's fixed input frequency, 1.193182 MHz.
+const PIT_BASE_FREQUENCY: u32 = 1_193_182;
+
+const PIT_CHANNEL_0: u16 = 0x40;
+const PIT_COMMAND: u16 = 0x43;
+
+/// Ticks since the timer was started. Monotonic; wraps after ~5.8 billion
+/// years at 100 Hz, so not a practical concern.
+static TICKS: AtomicU64 = AtomicU64::new(0);
+
+/// Program PIT channel 0 for periodic interrupts at `TIMER_HZ`.
+pub fn init() {
+    let divisor = PIT_BASE_FREQUENCY / TIMER_HZ;
+    assert!(divisor <= u16::MAX as u32, "PIT divisor out of range");
+
+    unsafe {
+        let mut command: Port<u8> = Port::new(PIT_COMMAND);
+        let mut channel0: Port<u8> = Port::new(PIT_CHANNEL_0);
+
+        // 0b00_11_010_0:
+        //   channel 0, lo/hi byte access, mode 2 (rate generator), binary.
+        command.write(0b0011_0100u8);
+        channel0.write((divisor & 0xFF) as u8);
+        channel0.write((divisor >> 8) as u8);
+    }
+
+    serial_println!(
+        "  PIT channel 0: divisor {} -> {} Hz ({} ms per tick)",
+        divisor,
+        TIMER_HZ,
+        1000 / TIMER_HZ
+    );
+}
+
+/// Ticks elapsed since boot.
+pub fn ticks() -> u64 {
+    TICKS.load(Ordering::Relaxed)
+}
+
+/// Milliseconds elapsed since the timer was started.
+pub fn uptime_ms() -> u64 {
+    ticks() * (1000 / TIMER_HZ as u64)
+}
+
+/// Busy-wait for `ms` milliseconds. Requires interrupts to be enabled.
+pub fn sleep_ms(ms: u64) {
+    let target = ticks() + (ms * TIMER_HZ as u64) / 1000;
+    while ticks() < target {
+        x86_64::instructions::hlt();
+    }
+}
+
+pub extern "x86-interrupt" fn timer_interrupt_handler(_frame: InterruptStackFrame) {
+    let tick = TICKS.fetch_add(1, Ordering::Relaxed) + 1;
+
+    // Proof of life, once a second. This is temporary scaffolding — it comes
+    // out when the scheduler takes over the tick in Phase 4.
+    if tick % TIMER_HZ as u64 == 0 {
+        serial_println!("[tick] uptime {}s ({} ticks)", tick / TIMER_HZ as u64, tick);
+    }
+
+    // TODO (Phase 4): drive the scheduler from here.
+    //   crate::process::scheduler::handle_timer_tick();
+
+    unsafe {
+        pic::notify_end_of_interrupt(InterruptIndex::Timer.as_u8());
+    }
+}

--- a/kernel/src/interrupts/timer.rs
+++ b/kernel/src/interrupts/timer.rs
@@ -78,10 +78,16 @@ pub extern "x86-interrupt" fn timer_interrupt_handler(_frame: InterruptStackFram
         serial_println!("[tick] uptime {}s ({} ticks)", tick / TIMER_HZ as u64, tick);
     }
 
-    // TODO (Phase 4): drive the scheduler from here.
-    //   crate::process::scheduler::handle_timer_tick();
-
+    // Acknowledge before scheduling: `on_tick` may not return to this handler
+    // for a long time (it returns on whichever thread we switch to), and until
+    // the PIC gets its EOI it will not deliver another timer interrupt to
+    // anybody.
     unsafe {
         pic::notify_end_of_interrupt(InterruptIndex::Timer.as_u8());
     }
+
+    // The wiring that never existed: a periodic interrupt that actually reaches
+    // a scheduler. This call may switch stacks and return on a different
+    // thread.
+    crate::task::on_tick();
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -13,6 +13,8 @@ use multiboot2::BootInformation;
 mod serial;
 mod vga_buffer;
 mod boot;
+#[cfg(target_arch = "x86_64")]
+mod boot32;
 mod memory;
 mod process;
 mod ipc;
@@ -100,7 +102,7 @@ struct Multiboot2Header {
 static MULTIBOOT2_HEADER: Multiboot2Header = {
     const MAGIC: u32 = 0xE85250D6;
     const ARCH: u32 = 0;
-    const HEADER_LEN: u32 = 16; // 4 u32 fields = 16 bytes for main header
+    const HEADER_LEN: u32 = core::mem::size_of::<Multiboot2Header>() as u32;
     
     Multiboot2Header {
         magic: MAGIC,
@@ -214,6 +216,12 @@ fn parse_boot_parameters(boot_info: &BootInformation) {
     serial_println!("Boot parameter parsing complete");
 }
 
+/// Rust kernel entry point.
+///
+/// This is NOT the ELF entry point — `_start32` in `boot32.rs` is. By the time
+/// we get here the CPU is in 64-bit long mode with a bootstrap identity map in
+/// place, and the trampoline has marshalled the Multiboot2 info pointer (which
+/// the loader passes in EBX) into RDI per the System V AMD64 ABI.
 #[cfg(target_arch = "x86_64")]
 #[no_mangle]
 pub extern "C" fn _start(multiboot_info_addr: usize) -> ! {
@@ -244,6 +252,8 @@ pub extern "C" fn _start(multiboot_info_addr: usize) -> ! {
     test_main();
 
     println!("Kosh kernel initialized successfully!");
+    serial_println!("Kosh kernel initialized successfully!");
+    serial_println!("Kosh: entering idle loop (no IDT and no timer yet — Phase 2)");
 
     // Halt the CPU in an infinite loop
     loop {

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -19,6 +19,12 @@ mod interrupts;
 #[cfg(target_arch = "x86_64")]
 mod task;
 #[cfg(target_arch = "x86_64")]
+mod gdt;
+#[cfg(target_arch = "x86_64")]
+mod usermode;
+#[cfg(target_arch = "x86_64")]
+mod user_program;
+#[cfg(target_arch = "x86_64")]
 mod boot32;
 mod memory;
 mod process;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -17,6 +17,8 @@ mod boot;
 #[cfg(target_arch = "x86_64")]
 mod interrupts;
 #[cfg(target_arch = "x86_64")]
+mod task;
+#[cfg(target_arch = "x86_64")]
 mod boot32;
 mod memory;
 mod process;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -1,5 +1,6 @@
 #![no_std]
 #![no_main]
+#![feature(abi_x86_interrupt)]
 #![feature(custom_test_frameworks)]
 #![test_runner(crate::test_runner)]
 #![reexport_test_harness_main = "test_main"]
@@ -13,6 +14,8 @@ use multiboot2::BootInformation;
 mod serial;
 mod vga_buffer;
 mod boot;
+#[cfg(target_arch = "x86_64")]
+mod interrupts;
 #[cfg(target_arch = "x86_64")]
 mod boot32;
 mod memory;
@@ -253,15 +256,50 @@ pub extern "C" fn _start(multiboot_info_addr: usize) -> ! {
 
     println!("Kosh kernel initialized successfully!");
     serial_println!("Kosh kernel initialized successfully!");
-    serial_println!("Kosh: entering idle loop (no IDT and no timer yet — Phase 2)");
 
-    // Halt the CPU in an infinite loop
+    idle_loop()
+}
+
+/// Idle loop.
+///
+/// There is no scheduler yet, so the kernel's "steady state" is to wait for
+/// interrupts. The timer ticks in the background; anything typed on the PS/2
+/// keyboard is echoed here, which proves the IRQ path end to end and is the
+/// beginning of the console the shell will use in Phase 7.
+#[cfg(target_arch = "x86_64")]
+fn idle_loop() -> ! {
+    serial_println!("Kosh: idle loop — timer is ticking, type to echo keystrokes");
+    println!("Kosh ready. Type something:");
+
     loop {
-        #[cfg(target_arch = "x86_64")]
+        while let Some(c) = interrupts::keyboard::read_char() {
+            match c {
+                // Enter
+                '\n' | '\r' => {
+                    println!();
+                    serial_println!();
+                }
+                // Backspace
+                '\x08' | '\x7f' => {
+                    print!("\x08 \x08");
+                    serial_print!("\x08 \x08");
+                }
+                c => {
+                    print!("{}", c);
+                    serial_print!("{}", c);
+                }
+            }
+        }
+
+        // Sleep until the next interrupt rather than spinning.
         x86_64::instructions::hlt();
-        
-        #[cfg(target_arch = "aarch64")]
-        unsafe { core::arch::asm!("wfi") }; // Wait for interrupt on ARM64
+    }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn idle_loop() -> ! {
+    loop {
+        unsafe { core::arch::asm!("wfi") };
     }
 }
 

--- a/kernel/src/memory/heap.rs
+++ b/kernel/src/memory/heap.rs
@@ -2,12 +2,17 @@ use core::alloc::{GlobalAlloc, Layout};
 use core::ptr::{self, NonNull};
 use spin::Mutex;
 use alloc::vec::Vec;
-use crate::memory::{PAGE_SIZE, align_up};
-use crate::memory::physical::allocate_frames;
+use crate::memory::PAGE_SIZE;
+use crate::memory::paging::{map_kernel_pages, KERNEL_HEAP_BASE};
 use crate::{serial_println, println};
 
 /// Minimum allocation size (to reduce fragmentation)
 const MIN_ALLOC_SIZE: usize = 16;
+
+/// Round `addr` up to a multiple of `align` (which must be a power of two).
+const fn align_up_to(addr: usize, align: usize) -> usize {
+    (addr + align - 1) & !(align - 1)
+}
 
 /// Maximum allocation size that can be handled by the heap
 const MAX_ALLOC_SIZE: usize = 1024 * 1024; // 1MB
@@ -15,8 +20,15 @@ const MAX_ALLOC_SIZE: usize = 1024 * 1024; // 1MB
 /// Magic number for heap corruption detection
 const HEAP_MAGIC: u32 = 0xDEADBEEF;
 
-/// Header for each allocated block
-#[repr(C)]
+/// Header for each allocated block.
+///
+/// `align(16)` matters: it rounds `size_of::<BlockHeader>()` up to a multiple
+/// of 16, so a 16-aligned block base gives a 16-aligned payload. Combined with
+/// rounding every allocation size up to 16, that keeps *every* block base
+/// 16-aligned for the life of the heap. Without it the header was 40 bytes,
+/// payloads landed on odd offsets, and even an 8-byte alignment request failed
+/// after the first split.
+#[repr(C, align(16))]
 struct BlockHeader {
     magic: u32,
     size: usize,
@@ -125,20 +137,24 @@ impl KernelHeapAllocator {
         }
     }
 
-    /// Initialize the heap with the given size
+    /// Initialize the heap with the given size.
+    ///
+    /// The heap lives at its own virtual address range ([`KERNEL_HEAP_BASE`]),
+    /// backed by frames the page tables map in. It previously took the raw
+    /// physical address of a contiguous frame run and used it as a pointer —
+    /// which happened to work only because paging was effectively off, and
+    /// silently required physical contiguity it did not need.
     pub fn init(&mut self, heap_size_pages: usize) -> Result<(), &'static str> {
         if heap_size_pages == 0 {
             return Err("Heap size cannot be zero");
         }
 
-        // Allocate physical pages for the heap
-        let start_frame = allocate_frames(heap_size_pages)
-            .ok_or("Failed to allocate physical memory for heap")?;
+        // Allocate and map `heap_size_pages` frames at the heap window. The
+        // frames do not have to be contiguous — that is the whole point of
+        // having page tables.
+        map_kernel_pages(KERNEL_HEAP_BASE, heap_size_pages)?;
 
-        // Map the physical pages to virtual memory
-        // For now, we'll use identity mapping (virtual = physical)
-        // In a full implementation, this would use the VMM
-        let heap_start = start_frame.address() as *mut u8;
+        let heap_start = KERNEL_HEAP_BASE as *mut u8;
         let heap_size = heap_size_pages * PAGE_SIZE;
 
         // Initialize the heap memory
@@ -168,15 +184,19 @@ impl KernelHeapAllocator {
 
     /// Allocate memory with the given layout
     pub fn allocate(&mut self, layout: Layout) -> Result<NonNull<u8>, &'static str> {
-        let size = layout.size().max(MIN_ALLOC_SIZE);
+        // Round up to 16 so the *next* block's base stays 16-aligned.
+        let size = align_up_to(layout.size().max(MIN_ALLOC_SIZE), MIN_ALLOC_SIZE);
         let align = layout.align();
 
         if size > MAX_ALLOC_SIZE {
             return Err("Allocation too large");
         }
 
-        // Find a suitable free block
+        // Find a suitable free block and, if the requested alignment forces
+        // the payload away from the natural header boundary, carve a leading
+        // free block off the front so the returned pointer really is aligned.
         let block = self.find_free_block(size, align)?;
+        let block = self.align_block(block, size, align)?;
 
         // Split the block if it's significantly larger than needed
         self.split_block(block, size);
@@ -199,7 +219,6 @@ impl KernelHeapAllocator {
         self.stats.current_allocations += 1;
         self.stats.bytes_allocated += size;
         self.stats.current_bytes += size;
-        self.stats.free_bytes -= size;
 
         if self.stats.current_bytes > self.stats.peak_bytes {
             self.stats.peak_bytes = self.stats.current_bytes;
@@ -252,7 +271,6 @@ impl KernelHeapAllocator {
             self.stats.current_allocations -= 1;
             self.stats.bytes_deallocated += size;
             self.stats.current_bytes -= size;
-            self.stats.free_bytes += size;
 
             // Add back to free list
             self.add_to_free_list(block);
@@ -264,28 +282,119 @@ impl KernelHeapAllocator {
         Ok(())
     }
 
-    /// Find a free block that can satisfy the allocation
-    fn find_free_block(&mut self, size: usize, _align: usize) -> Result<NonNull<BlockHeader>, &'static str> {
+    /// Find a free block that can satisfy `size` bytes at `align`.
+    ///
+    /// The previous version ignored `layout.align()` entirely: it aligned to
+    /// PAGE_SIZE regardless of what was asked for (rejecting almost everything
+    /// by demanding up to 4095 bytes of slack) and then returned the
+    /// *unaligned* pointer anyway. So it both over-rejected and under-delivered.
+    fn find_free_block(
+        &mut self,
+        size: usize,
+        align: usize,
+    ) -> Result<NonNull<BlockHeader>, &'static str> {
         let mut current = self.free_list_head;
 
         while let Some(block) = current {
             unsafe {
                 let block_ptr = block.as_ptr();
-                if (*block_ptr).is_free && (*block_ptr).size >= size {
-                    // Check alignment
-                    let data_ptr = (*block_ptr).data_ptr();
-                    let aligned_ptr = align_up(data_ptr as usize);
-                    let alignment_offset = aligned_ptr - data_ptr as usize;
-
-                    if (*block_ptr).size >= size + alignment_offset {
-                        return Ok(block);
-                    }
+                if (*block_ptr).is_free && Self::block_fits(block, size, align) {
+                    return Ok(block);
                 }
                 current = (*block_ptr).next;
             }
         }
 
         Err("Out of memory")
+    }
+
+    /// Where the payload would have to sit inside a block starting at `base`
+    /// to satisfy `align`.
+    ///
+    /// If the natural payload position is already aligned, that is the answer.
+    /// Otherwise we must carve a leading free block off the front, and that
+    /// leading block needs a header plus at least `MIN_ALLOC_SIZE` of payload —
+    /// so the answer is the first aligned address at or beyond
+    /// `base + 2*header + MIN_ALLOC_SIZE`.
+    ///
+    /// Returning the *first* aligned address without that floor was wrong: for
+    /// any alignment above 16 the gap was a few bytes, too small to be a legal
+    /// block, and the allocation was rejected outright.
+    fn aligned_payload(base: usize, data: usize, align: usize) -> Option<usize> {
+        if data % align == 0 {
+            return Some(data);
+        }
+
+        let header = core::mem::size_of::<BlockHeader>();
+        let floor = base.checked_add(2 * header)?.checked_add(MIN_ALLOC_SIZE)?;
+        Some(align_up_to(core::cmp::max(data, floor), align))
+    }
+
+    /// Whether `block` can serve `size` bytes at `align`.
+    ///
+    /// Two ways to satisfy it: the payload is already aligned, or there is
+    /// enough room to carve a leading free block off the front (which needs a
+    /// whole header plus a minimum-sized payload, or it would not be a valid
+    /// block).
+    fn block_fits(block: NonNull<BlockHeader>, size: usize, align: usize) -> bool {
+        unsafe {
+            let b = block.as_ptr();
+            let header = core::mem::size_of::<BlockHeader>();
+            let base = b as usize;
+            let data = (*b).data_ptr() as usize;
+            let avail = (*b).size;
+
+            let Some(aligned) = Self::aligned_payload(base, data, align) else {
+                return false;
+            };
+
+            if aligned == data {
+                return avail >= size;
+            }
+
+            let lead_size = aligned - base - 2 * header;
+            let new_size = (base + header + avail).saturating_sub(aligned);
+
+            lead_size >= MIN_ALLOC_SIZE && new_size >= size
+        }
+    }
+
+    /// Carve a leading free block off `block` if needed so the payload lands on
+    /// `align`. Returns the block that should actually serve the allocation.
+    fn align_block(
+        &mut self,
+        block: NonNull<BlockHeader>,
+        _size: usize,
+        align: usize,
+    ) -> Result<NonNull<BlockHeader>, &'static str> {
+        unsafe {
+            let b = block.as_ptr();
+            let header = core::mem::size_of::<BlockHeader>();
+            let base = b as usize;
+            let data = (*b).data_ptr() as usize;
+            let avail = (*b).size;
+
+            let aligned =
+                Self::aligned_payload(base, data, align).ok_or("alignment not satisfiable")?;
+            if aligned == data {
+                return Ok(block);
+            }
+
+            let lead_size = aligned - base - 2 * header;
+            let new_header = (aligned - header) as *mut BlockHeader;
+            let new_size = base + header + avail - aligned;
+
+            // Shrink the original into the leading free block...
+            (*b).size = lead_size;
+
+            // ...and write a fresh header for the aligned remainder.
+            ptr::write(new_header, BlockHeader::new(new_size));
+            let new_block = NonNull::new(new_header).ok_or("alignment split produced null")?;
+            self.add_to_free_list(new_block);
+
+            debug_assert_eq!((*new_block.as_ptr()).data_ptr() as usize % align, 0);
+            Ok(new_block)
+        }
     }
 
     /// Split a block if it's significantly larger than needed
@@ -348,27 +457,136 @@ impl KernelHeapAllocator {
         }
     }
 
-    /// Coalesce adjacent free blocks
-    fn coalesce_free_blocks(&mut self, block: NonNull<BlockHeader>) {
-        // This is a simplified version - in a full implementation,
-        // we would check for physically adjacent blocks and merge them
-        // For now, we just ensure the block is properly linked
-        unsafe {
-            let block_ptr = block.as_ptr();
-            if !(*block_ptr).is_free {
-                return;
-            }
+    /// Merge every run of physically-adjacent free blocks.
+    ///
+    /// This used to be an empty function with a comment describing what it
+    /// would do, so the heap fragmented monotonically and never recovered: free
+    /// a 64-byte block next to another 64-byte block and you still could not
+    /// serve a 128-byte request.
+    ///
+    /// The heap is one contiguous run of blocks — `header + payload`, back to
+    /// back, from `heap_start` to `heap_start + heap_size` — so a linear walk
+    /// visits them in address order and adjacency is just pointer arithmetic.
+    ///
+    /// O(number of blocks) per call. Fine at this scale; if it ever shows up in
+    /// a profile, the fix is a boundary tag holding the previous block's size,
+    /// which makes merging O(1).
+    fn coalesce_free_blocks(&mut self, _hint: NonNull<BlockHeader>) {
+        if self.heap_start.is_null() {
+            return;
+        }
 
-            // In a more sophisticated implementation, we would:
-            // 1. Check if the next physical block is free and merge
-            // 2. Check if the previous physical block is free and merge
-            // 3. Update the free list accordingly
+        let header_size = core::mem::size_of::<BlockHeader>();
+        let heap_end = self.heap_start as usize + self.heap_size;
+        let mut cursor = self.heap_start as usize;
+
+        while cursor < heap_end {
+            let block = cursor as *mut BlockHeader;
+
+            unsafe {
+                if !(*block).is_valid() {
+                    // Corruption: stop rather than walk off into nothing.
+                    serial_println!("Heap corruption during coalesce at 0x{:x}", cursor);
+                    return;
+                }
+
+                let mut total = (*block).total_size();
+
+                if (*block).is_free {
+                    // Absorb every free block immediately following this one.
+                    loop {
+                        let next_addr = cursor + total;
+                        if next_addr >= heap_end {
+                            break;
+                        }
+
+                        let next = next_addr as *mut BlockHeader;
+                        if !(*next).is_valid() || !(*next).is_free {
+                            break;
+                        }
+
+                        let next_total = (*next).total_size();
+                        if let Some(nn) = NonNull::new(next) {
+                            self.remove_from_free_list(nn);
+                        }
+
+                        // The absorbed header becomes payload.
+                        (*block).size += next_total;
+                        (*next).magic = 0;
+                        total = (*block).total_size();
+                    }
+                }
+
+                cursor += total;
+            }
         }
     }
 
-    /// Get allocation statistics
+    /// Get allocation statistics.
+    ///
+    /// `free_bytes` is recomputed from the block chain rather than tracked
+    /// incrementally: the incremental version ignored block headers and was not
+    /// updated by `split_block`, so it drifted and eventually underflowed.
     pub fn stats(&self) -> AllocationStats {
-        self.stats
+        let mut stats = self.stats;
+        stats.free_bytes = self.free_bytes();
+        stats
+    }
+
+    /// Sum of the payload sizes of all free blocks.
+    fn free_bytes(&self) -> usize {
+        if self.heap_start.is_null() {
+            return 0;
+        }
+
+        let heap_end = self.heap_start as usize + self.heap_size;
+        let mut cursor = self.heap_start as usize;
+        let mut free = 0usize;
+
+        while cursor < heap_end {
+            unsafe {
+                let block = cursor as *mut BlockHeader;
+                if !(*block).is_valid() {
+                    break;
+                }
+                if (*block).is_free {
+                    free += (*block).size;
+                }
+                cursor += (*block).total_size();
+            }
+        }
+
+        free
+    }
+
+    /// Number of blocks in the heap, and how many of them are free.
+    ///
+    /// Used by the stress test to prove coalescing actually works: after
+    /// freeing everything the heap must collapse back to a single free block.
+    pub fn block_census(&self) -> (usize, usize) {
+        if self.heap_start.is_null() {
+            return (0, 0);
+        }
+
+        let heap_end = self.heap_start as usize + self.heap_size;
+        let mut cursor = self.heap_start as usize;
+        let (mut total, mut free) = (0usize, 0usize);
+
+        while cursor < heap_end {
+            unsafe {
+                let block = cursor as *mut BlockHeader;
+                if !(*block).is_valid() {
+                    break;
+                }
+                total += 1;
+                if (*block).is_free {
+                    free += 1;
+                }
+                cursor += (*block).total_size();
+            }
+        }
+
+        (total, free)
     }
 
     /// Print heap statistics
@@ -470,6 +688,113 @@ pub fn heap_stats() -> AllocationStats {
 /// Print heap statistics
 pub fn print_heap_stats() {
     KERNEL_HEAP.lock().print_stats();
+}
+
+/// Blocks in the heap, and how many are free.
+pub fn block_census() -> (usize, usize) {
+    KERNEL_HEAP.lock().block_census()
+}
+
+/// Stress the allocator: many mixed-size, mixed-alignment allocations, freed in
+/// a scrambled order, then assert the heap collapses back to a single free
+/// block of its original size.
+///
+/// This is the test that proves coalescing works. Before Phase 3
+/// `coalesce_free_blocks` was an empty function, so this would have finished
+/// with hundreds of stranded free blocks instead of one.
+pub fn stress_test() {
+    use alloc::vec::Vec;
+
+    const ROUNDS: usize = 2000;
+
+    serial_println!("Heap stress test: {} mixed alloc/free rounds...", ROUNDS);
+
+    let (blocks_before, _) = block_census();
+    let free_before = heap_stats().free_bytes;
+
+    let mut live: Vec<(NonNull<u8>, usize)> = Vec::new();
+    let mut misaligned = 0usize;
+    let mut failures = 0usize;
+
+    for i in 0..ROUNDS {
+        // Sizes 16..~2 KiB, alignments 8/16/32/64/128 — cycled so we exercise
+        // the alignment-split path rather than only the happy case.
+        let size = 16 + (i * 37) % 2048;
+        let align = 1usize << (3 + (i % 5));
+
+        let layout = match Layout::from_size_align(size, align) {
+            Ok(l) => l,
+            Err(_) => continue,
+        };
+
+        let result = KERNEL_HEAP.lock().allocate(layout);
+
+        match result {
+            Ok(ptr) => {
+                if ptr.as_ptr() as usize % align != 0 {
+                    misaligned += 1;
+                }
+                // Touch the whole allocation so a bad mapping or an overlapping
+                // block shows up as corruption rather than passing silently.
+                unsafe { ptr::write_bytes(ptr.as_ptr(), (i & 0xFF) as u8, size) };
+                live.push((ptr, size));
+            }
+            Err(_) => failures += 1,
+        }
+
+        // Free roughly two thirds of what we allocate, out of order, to churn
+        // the free list and force merges of non-adjacent-in-time blocks.
+        if live.len() > 8 && i % 3 != 0 {
+            let victim = live.remove((i * 7) % live.len());
+            if KERNEL_HEAP.lock().deallocate(victim.0).is_err() {
+                failures += 1;
+            }
+        }
+    }
+
+    // Drain the rest.
+    while let Some((ptr, _)) = live.pop() {
+        if KERNEL_HEAP.lock().deallocate(ptr).is_err() {
+            failures += 1;
+        }
+    }
+    drop(live);
+
+    let (blocks_after, free_blocks_after) = block_census();
+    let free_after = heap_stats().free_bytes;
+
+    serial_println!("  allocation failures : {}", failures);
+    serial_println!("  misaligned pointers : {}", misaligned);
+    serial_println!(
+        "  blocks: {} before -> {} after ({} free)",
+        blocks_before,
+        blocks_after,
+        free_blocks_after
+    );
+    serial_println!("  free bytes: {} before -> {} after", free_before, free_after);
+
+    if misaligned != 0 {
+        serial_println!("  FAIL: allocator returned {} misaligned pointers", misaligned);
+    } else if failures != 0 {
+        serial_println!("  FAIL: {} allocation/deallocation errors", failures);
+    } else if blocks_after != 1 {
+        serial_println!(
+            "  FAIL: heap did not coalesce back to one block ({} remain)",
+            blocks_after
+        );
+    } else if free_after != free_before {
+        serial_println!(
+            "  FAIL: leaked {} bytes",
+            free_before.saturating_sub(free_after)
+        );
+    } else {
+        serial_println!("  PASS: heap fully reclaimed, coalesced to a single free block");
+    }
+
+    match validate_heap() {
+        Ok(()) => serial_println!("  PASS: heap integrity validated"),
+        Err(e) => serial_println!("  FAIL: heap integrity: {}", e),
+    }
 }
 
 /// Validate heap integrity

--- a/kernel/src/memory/heap.rs
+++ b/kernel/src/memory/heap.rs
@@ -514,7 +514,15 @@ pub fn test_heap_allocator() {
         let size = 32 + i * 16;
         let layout = Layout::from_size_align(size, 8).unwrap();
         
-        match KERNEL_HEAP.lock().allocate(layout) {
+        // NOTE: the lock MUST be released before `ptrs.push`. A temporary in a
+        // `match` scrutinee lives until the end of the match, so writing
+        // `match KERNEL_HEAP.lock().allocate(..)` holds the spinlock while the
+        // Vec grows — and Vec growth calls the global allocator, which tries to
+        // take the same lock. That is a hard deadlock, and it was hanging the
+        // boot right here.
+        let result = KERNEL_HEAP.lock().allocate(layout);
+
+        match result {
             Ok(ptr) => {
                 serial_println!("Allocated {} bytes at 0x{:x}", size, ptr.as_ptr() as usize);
                 ptrs.push((ptr, layout));

--- a/kernel/src/memory/mod.rs
+++ b/kernel/src/memory/mod.rs
@@ -1,4 +1,5 @@
 pub mod physical;
+pub mod paging;
 pub mod vmm;
 pub mod heap;
 pub mod swap;

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -1,0 +1,374 @@
+//! Kernel page tables.
+//!
+//! The bootstrap trampoline in `boot32.rs` sets up a flat identity map so the
+//! CPU can reach long mode. That map is deliberately crude: everything is
+//! writable and executable, and it only covers the first 1 GiB.
+//!
+//! This module replaces it with page tables the kernel builds itself:
+//!
+//!   * **W^X on the kernel image** — `.text` is read+execute, `.rodata` is
+//!     read-only+NX, everything else is read+write+NX. Nothing is both
+//!     writable and executable.
+//!   * **A physical memory map** at [`PHYSMAP_BASE`] so the kernel can reach
+//!     any physical frame by adding a constant, without editing page tables.
+//!     This is what `vmm.rs`'s `PHYSICAL_MEMORY_OFFSET` always assumed existed
+//!     — nothing had ever created it.
+//!   * **A dedicated heap window** at [`KERNEL_HEAP_BASE`], so the heap lives
+//!     at proper virtual addresses instead of using raw physical addresses as
+//!     pointers.
+//!   * **Page 0 left unmapped**, preserving the null guard.
+//!
+//! Until this module ran, `Cr3::write` appeared nowhere in the kernel — the
+//! "virtual memory manager" was reading the bootloader's CR3 and describing it.
+
+use spin::Mutex;
+use x86_64::registers::control::{Cr0, Cr0Flags, Cr3, Cr3Flags};
+use x86_64::registers::model_specific::{Efer, EferFlags};
+use x86_64::structures::paging::{
+    FrameAllocator, Mapper, OffsetPageTable, Page, PageTable, PageTableFlags, PhysFrame, Size2MiB,
+    Size4KiB,
+};
+use x86_64::{PhysAddr, VirtAddr};
+
+use crate::memory::physical::{allocate_frame, bitmap_extent, PageFrame};
+use crate::memory::PAGE_SIZE;
+use crate::serial_println;
+
+/// All of physical memory is mapped here, read+write, never executable.
+/// PML4 entry 256 — the first entry of the higher half.
+pub const PHYSMAP_BASE: u64 = 0xFFFF_8000_0000_0000;
+
+/// Virtual base of the kernel heap window. PML4 entry 288.
+pub const KERNEL_HEAP_BASE: u64 = 0xFFFF_9000_0000_0000;
+
+extern "C" {
+    static __kernel_start: u8;
+    static __text_start: u8;
+    static __text_end: u8;
+    static __rodata_start: u8;
+    static __rodata_end: u8;
+    static __kernel_end: u8;
+}
+
+fn sym(s: &u8) -> u64 {
+    s as *const u8 as u64
+}
+
+/// Adapter so the `x86_64` crate's mapper can pull frames from our bitmap
+/// allocator.
+struct KoshFrameAllocator;
+
+unsafe impl FrameAllocator<Size4KiB> for KoshFrameAllocator {
+    fn allocate_frame(&mut self) -> Option<PhysFrame<Size4KiB>> {
+        allocate_frame().map(|f: PageFrame| {
+            PhysFrame::containing_address(PhysAddr::new(f.address() as u64))
+        })
+    }
+}
+
+/// Set once `init` has switched CR3. Before that, physical addresses must be
+/// reached through the bootstrap identity map instead.
+static PHYSMAP_ACTIVE: Mutex<bool> = Mutex::new(false);
+
+/// Translate a physical address to a kernel-virtual one.
+///
+/// Before [`init`] this is the identity map (offset 0); afterwards it is the
+/// physmap. Callers do not need to care which.
+pub fn phys_to_virt(phys: u64) -> u64 {
+    if *PHYSMAP_ACTIVE.lock() {
+        PHYSMAP_BASE + phys
+    } else {
+        phys
+    }
+}
+
+/// Build the kernel's own page tables and install them.
+///
+/// `phys_mem_end` is the highest physical address that needs to appear in the
+/// physmap — normally the end of the last usable memory region.
+pub fn init(phys_mem_end: u64) -> Result<(), &'static str> {
+    serial_println!("Building kernel page tables...");
+
+    // NO_EXECUTE is a reserved bit unless EFER.NXE is set; setting it without
+    // enabling the feature turns every NX mapping into a reserved-bit page
+    // fault. Enable it before we write a single entry.
+    unsafe {
+        Efer::update(|flags| flags.insert(EferFlags::NO_EXECUTE_ENABLE));
+    }
+    serial_println!("  EFER.NXE enabled");
+
+    // CR0.WP makes read-only mappings apply to ring 0 as well. Without it the
+    // kernel can happily write through a read-only PTE and the .rodata/.text
+    // protections below are decorative — which is exactly what the first
+    // version of this code shipped: a deliberate write to .text succeeded.
+    unsafe {
+        Cr0::update(|flags| flags.insert(Cr0Flags::WRITE_PROTECT));
+    }
+    serial_println!("  CR0.WP enabled (read-only pages enforced in ring 0)");
+
+    // We are still running on the bootstrap identity map, so a physical
+    // address is also a valid virtual address. That is what makes it possible
+    // to build a fresh table hierarchy at all.
+    let pml4_frame = allocate_frame().ok_or("no frame for PML4")?;
+    let pml4_phys = pml4_frame.address() as u64;
+    let pml4: &mut PageTable = unsafe {
+        let ptr = pml4_phys as *mut PageTable;
+        ptr.write(PageTable::new());
+        &mut *ptr
+    };
+
+    // Offset 0: during construction, physical == virtual.
+    let mut mapper = unsafe { OffsetPageTable::new(pml4, VirtAddr::new(0)) };
+    let mut frames = KoshFrameAllocator;
+
+    map_kernel_image(&mut mapper, &mut frames)?;
+    let identity_end = map_low_identity(&mut mapper, &mut frames)?;
+    map_physical_memory(&mut mapper, &mut frames, phys_mem_end)?;
+
+    // Install. From the next instruction onwards the kernel is running on
+    // tables it built, with W^X enforced and a real physmap.
+    unsafe {
+        Cr3::write(
+            PhysFrame::containing_address(PhysAddr::new(pml4_phys)),
+            Cr3Flags::empty(),
+        );
+    }
+
+    *PHYSMAP_ACTIVE.lock() = true;
+
+    serial_println!("  CR3 -> 0x{:x} (kernel page tables active)", pml4_phys);
+    serial_println!(
+        "  identity window : 0x{:x}..0x{:x} (4 KiB pages, W^X)",
+        PAGE_SIZE,
+        identity_end
+    );
+    serial_println!(
+        "  physmap         : 0x{:x} -> 0x0..0x{:x} (2 MiB pages, RW+NX)",
+        PHYSMAP_BASE,
+        phys_mem_end
+    );
+    serial_println!("  page 0          : unmapped (null guard)");
+
+    Ok(())
+}
+
+/// Map the kernel image with per-section permissions.
+///
+/// The identity mapping is kept — the kernel is linked at 1 MiB and is
+/// executing there, so it cannot move without a jump trampoline. What changes
+/// is the permissions: `.text` loses write, everything else loses execute.
+fn map_kernel_image(
+    mapper: &mut OffsetPageTable,
+    frames: &mut KoshFrameAllocator,
+) -> Result<(), &'static str> {
+    let text_start = align_down_page(sym(unsafe { &__text_start }));
+    let text_end = align_up_page(sym(unsafe { &__text_end }));
+    let rodata_start = align_down_page(sym(unsafe { &__rodata_start }));
+    let rodata_end = align_up_page(sym(unsafe { &__rodata_end }));
+    let kernel_start = align_down_page(sym(unsafe { &__kernel_start }));
+    let kernel_end = align_up_page(sym(unsafe { &__kernel_end }));
+
+    const PRESENT: PageTableFlags = PageTableFlags::PRESENT;
+    let rx = PRESENT;
+    let ro = PRESENT | PageTableFlags::NO_EXECUTE;
+    let rw = PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE;
+
+    let mut addr = kernel_start;
+    while addr < kernel_end {
+        let flags = if addr >= text_start && addr < text_end {
+            rx
+        } else if addr >= rodata_start && addr < rodata_end {
+            ro
+        } else {
+            rw
+        };
+        identity_map_4k(mapper, frames, addr, flags)?;
+        addr += PAGE_SIZE as u64;
+    }
+
+    serial_println!(
+        "  kernel image    : .text 0x{:x}..0x{:x} RX, .rodata 0x{:x}..0x{:x} RO+NX, rest RW+NX",
+        text_start,
+        text_end,
+        rodata_start,
+        rodata_end
+    );
+
+    Ok(())
+}
+
+/// Identity-map the low region the kernel still touches by physical address:
+/// VGA at 0xB8000, and the physical frame bitmap.
+///
+/// Page 0 is skipped so a null dereference still faults.
+fn map_low_identity(
+    mapper: &mut OffsetPageTable,
+    frames: &mut KoshFrameAllocator,
+) -> Result<u64, &'static str> {
+    let (_bitmap_start, bitmap_end) = bitmap_extent();
+    let kernel_start = align_down_page(sym(unsafe { &__kernel_start }));
+    let kernel_end = align_up_page(sym(unsafe { &__kernel_end }));
+
+    // One 2 MiB of slack past the bitmap covers early page-table frames, which
+    // the allocator hands out from just above it.
+    let end = align_up_2mib(bitmap_end as u64 + 2 * 1024 * 1024);
+
+    let rw = PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE;
+
+    let mut addr = PAGE_SIZE as u64; // skip page 0: null guard
+    while addr < end {
+        // The kernel image was already mapped with tighter permissions.
+        if addr >= kernel_start && addr < kernel_end {
+            addr += PAGE_SIZE as u64;
+            continue;
+        }
+        identity_map_4k(mapper, frames, addr, rw)?;
+        addr += PAGE_SIZE as u64;
+    }
+
+    Ok(end)
+}
+
+/// Map all of physical memory at [`PHYSMAP_BASE`] using 2 MiB pages.
+fn map_physical_memory(
+    mapper: &mut OffsetPageTable,
+    frames: &mut KoshFrameAllocator,
+    phys_mem_end: u64,
+) -> Result<(), &'static str> {
+    const HUGE: u64 = 2 * 1024 * 1024;
+    let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE;
+
+    let end = align_up_2mib(phys_mem_end);
+    let mut phys = 0u64;
+
+    while phys < end {
+        let page: Page<Size2MiB> =
+            Page::containing_address(VirtAddr::new(PHYSMAP_BASE + phys));
+        let frame: PhysFrame<Size2MiB> =
+            PhysFrame::containing_address(PhysAddr::new(phys));
+
+        unsafe {
+            mapper
+                .map_to(page, frame, flags, frames)
+                .map_err(|_| "failed to map physmap page")?
+                .ignore(); // not live yet; no TLB entry can exist
+        }
+
+        phys += HUGE;
+    }
+
+    Ok(())
+}
+
+fn identity_map_4k(
+    mapper: &mut OffsetPageTable,
+    frames: &mut KoshFrameAllocator,
+    addr: u64,
+    flags: PageTableFlags,
+) -> Result<(), &'static str> {
+    let page: Page<Size4KiB> = Page::containing_address(VirtAddr::new(addr));
+    let frame: PhysFrame<Size4KiB> = PhysFrame::containing_address(PhysAddr::new(addr));
+
+    unsafe {
+        mapper
+            .map_to(page, frame, flags, frames)
+            .map_err(|_| "failed to identity-map page")?
+            .ignore();
+    }
+    Ok(())
+}
+
+/// Map `pages` freshly-allocated frames at `virt`, read+write, no-execute.
+///
+/// Used for the kernel heap. Frames do not need to be contiguous — that is the
+/// entire point of having page tables.
+pub fn map_kernel_pages(virt: u64, pages: usize) -> Result<(), &'static str> {
+    let mut mapper = unsafe { active_mapper() };
+    let mut frames = KoshFrameAllocator;
+    let flags = PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE;
+
+    for i in 0..pages {
+        let frame = allocate_frame().ok_or("out of physical memory mapping kernel pages")?;
+        let page: Page<Size4KiB> =
+            Page::containing_address(VirtAddr::new(virt + (i * PAGE_SIZE) as u64));
+        let phys: PhysFrame<Size4KiB> =
+            PhysFrame::containing_address(PhysAddr::new(frame.address() as u64));
+
+        unsafe {
+            mapper
+                .map_to(page, phys, flags, &mut frames)
+                .map_err(|_| "failed to map kernel page")?
+                .flush();
+        }
+    }
+
+    Ok(())
+}
+
+/// Borrow the live page tables through the physmap.
+///
+/// # Safety
+/// Only valid after [`init`] has installed the tables and enabled the physmap.
+/// The caller must not create two aliasing mappers at once.
+pub unsafe fn active_mapper() -> OffsetPageTable<'static> {
+    let (frame, _) = Cr3::read();
+    let virt = PHYSMAP_BASE + frame.start_address().as_u64();
+    let table: &'static mut PageTable = &mut *(virt as *mut PageTable);
+    OffsetPageTable::new(table, VirtAddr::new(PHYSMAP_BASE))
+}
+
+/// Translate a kernel-virtual address using the live tables. `None` if unmapped.
+pub fn translate(virt: u64) -> Option<u64> {
+    use x86_64::structures::paging::Translate;
+    let mapper = unsafe { active_mapper() };
+    mapper.translate_addr(VirtAddr::new(virt)).map(|p| p.as_u64())
+}
+
+fn align_down_page(addr: u64) -> u64 {
+    addr & !(PAGE_SIZE as u64 - 1)
+}
+
+fn align_up_page(addr: u64) -> u64 {
+    align_down_page(addr + PAGE_SIZE as u64 - 1)
+}
+
+fn align_up_2mib(addr: u64) -> u64 {
+    const HUGE: u64 = 2 * 1024 * 1024;
+    (addr + HUGE - 1) & !(HUGE - 1)
+}
+
+/// Verify the tables we just installed behave as advertised.
+pub fn self_test() {
+    serial_println!("Verifying kernel page tables...");
+
+    // The physmap must alias the identity region. Reading the kernel's first
+    // bytes through both windows must give the same value.
+    let kernel_start = align_down_page(sym(unsafe { &__kernel_start }));
+    let via_identity = unsafe { core::ptr::read_volatile(kernel_start as *const u64) };
+    let via_physmap =
+        unsafe { core::ptr::read_volatile((PHYSMAP_BASE + kernel_start) as *const u64) };
+
+    if via_identity == via_physmap {
+        serial_println!("  physmap aliases identity map: OK (0x{:016x})", via_identity);
+    } else {
+        serial_println!(
+            "  physmap MISMATCH: identity 0x{:x} vs physmap 0x{:x}",
+            via_identity,
+            via_physmap
+        );
+    }
+
+    match translate(kernel_start) {
+        Some(phys) if phys == kernel_start => {
+            serial_println!("  translate(0x{:x}) -> 0x{:x}: OK", kernel_start, phys)
+        }
+        Some(phys) => serial_println!("  translate mismatch: 0x{:x}", phys),
+        None => serial_println!("  translate FAILED: kernel not mapped?"),
+    }
+
+    if translate(0).is_none() {
+        serial_println!("  page 0 unmapped: OK (null dereferences will fault)");
+    } else {
+        serial_println!("  WARNING: page 0 is mapped, null dereferences will NOT fault");
+    }
+}

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -305,6 +305,85 @@ pub fn map_kernel_pages(virt: u64, pages: usize) -> Result<(), &'static str> {
     Ok(())
 }
 
+/// Map `pages` of existing physical memory starting at `phys` to `virt`, with
+/// `flags`, for ring-3 access.
+///
+/// Every table on the walk also needs `USER_ACCESSIBLE`, or the CPU stops at
+/// the first supervisor-only level and the leaf flags never get consulted. That
+/// is why this uses `map_to_with_table_flags` rather than plain `map_to`:
+/// permissive parent entries, restrictive leaves. Kernel pages sharing those
+/// tables stay private because *their* leaf entries lack the bit.
+pub fn map_user_range(
+    virt: u64,
+    phys: u64,
+    pages: usize,
+    flags: PageTableFlags,
+) -> Result<(), &'static str> {
+    let mut mapper = unsafe { active_mapper() };
+    let mut frames = KoshFrameAllocator;
+
+    let table_flags =
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::USER_ACCESSIBLE;
+
+    for i in 0..pages {
+        let offset = (i * PAGE_SIZE) as u64;
+        let page: Page<Size4KiB> = Page::containing_address(VirtAddr::new(virt + offset));
+        let frame: PhysFrame<Size4KiB> =
+            PhysFrame::containing_address(PhysAddr::new(phys + offset));
+
+        unsafe {
+            mapper
+                .map_to_with_table_flags(page, frame, flags, table_flags, &mut frames)
+                .map_err(|_| "failed to map user range")?
+                .flush();
+        }
+    }
+
+    Ok(())
+}
+
+/// Allocate `pages` fresh frames and map them at `virt` for ring-3 access.
+pub fn map_user_pages(
+    virt: u64,
+    pages: usize,
+    flags: PageTableFlags,
+) -> Result<(), &'static str> {
+    let mut mapper = unsafe { active_mapper() };
+    let mut frames = KoshFrameAllocator;
+
+    let table_flags =
+        PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::USER_ACCESSIBLE;
+
+    for i in 0..pages {
+        let frame = allocate_frame().ok_or("out of physical memory mapping user pages")?;
+
+        // Zero it through the physmap before it is reachable from ring 3 —
+        // handing a user process a page of somebody else's data is a textbook
+        // information leak.
+        unsafe {
+            core::ptr::write_bytes(
+                (PHYSMAP_BASE + frame.address() as u64) as *mut u8,
+                0,
+                PAGE_SIZE,
+            );
+        }
+
+        let page: Page<Size4KiB> =
+            Page::containing_address(VirtAddr::new(virt + (i * PAGE_SIZE) as u64));
+        let phys: PhysFrame<Size4KiB> =
+            PhysFrame::containing_address(PhysAddr::new(frame.address() as u64));
+
+        unsafe {
+            mapper
+                .map_to_with_table_flags(page, phys, flags, table_flags, &mut frames)
+                .map_err(|_| "failed to map user page")?
+                .flush();
+        }
+    }
+
+    Ok(())
+}
+
 /// Borrow the live page tables through the physmap.
 ///
 /// # Safety

--- a/kernel/src/memory/physical.rs
+++ b/kernel/src/memory/physical.rs
@@ -427,6 +427,27 @@ pub fn deallocate_frames(start_frame: PageFrame, count: usize) {
     }
 }
 
+/// Physical extent of the frame bitmap, as (start, end).
+///
+/// The bitmap is accessed by physical address, so whoever builds the kernel
+/// page tables has to keep it reachable.
+pub fn bitmap_extent() -> (usize, usize) {
+    let guard = PHYSICAL_MEMORY_MANAGER.lock();
+    match guard.as_ref() {
+        Some(m) => (m.bitmap_start, m.bitmap_start + m.bitmap.len()),
+        None => (0, 0),
+    }
+}
+
+/// End of usable physical memory as reported by the bootloader.
+pub fn physical_memory_end() -> u64 {
+    let guard = PHYSICAL_MEMORY_MANAGER.lock();
+    match guard.as_ref() {
+        Some(m) => (m.total_frames * PAGE_SIZE) as u64,
+        None => 0,
+    }
+}
+
 /// Get memory statistics
 #[allow(dead_code)]
 pub fn memory_stats() -> Option<MemoryStats> {

--- a/kernel/src/memory/physical.rs
+++ b/kernel/src/memory/physical.rs
@@ -1,7 +1,26 @@
 use multiboot2::{BootInformation, MemoryAreaType};
 use spin::Mutex;
-use crate::memory::{PAGE_SIZE, align_down};
+use crate::memory::{PAGE_SIZE, align_down, align_up};
 use crate::{serial_println, println};
+
+extern "C" {
+    /// Start of the loaded kernel image (defined by linker.ld).
+    static __kernel_start: u8;
+    /// End of the loaded kernel image, including .bss (defined by linker.ld).
+    static __kernel_end: u8;
+}
+
+/// Physical extent of the kernel image as actually loaded by the bootloader.
+/// These frames must never be handed out by the allocator — the boot page
+/// tables and the boot stack live in .bss, inside this range.
+fn kernel_image_range() -> (usize, usize) {
+    unsafe {
+        (
+            &__kernel_start as *const u8 as usize,
+            &__kernel_end as *const u8 as usize,
+        )
+    }
+}
 
 /// Physical page frame number
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -102,9 +121,11 @@ impl PhysicalMemoryManager {
         // Calculate bitmap size (1 bit per page frame)
         let bitmap_size = (total_frames + 7) / 8; // Round up to nearest byte
         
-        // Find a suitable location for the bitmap after the kernel
-        // We'll place it at 2MB to avoid low memory areas
-        let bitmap_start = 0x200000; // 2MB
+        // Place the bitmap immediately after the kernel image. The previous
+        // hardcoded 2 MiB only worked by accident (the kernel happened to be
+        // small enough) and would silently corrupt the kernel once it grew.
+        let (_kernel_start, kernel_end) = kernel_image_range();
+        let bitmap_start = align_up(kernel_end);
         let bitmap_end = bitmap_start + bitmap_size;
         
         // Ensure bitmap doesn't overlap with any reserved areas
@@ -127,11 +148,15 @@ impl PhysicalMemoryManager {
         // Clear the bitmap (all pages initially marked as used)
         bitmap.fill(0xFF);
         
+        // The bitmap is filled with 0xFF above, i.e. every frame starts out
+        // marked used. The counters have to agree with that, otherwise the
+        // first `mark_frame_free` underflows `used_frames` (panicking in debug,
+        // wrapping to ~u64::MAX in release and corrupting every memory stat).
         let mut manager = Self {
             bitmap,
             total_frames,
             free_frames: 0,
-            used_frames: 0,
+            used_frames: total_frames,
             reserved_frames: 0,
             bitmap_start,
         };
@@ -157,15 +182,22 @@ impl PhysicalMemoryManager {
             let start_frame = PageFrame::from_address(start_addr);
             let end_frame = PageFrame::from_address(end_addr - 1);
             
+            let (kernel_start, kernel_end) = kernel_image_range();
+
             if area.typ() == MemoryAreaType::Available {
-                // Mark pages as free, but avoid the bitmap area and low memory
+                // Mark pages as free, but avoid low memory, the kernel image
+                // and the bitmap itself.
                 for frame_num in start_frame.0..=end_frame.0 {
                     let frame_addr = frame_num * PAGE_SIZE;
                     
-                    // Skip low memory (first 1MB) and bitmap area
-                    if frame_addr < 0x100000 || 
-                       (frame_addr >= self.bitmap_start && 
-                        frame_addr < self.bitmap_start + self.bitmap.len()) {
+                    // Skip low memory (first 1MB), the kernel image (which
+                    // includes the boot page tables and boot stack in .bss),
+                    // and the frame bitmap.
+                    if frame_addr < 0x100000
+                        || (frame_addr >= kernel_start && frame_addr < kernel_end)
+                        || (frame_addr >= self.bitmap_start
+                            && frame_addr < self.bitmap_start + self.bitmap.len())
+                    {
                         self.reserved_frames += 1;
                         continue;
                     }

--- a/kernel/src/memory/vmm.rs
+++ b/kernel/src/memory/vmm.rs
@@ -308,12 +308,13 @@ pub mod kernel_layout {
     /// Offset at which all of physical memory is visible in the virtual
     /// address space.
     ///
-    /// Phase 1: the boot trampoline installs a flat identity map of the first
-    /// 1 GiB, so physical == virtual and the offset is 0. This becomes
-    /// 0xFFFF_8000_0000_0000 once the kernel builds its own higher-half
-    /// address space (Phase 3) — until something actually *creates* that
-    /// mapping, using it here is an immediate page fault.
-    pub const PHYSICAL_MEMORY_OFFSET: VirtualAddress = VirtualAddress(0);
+    /// Phase 3: `memory::paging` maps all of physical memory here when it
+    /// builds the kernel page tables, so this offset is now backed by real
+    /// mappings. (Through Phase 2 it had to be 0 — the constant claimed a
+    /// higher-half physmap that nothing had ever created, so using it was an
+    /// immediate page fault.)
+    pub const PHYSICAL_MEMORY_OFFSET: VirtualAddress =
+        VirtualAddress(crate::memory::paging::PHYSMAP_BASE as usize);
 }
 
 /// Global virtual memory manager
@@ -554,6 +555,6 @@ mod tests {
         assert_eq!(kernel_layout::KERNEL_DATA_SIZE, 16 * 1024 * 1024);
         assert_eq!(kernel_layout::KERNEL_HEAP_START.as_usize(), 0xFFFFFFFF82000000);
         assert_eq!(kernel_layout::KERNEL_HEAP_SIZE, 64 * 1024 * 1024);
-        assert_eq!(kernel_layout::PHYSICAL_MEMORY_OFFSET.as_usize(), 0);
+        assert_eq!(kernel_layout::PHYSICAL_MEMORY_OFFSET.as_usize(), 0xFFFF800000000000);
     }
 }

--- a/kernel/src/memory/vmm.rs
+++ b/kernel/src/memory/vmm.rs
@@ -305,7 +305,15 @@ pub mod kernel_layout {
     pub const KERNEL_HEAP_SIZE: usize = 64 * 1024 * 1024;
     
     /// Physical memory mapping start (for higher half kernel)
-    pub const PHYSICAL_MEMORY_OFFSET: VirtualAddress = VirtualAddress(0xFFFF800000000000);
+    /// Offset at which all of physical memory is visible in the virtual
+    /// address space.
+    ///
+    /// Phase 1: the boot trampoline installs a flat identity map of the first
+    /// 1 GiB, so physical == virtual and the offset is 0. This becomes
+    /// 0xFFFF_8000_0000_0000 once the kernel builds its own higher-half
+    /// address space (Phase 3) — until something actually *creates* that
+    /// mapping, using it here is an immediate page fault.
+    pub const PHYSICAL_MEMORY_OFFSET: VirtualAddress = VirtualAddress(0);
 }
 
 /// Global virtual memory manager
@@ -546,6 +554,6 @@ mod tests {
         assert_eq!(kernel_layout::KERNEL_DATA_SIZE, 16 * 1024 * 1024);
         assert_eq!(kernel_layout::KERNEL_HEAP_START.as_usize(), 0xFFFFFFFF82000000);
         assert_eq!(kernel_layout::KERNEL_HEAP_SIZE, 64 * 1024 * 1024);
-        assert_eq!(kernel_layout::PHYSICAL_MEMORY_OFFSET.as_usize(), 0xFFFF800000000000);
+        assert_eq!(kernel_layout::PHYSICAL_MEMORY_OFFSET.as_usize(), 0);
     }
 }

--- a/kernel/src/process/scheduler.rs
+++ b/kernel/src/process/scheduler.rs
@@ -1,6 +1,21 @@
 use alloc::vec::Vec;
 use spin::Mutex;
 use crate::process::{ProcessId, ProcessPriority, get_runnable_processes, get_process, set_current_process, get_current_process};
+// NOTE (Phase 4): this module is scheduling *policy* over the process table —
+// round-robin, priorities, a simplified CFS. It does not perform context
+// switches, and `handle_timer_tick` below still has no caller.
+//
+// The thing that actually runs threads is `crate::task`: it owns the stacks,
+// the switch primitive (`task::switch::kosh_switch_context`) and the timer
+// wiring. `task` deliberately covers *kernel* threads; this module is meant to
+// govern userspace processes, which do not exist until ring 3 arrives in
+// Phase 5. When they do, the intended shape is for `task` to ask this module
+// which process to run next, rather than for this module to grow its own
+// switch.
+//
+// Until then, treat everything here as unwired. It is kept because the policy
+// code is real and worth reusing — not because it is running.
+#[allow(unused_imports)]
 use crate::process::context::{CpuContext, ContextSwitcher};
 use crate::power::{power_policy, responsiveness, ProcessActivity};
 use crate::{serial_println, println};

--- a/kernel/src/serial.rs
+++ b/kernel/src/serial.rs
@@ -13,6 +13,21 @@ lazy_static! {
 #[doc(hidden)]
 pub fn _print(args: ::core::fmt::Arguments) {
     use core::fmt::Write;
+
+    // Interrupts off while the port lock is held. Once the kernel is
+    // preemptive, a thread can be interrupted mid-print; if the timer handler
+    // (or the thread scheduled next) then tries to print, it spins forever on a
+    // lock parked in a thread that is no longer running. Same reasoning as the
+    // `try_lock` rule in the interrupt handlers.
+    #[cfg(target_arch = "x86_64")]
+    x86_64::instructions::interrupts::without_interrupts(|| {
+        SERIAL1
+            .lock()
+            .write_fmt(args)
+            .expect("Printing to serial failed");
+    });
+
+    #[cfg(not(target_arch = "x86_64"))]
     SERIAL1.lock().write_fmt(args).expect("Printing to serial failed");
 }
 

--- a/kernel/src/serial.rs
+++ b/kernel/src/serial.rs
@@ -18,9 +18,7 @@ pub fn _print(args: ::core::fmt::Arguments) {
 
 #[macro_export]
 macro_rules! serial_print {
-    ($($arg:tt)*) => {
-        $crate::serial::_print(format_args!($($arg)*));
-    };
+    ($($arg:tt)*) => ($crate::serial::_print(format_args!($($arg)*)));
 }
 
 #[macro_export]

--- a/kernel/src/syscall/dispatcher.rs
+++ b/kernel/src/syscall/dispatcher.rs
@@ -131,11 +131,20 @@ fn sys_exit(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
     // 3. Notify parent process
     // 4. Schedule next process
     
-    // Since we don't have direct access to the process table from here,
-    // we'll use the public interface when it's available
-    serial_println!("Process {} terminated with exit code {}", process_id.0, exit_code);
-    
-    // Return success - the process will be cleaned up by the scheduler
+    serial_println!(
+        "Process {} terminated with exit code {}",
+        process_id.0,
+        exit_code
+    );
+
+    // Actually terminate. The ring-3 program runs on a kernel thread, so
+    // retiring that thread is the exit: `exit_current` marks it finished and
+    // schedules away, and never returns. Previously this logged and returned
+    // Ok(0), leaving the caller running as if nothing had happened.
+    #[cfg(target_arch = "x86_64")]
+    crate::task::exit_current();
+
+    #[allow(unreachable_code)]
     Ok(0)
 }
 
@@ -374,23 +383,43 @@ fn sys_read(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
     }
 }
 
-fn sys_write(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
+fn sys_write(_process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
+    use crate::syscall::uaccess::copy_from_user;
+
     let fd = args[0];
     let buf_ptr = args[1];
-    let count = args[2];
-    
-    serial_println!("Process {} requesting write: fd={}, buf=0x{:x}, count={}", 
-                   process_id.0, fd, buf_ptr, count);
-    
-    // TODO: Implement file writing
-    // For now, if writing to stdout (fd=1) or stderr (fd=2), we could output to console
-    if fd == 1 || fd == 2 {
-        // TODO: Read string from user space and print it
-        serial_println!("Process {} writing {} bytes to console", process_id.0, count);
-        Ok(count) // Return number of bytes "written"
-    } else {
-        Err(SyscallError::NotSupported)
+    let count = args[2] as usize;
+
+    // Only the console for now; real file descriptors need the VFS.
+    if fd != 1 && fd != 2 {
+        return Err(SyscallError::NotSupported);
     }
+
+    // Copy through a bounded kernel buffer rather than dereferencing the user
+    // pointer directly. `copy_from_user` is what makes this safe: it checks the
+    // span is in the user half and that every page is present and
+    // USER_ACCESSIBLE. This used to return `count` without reading anything.
+    const CHUNK: usize = 256;
+    let mut buffer = [0u8; CHUNK];
+    let mut written = 0usize;
+
+    while written < count {
+        let n = core::cmp::min(CHUNK, count - written);
+        let slice = &mut buffer[..n];
+
+        copy_from_user(buf_ptr + written as u64, slice)
+            .map_err(|_| SyscallError::InvalidArgument)?;
+
+        for &byte in slice.iter() {
+            let c = byte as char;
+            crate::serial_print!("{}", c);
+            crate::print!("{}", c);
+        }
+
+        written += n;
+    }
+
+    Ok(count as u64)
 }
 
 fn sys_lseek(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {

--- a/kernel/src/syscall/entry.rs
+++ b/kernel/src/syscall/entry.rs
@@ -1,0 +1,223 @@
+//! The `syscall`/`sysret` fast-path entry point.
+//!
+//! Before Phase 5 there was no way into the kernel from user mode at all.
+//! `syscall/mod.rs` had `setup_syscall_interrupt()` — a `serial_println!`, a
+//! `// TODO: Set up IDT entry for interrupt 0x80`, and `Ok(())` — and
+//! `syscall_entry()`, documented as "called from assembly interrupt handler",
+//! with no assembly interrupt handler anywhere in the tree. The dispatcher
+//! below it was real and well-validated, and completely unreachable.
+//!
+//! ## What the instruction does and does not do
+//!
+//! `syscall` is fast because it does almost nothing: it loads CS/SS from
+//! `STAR`, RIP from `LSTAR`, masks RFLAGS with `SFMASK`, stashes the caller's
+//! RIP in RCX and RFLAGS in R11 — and *leaves RSP pointing at the user stack*.
+//! Everything else is the kernel's job. In particular the stack switch is
+//! manual, which is the first thing the stub below does.
+//!
+//! ## Register ABI
+//!
+//! Linux's convention, which the existing userspace code already assumes:
+//!
+//! | register | meaning |
+//! |---|---|
+//! | RAX | syscall number, and the return value |
+//! | RDI RSI RDX R10 R8 R9 | arguments 1-6 |
+//! | RCX R11 | clobbered by the instruction itself |
+//!
+//! Argument 4 lives in R10 rather than RCX precisely because `syscall`
+//! destroys RCX.
+
+use core::sync::atomic::{AtomicU64, Ordering};
+
+use x86_64::registers::model_specific::{Efer, EferFlags, LStar, SFMask, Star};
+use x86_64::registers::rflags::RFlags;
+use x86_64::VirtAddr;
+
+use crate::process::ProcessId;
+use crate::serial_println;
+
+/// Kernel stack used while servicing a syscall.
+///
+/// One static stack is correct only because exactly one thread can be in ring 3
+/// in Phase 5, and `SFMASK` masks IF so a syscall cannot be interrupted into a
+/// second syscall. Multiple user threads need this to become per-thread, reached
+/// through `swapgs` and a per-CPU block — see the note on `SAVED_USER_RSP`.
+const SYSCALL_STACK_SIZE: usize = 32 * 1024;
+
+#[repr(align(16))]
+struct SyscallStack([u8; SYSCALL_STACK_SIZE]);
+
+static mut SYSCALL_STACK: SyscallStack = SyscallStack([0; SYSCALL_STACK_SIZE]);
+
+/// Top of the syscall stack, read by the assembly stub.
+#[no_mangle]
+static mut SYSCALL_KERNEL_RSP: u64 = 0;
+
+/// Where the stub parks the user's RSP for the duration of the call.
+///
+/// A plain static rather than `swapgs` + per-CPU data: single CPU, single
+/// ring-3 thread, and interrupts masked during the call, so nothing can
+/// re-enter. The moment any of those three stops being true this must become
+/// `swapgs`-based, or two concurrent syscalls will trample each other's stacks.
+#[no_mangle]
+static mut SAVED_USER_RSP: u64 = 0;
+
+/// Registers the stub pushes, in push order (so the first field is at the
+/// lowest address — the layout the stub builds by pushing RAX last).
+#[repr(C)]
+pub struct SyscallFrame {
+    pub rax: u64,
+    pub rdi: u64,
+    pub rsi: u64,
+    pub rdx: u64,
+    pub r10: u64,
+    pub r8: u64,
+    pub r9: u64,
+    /// User RIP, delivered by the CPU in RCX. `sysretq` needs it back there.
+    pub rip: u64,
+    /// User RFLAGS, delivered in R11. `sysretq` needs it back there.
+    pub rflags: u64,
+}
+
+extern "C" {
+    fn kosh_syscall_entry();
+}
+
+core::arch::global_asm!(
+    r#"
+.section .text.kosh_syscall, "ax"
+.global kosh_syscall_entry
+.type kosh_syscall_entry, @function
+
+kosh_syscall_entry:
+    /* On entry: RSP is still the *user* stack, RCX = user RIP,
+       R11 = user RFLAGS, RAX = syscall number. Interrupts are already masked
+       by SFMASK. */
+
+    movq    %rsp, SAVED_USER_RSP(%rip)
+    movq    SYSCALL_KERNEL_RSP(%rip), %rsp
+
+    /* Build SyscallFrame. Pushed high field first so RAX lands lowest. */
+    pushq   %r11                /* rflags */
+    pushq   %rcx                /* rip    */
+    pushq   %r9
+    pushq   %r8
+    pushq   %r10
+    pushq   %rdx
+    pushq   %rsi
+    pushq   %rdi
+    pushq   %rax
+
+    movq    %rsp, %rdi          /* &mut SyscallFrame */
+
+    /* SysV wants RSP 16-byte aligned at the call. Nine pushes from a
+       16-aligned top leaves it 8 past, so nudge it. */
+    subq    $8, %rsp
+    call    kosh_syscall_handler
+    addq    $8, %rsp
+
+    movq    %rax, (%rsp)        /* return value into frame.rax */
+
+    popq    %rax
+    popq    %rdi
+    popq    %rsi
+    popq    %rdx
+    popq    %r10
+    popq    %r8
+    popq    %r9
+    popq    %rcx                /* sysretq takes the target RIP here    */
+    popq    %r11                /* ...and the target RFLAGS here        */
+
+    movq    SAVED_USER_RSP(%rip), %rsp
+    sysretq
+"#,
+    options(att_syntax)
+);
+
+/// Rust side of the syscall entry. Called by the stub with the saved frame.
+#[no_mangle]
+pub extern "C" fn kosh_syscall_handler(frame: &mut SyscallFrame) -> u64 {
+    let number = frame.rax;
+    let args = [frame.rdi, frame.rsi, frame.rdx, frame.r10, frame.r8, frame.r9];
+
+    SYSCALL_COUNT.fetch_add(1, Ordering::Relaxed);
+
+    // Phase 5 runs a single ring-3 thread; a real current-process lookup lands
+    // with the process table in Phase 6.
+    let pid = ProcessId::new(1);
+
+    match crate::syscall::dispatcher::dispatch_syscall(pid, number, args) {
+        Ok(value) => value,
+        Err(err) => {
+            serial_println!("syscall {} failed: {:?}", number, err);
+
+            // Linux convention: errors come back as a negative value in RAX,
+            // successes as a non-negative one, and userspace tests the sign.
+            //
+            // Note `SyscallError::to_errno()` already returns *negative*
+            // numbers (-22 for EINVAL, and so on), which is unusual for
+            // something named "errno". Negating it here — the obvious thing to
+            // write — flips errors positive, and userspace then reads every
+            // failure as success. Normalise instead of assuming.
+            let errno = err.to_errno() as i64;
+            let negative = if errno > 0 { -errno } else { errno };
+            negative as u64
+        }
+    }
+}
+
+static SYSCALL_COUNT: AtomicU64 = AtomicU64::new(0);
+
+/// Syscalls serviced since boot.
+pub fn syscall_count() -> u64 {
+    SYSCALL_COUNT.load(Ordering::Relaxed)
+}
+
+/// Program the MSRs that make `syscall` work.
+pub fn init() {
+    let sel = crate::gdt::selectors();
+
+    unsafe {
+        SYSCALL_KERNEL_RSP = {
+            let base = &raw const SYSCALL_STACK as u64;
+            (base + SYSCALL_STACK_SIZE as u64) & !0xF
+        };
+    }
+
+    unsafe {
+        // Without SCE, `syscall` is an invalid opcode.
+        Efer::update(|flags| flags.insert(EferFlags::SYSTEM_CALL_EXTENSIONS));
+
+        // The crate checks the descriptor arithmetic described in `gdt.rs` and
+        // refuses selectors that would make `sysret` land somewhere absurd.
+        Star::write(sel.user_code, sel.user_data, sel.kernel_code, sel.kernel_data)
+            .expect("GDT selector layout is incompatible with sysret");
+
+        LStar::write(VirtAddr::new(kosh_syscall_entry as usize as u64));
+
+        // Bits cleared in RFLAGS on entry. Masking IF means a syscall cannot be
+        // interrupted — which is what makes the single static kernel stack
+        // above safe. DF is masked so string instructions behave; TF so a
+        // single-stepping debugger in userspace does not trap in the kernel.
+        SFMask::write(
+            RFlags::INTERRUPT_FLAG | RFlags::DIRECTION_FLAG | RFlags::TRAP_FLAG,
+        );
+    }
+
+    serial_println!("Syscall interface (SYSCALL/SYSRET):");
+    serial_println!("  EFER.SCE enabled");
+    serial_println!(
+        "  STAR: syscall CS 0x{:x}/SS 0x{:x}, sysret CS 0x{:x}/SS 0x{:x}",
+        sel.kernel_code.0,
+        sel.kernel_data.0,
+        sel.user_code.0 | 3,
+        sel.user_data.0 | 3
+    );
+    serial_println!(
+        "  LSTAR -> 0x{:x}, kernel stack 0x{:x}",
+        kosh_syscall_entry as usize as u64,
+        unsafe { SYSCALL_KERNEL_RSP }
+    );
+    serial_println!("  SFMASK masks IF, DF, TF");
+}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -3,7 +3,9 @@ use crate::process::ProcessId;
 use crate::{serial_println, println};
 
 pub mod dispatcher;
+pub mod entry;
 pub mod numbers;
+pub mod uaccess;
 pub mod validation;
 pub mod error;
 pub mod test;
@@ -23,24 +25,11 @@ pub fn init_syscall_interface() -> Result<(), &'static str> {
     // Initialize the system call dispatcher
     dispatcher::init_syscall_dispatcher()?;
     
-    // Set up system call interrupt handler
-    setup_syscall_interrupt()?;
+    // Program the SYSCALL/SYSRET MSRs. This replaces the int 0x80 stub that
+    // never existed.
+    entry::init();
     
     serial_println!("System call interface initialized successfully");
-    Ok(())
-}
-
-/// Set up the system call interrupt handler (int 0x80)
-fn setup_syscall_interrupt() -> Result<(), &'static str> {
-    // For now, we'll use a simple approach with software interrupt 0x80
-    // In a more sophisticated implementation, we would use SYSCALL/SYSRET instructions
-    
-    serial_println!("Setting up system call interrupt handler (int 0x80)");
-    
-    // TODO: Set up IDT entry for interrupt 0x80
-    // This would require implementing an IDT (Interrupt Descriptor Table)
-    // For now, we'll just log that it's set up
-    
     Ok(())
 }
 

--- a/kernel/src/syscall/numbers.rs
+++ b/kernel/src/syscall/numbers.rs
@@ -55,7 +55,10 @@ pub const SYS_CHECK_CAPABILITY: u64 = 62;
 pub const SYS_LIST_CAPABILITIES: u64 = 63;
 
 /// Debug and testing system calls (only available in debug builds)
-#[cfg(debug_assertions)]
+// Deliberately NOT cfg(debug_assertions): userspace calls this unconditionally
+// (see userspace/shell/src/output.rs), and having the number vanish from
+// release kernels is exactly the kind of silent difference that hides bugs
+// until the release build is the one that matters.
 pub const SYS_DEBUG_PRINT: u64 = 100;
 #[cfg(debug_assertions)]
 pub const SYS_DEBUG_DUMP: u64 = 101;

--- a/kernel/src/syscall/uaccess.rs
+++ b/kernel/src/syscall/uaccess.rs
@@ -1,0 +1,174 @@
+//! Copying across the user/kernel boundary.
+//!
+//! A syscall argument that is a pointer is *untrusted input*. The kernel must
+//! never dereference it without first establishing that it points where the
+//! caller is allowed to point.
+//!
+//! This did not exist before Phase 5, and the consequences were visible in the
+//! dispatcher: `sys_write` returned the byte count without reading the buffer,
+//! `sys_read` returned a length without writing one, and `sys_send_message`
+//! discarded the user pointer entirely and sent a `format!` string in its
+//! place. Those all "worked" because nothing could call them.
+//!
+//! Two checks, both necessary:
+//!
+//! 1. **Range.** The whole span must lie in the lower canonical half. A caller
+//!    passing `0xFFFF_8000_0000_0000` is asking the kernel to read its own
+//!    physmap on their behalf.
+//! 2. **Mapping.** Every page in the span must be present *and* carry
+//!    `USER_ACCESSIBLE`. Range checking alone is not enough — a kernel-only
+//!    page can sit at a low address.
+
+use x86_64::structures::paging::mapper::TranslateResult;
+use x86_64::structures::paging::{PageTableFlags, Translate};
+use x86_64::VirtAddr;
+
+use crate::memory::PAGE_SIZE;
+
+/// First address of the higher (kernel) half. Anything at or above this is
+/// never a valid user pointer.
+const USER_ADDRESS_LIMIT: u64 = 0x0000_8000_0000_0000;
+
+/// Refuse absurdly large transfers outright rather than walking millions of
+/// page-table entries on behalf of a hostile caller.
+const MAX_TRANSFER: usize = 16 * 1024 * 1024;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum UserAccessError {
+    /// Pointer or length puts part of the span outside the user half.
+    OutOfRange,
+    /// A page in the span is not mapped.
+    NotMapped,
+    /// A page in the span is mapped, but not for user access.
+    NotUserAccessible,
+    /// A page in the span is mapped read-only and this is a write.
+    NotWritable,
+    /// Length exceeds `MAX_TRANSFER`.
+    TooLarge,
+}
+
+/// Check that `[ptr, ptr + len)` is a valid user span.
+///
+/// `writable` additionally requires every page to be writable by the user.
+pub fn validate_user_range(ptr: u64, len: usize, writable: bool) -> Result<(), UserAccessError> {
+    if len == 0 {
+        return Ok(());
+    }
+    if len > MAX_TRANSFER {
+        return Err(UserAccessError::TooLarge);
+    }
+
+    // Overflow here is itself an attack: `ptr = u64::MAX, len = 2` would
+    // otherwise wrap into a "valid looking" range.
+    let end = ptr.checked_add(len as u64).ok_or(UserAccessError::OutOfRange)?;
+    if end > USER_ADDRESS_LIMIT {
+        return Err(UserAccessError::OutOfRange);
+    }
+
+    let mapper = unsafe { crate::memory::paging::active_mapper() };
+
+    let first_page = ptr & !(PAGE_SIZE as u64 - 1);
+    let mut page = first_page;
+
+    while page < end {
+        match mapper.translate(VirtAddr::new(page)) {
+            TranslateResult::Mapped { flags, .. } => {
+                if !flags.contains(PageTableFlags::USER_ACCESSIBLE) {
+                    return Err(UserAccessError::NotUserAccessible);
+                }
+                if writable && !flags.contains(PageTableFlags::WRITABLE) {
+                    return Err(UserAccessError::NotWritable);
+                }
+            }
+            _ => return Err(UserAccessError::NotMapped),
+        }
+
+        page += PAGE_SIZE as u64;
+    }
+
+    Ok(())
+}
+
+/// Copy `dst.len()` bytes from the user address `src` into `dst`.
+pub fn copy_from_user(src: u64, dst: &mut [u8]) -> Result<(), UserAccessError> {
+    validate_user_range(src, dst.len(), false)?;
+
+    // The span is validated and the kernel shares the address space, so a
+    // straight copy is sound. Volatile so the compiler cannot decide the
+    // user's memory is unobservable and elide it.
+    for (i, byte) in dst.iter_mut().enumerate() {
+        *byte = unsafe { core::ptr::read_volatile((src + i as u64) as *const u8) };
+    }
+
+    Ok(())
+}
+
+/// Copy `src` into the user address `dst`.
+pub fn copy_to_user(dst: u64, src: &[u8]) -> Result<(), UserAccessError> {
+    validate_user_range(dst, src.len(), true)?;
+
+    for (i, byte) in src.iter().enumerate() {
+        unsafe { core::ptr::write_volatile((dst + i as u64) as *mut u8, *byte) };
+    }
+
+    Ok(())
+}
+
+/// Read a NUL-terminated user string, up to `max` bytes, into `buf`.
+/// Returns the number of bytes read, excluding the terminator.
+pub fn copy_str_from_user(
+    src: u64,
+    buf: &mut [u8],
+    max: usize,
+) -> Result<usize, UserAccessError> {
+    let limit = core::cmp::min(max, buf.len());
+
+    for i in 0..limit {
+        let addr = src + i as u64;
+        validate_user_range(addr, 1, false)?;
+
+        let byte = unsafe { core::ptr::read_volatile(addr as *const u8) };
+        if byte == 0 {
+            return Ok(i);
+        }
+        buf[i] = byte;
+    }
+
+    Ok(limit)
+}
+
+/// Prove the checks reject what they should.
+pub fn self_test() {
+    use crate::serial_println;
+
+    serial_println!("Verifying user-pointer validation...");
+
+    let kernel_addr = crate::memory::paging::PHYSMAP_BASE;
+    let checks: [(&str, Result<(), UserAccessError>, bool); 4] = [
+        (
+            "kernel physmap address rejected",
+            validate_user_range(kernel_addr, 8, false),
+            false,
+        ),
+        (
+            "null pointer rejected",
+            validate_user_range(0, 8, false),
+            false,
+        ),
+        (
+            "length overflow rejected",
+            validate_user_range(u64::MAX - 1, 16, false),
+            false,
+        ),
+        (
+            "oversized transfer rejected",
+            validate_user_range(0x4000_0000, MAX_TRANSFER + 1, false),
+            false,
+        ),
+    ];
+
+    for (name, result, should_succeed) in checks {
+        let ok = result.is_ok() == should_succeed;
+        serial_println!("  {} {}", if ok { "PASS" } else { "FAIL" }, name);
+    }
+}

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -1,0 +1,388 @@
+//! Preemptive kernel threads.
+//!
+//! This is the first thing in Kosh that actually schedules. Through Phase 3,
+//! `process::scheduler` implemented round-robin, priority and CFS *policy* over
+//! a table of processes — but "scheduling" ended at writing a PID into a field.
+//! `handle_timer_tick()` had no callers, `ContextSwitcher::switch_context()`
+//! had no callers, and no stack was ever switched.
+//!
+//! ## Scope: kernel threads, not processes
+//!
+//! A [`Thread`] here shares the kernel's address space and runs in ring 0. It
+//! has its own stack and nothing else. That is deliberately *not* the same
+//! abstraction as `process::Process`, which is meant to be a userspace process
+//! with its own address space and ring-3 context — that arrives in Phase 5,
+//! and will build on this switch primitive rather than replace it. Most kernels
+//! carry both; conflating them now would mean pretending an address-space
+//! switch exists before one does.
+//!
+//! ## Locking
+//!
+//! Every scheduler access runs with interrupts disabled. The timer handler
+//! takes the same lock, so touching it with interrupts on means a tick landing
+//! mid-update deadlocks against a lock the interrupted code already holds.
+//!
+//! The lock is always released *before* the switch. Holding a spinlock across a
+//! context switch parks it in the outgoing thread, and the incoming thread
+//! spins on it forever.
+
+pub mod switch;
+
+use alloc::boxed::Box;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+use spin::Mutex;
+
+use crate::interrupts::without_interrupts;
+use crate::serial_println;
+use switch::kosh_switch_context;
+
+/// Fixed thread table. A fixed array rather than a `Vec` on purpose: the
+/// scheduler hands out a raw pointer into a TCB and then drops its lock before
+/// switching, so a concurrent `spawn` reallocating the backing store would
+/// leave that pointer dangling.
+const MAX_THREADS: usize = 16;
+
+/// Per-thread kernel stack. Generous — these are debug-friendly, not tight.
+const STACK_SIZE: usize = 16 * 1024;
+
+/// Timer ticks a thread runs before being preempted. 100 Hz tick, so 2 ticks is
+/// a 20 ms slice.
+const TIME_SLICE_TICKS: u32 = 2;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum State {
+    Ready,
+    Running,
+    Finished,
+}
+
+pub struct Thread {
+    pub id: usize,
+    pub name: &'static str,
+    /// Saved stack pointer while this thread is not running.
+    rsp: u64,
+    /// Owning handle to the stack. `None` for the bootstrap thread, which runs
+    /// on the stack the boot trampoline set up.
+    _stack: Option<Box<[u8]>>,
+    state: State,
+    entry: Option<(fn(usize), usize)>,
+    /// Ticks this thread has been scheduled for — a cheap fairness check.
+    ticks: u64,
+}
+
+impl Thread {
+    /// Lay out a synthetic stack that [`kosh_switch_context`] can "resume" into
+    /// even though this thread has never run.
+    ///
+    /// The frame must mirror the pop sequence exactly. From low address to
+    /// high: RFLAGS, R15, R14, R13, R12, RBX, RBP, return address.
+    ///
+    /// The trailing dummy word exists for ABI alignment: after `ret` pops the
+    /// return address, RSP must be congruent to 8 mod 16, which is the state a
+    /// function sees immediately after a real `call`.
+    fn prepare_stack(stack: &mut [u8]) -> u64 {
+        let top = (stack.as_mut_ptr() as u64 + stack.len() as u64) & !0xF;
+
+        unsafe {
+            let put = |offset: u64, value: u64| {
+                core::ptr::write((top - offset) as *mut u64, value);
+            };
+
+            put(8, 0); // alignment dummy
+            put(16, thread_bootstrap as usize as u64); // return address
+            put(24, 0); // rbp
+            put(32, 0); // rbx
+            put(40, 0); // r12
+            put(48, 0); // r13
+            put(56, 0); // r14
+            put(64, 0); // r15
+
+            // RFLAGS with IF clear: a new thread is first entered from inside
+            // the timer interrupt handler, where interrupts are off. It enables
+            // them itself in `thread_bootstrap`, once it is on its own stack
+            // and no longer touching scheduler state.
+            put(72, 0x0000_0002);
+        }
+
+        top - 72
+    }
+}
+
+struct Scheduler {
+    threads: [Option<Thread>; MAX_THREADS],
+    current: usize,
+    slice_remaining: u32,
+    switches: u64,
+}
+
+impl Scheduler {
+    const fn new() -> Self {
+        Self {
+            threads: [const { None }; MAX_THREADS],
+            current: 0,
+            slice_remaining: TIME_SLICE_TICKS,
+            switches: 0,
+        }
+    }
+
+    /// Next runnable thread after `current`, wrapping. Plain round-robin.
+    fn next_runnable(&self) -> Option<usize> {
+        for step in 1..=MAX_THREADS {
+            let idx = (self.current + step) % MAX_THREADS;
+            if let Some(t) = &self.threads[idx] {
+                if t.state == State::Ready {
+                    return Some(idx);
+                }
+            }
+        }
+        None
+    }
+}
+
+static SCHEDULER: Mutex<Scheduler> = Mutex::new(Scheduler::new());
+static ENABLED: AtomicBool = AtomicBool::new(false);
+
+/// Register the currently-executing context as thread 0 and start scheduling.
+pub fn init() {
+    without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+        sched.threads[0] = Some(Thread {
+            id: 0,
+            name: "kmain",
+            rsp: 0, // filled in by the first switch away from here
+            _stack: None,
+            state: State::Running,
+            entry: None,
+            ticks: 0,
+        });
+        sched.current = 0;
+    });
+
+    serial_println!(
+        "Scheduler: round-robin over up to {} kernel threads, {} ms slice",
+        MAX_THREADS,
+        TIME_SLICE_TICKS * 10
+    );
+}
+
+/// Create a runnable kernel thread. It starts the next time the scheduler runs.
+pub fn spawn(name: &'static str, entry: fn(usize), arg: usize) -> Result<usize, &'static str> {
+    let mut stack = alloc::vec![0u8; STACK_SIZE].into_boxed_slice();
+    let rsp = Thread::prepare_stack(&mut stack);
+
+    without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+
+        let slot = sched
+            .threads
+            .iter()
+            .position(|t| t.is_none())
+            .ok_or("thread table full")?;
+
+        sched.threads[slot] = Some(Thread {
+            id: slot,
+            name,
+            rsp,
+            _stack: Some(stack),
+            state: State::Ready,
+            entry: Some((entry, arg)),
+            ticks: 0,
+        });
+
+        serial_println!("  spawned thread {} '{}' (stack top 0x{:x})", slot, name, rsp);
+        Ok(slot)
+    })
+}
+
+/// Begin preempting. Called once the demo threads exist.
+pub fn start() {
+    ENABLED.store(true, Ordering::SeqCst);
+}
+
+/// Called from the timer interrupt, after the EOI.
+///
+/// This is the wiring that did not exist: a periodic interrupt that actually
+/// reaches the scheduler.
+pub fn on_tick() {
+    if !ENABLED.load(Ordering::Relaxed) {
+        return;
+    }
+
+    let should_switch = {
+        let mut sched = SCHEDULER.lock();
+        let current = sched.current;
+        if let Some(t) = sched.threads[current].as_mut() {
+            t.ticks += 1;
+        }
+
+        if sched.slice_remaining > 1 {
+            sched.slice_remaining -= 1;
+            false
+        } else {
+            sched.slice_remaining = TIME_SLICE_TICKS;
+            true
+        }
+    };
+
+    if should_switch {
+        schedule();
+    }
+}
+
+/// Pick the next runnable thread and switch to it.
+///
+/// Safe to call from a thread as well as from the timer handler; it is a no-op
+/// if nothing else is runnable.
+pub fn schedule() {
+    // Interrupts must stay off from here until the switch completes: the lock
+    // is released before `kosh_switch_context`, and a tick arriving in that
+    // window would re-enter the scheduler with `current` already advanced.
+    let saved = crate::interrupts::interrupts_enabled();
+    x86_64::instructions::interrupts::disable();
+
+    let plan = {
+        let mut sched = SCHEDULER.lock();
+
+        match sched.next_runnable() {
+            None => None,
+            Some(next) => {
+                let current = sched.current;
+                if next == current {
+                    None
+                } else {
+                    if let Some(t) = sched.threads[current].as_mut() {
+                        if t.state == State::Running {
+                            t.state = State::Ready;
+                        }
+                    }
+                    if let Some(t) = sched.threads[next].as_mut() {
+                        t.state = State::Running;
+                    }
+
+                    sched.current = next;
+                    sched.switches += 1;
+
+                    let next_rsp = sched.threads[next].as_ref().unwrap().rsp;
+                    let prev_rsp = sched.threads[current].as_mut().unwrap().rsp_ptr();
+
+                    Some((prev_rsp, next_rsp))
+                }
+            }
+        }
+        // lock dropped here, before the switch
+    };
+
+    if let Some((prev_rsp, next_rsp)) = plan {
+        unsafe { kosh_switch_context(prev_rsp, next_rsp) };
+    }
+
+    if saved {
+        x86_64::instructions::interrupts::enable();
+    }
+}
+
+impl Thread {
+    fn rsp_ptr(&mut self) -> *mut u64 {
+        &mut self.rsp as *mut u64
+    }
+}
+
+/// First thing a new thread executes.
+///
+/// It reads its own entry point out of the thread table rather than having it
+/// passed in a register, which keeps the assembly in `switch.rs` down to the
+/// callee-saved set and nothing thread-specific.
+extern "C" fn thread_bootstrap() -> ! {
+    let entry = without_interrupts(|| {
+        let sched = SCHEDULER.lock();
+        sched.threads[sched.current].as_ref().and_then(|t| t.entry)
+    });
+
+    // We arrived here from inside the timer interrupt handler, so interrupts
+    // are still masked. Now that we are on our own stack and hold no locks, we
+    // can take part in preemption.
+    x86_64::instructions::interrupts::enable();
+
+    if let Some((func, arg)) = entry {
+        func(arg);
+    }
+
+    exit_current()
+}
+
+/// Retire the running thread and never come back.
+pub fn exit_current() -> ! {
+    without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+        let current = sched.current;
+        if let Some(t) = sched.threads[current].as_mut() {
+            t.state = State::Finished;
+        }
+    });
+
+    loop {
+        schedule();
+        // Only reachable if nothing else is runnable; wait for a tick that
+        // makes something else ready.
+        x86_64::instructions::hlt();
+    }
+}
+
+/// Yield the rest of this thread's slice.
+pub fn yield_now() {
+    schedule();
+}
+
+/// Number of threads not yet finished, excluding thread 0.
+pub fn live_threads() -> usize {
+    without_interrupts(|| {
+        SCHEDULER
+            .lock()
+            .threads
+            .iter()
+            .skip(1)
+            .filter(|t| matches!(t, Some(t) if t.state != State::Finished))
+            .count()
+    })
+}
+
+/// Total context switches performed.
+pub fn switch_count() -> u64 {
+    without_interrupts(|| SCHEDULER.lock().switches)
+}
+
+/// Free the stacks of finished threads.
+pub fn reap_finished() {
+    without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+        let current = sched.current;
+        for (i, slot) in sched.threads.iter_mut().enumerate() {
+            if i == current {
+                continue;
+            }
+            if matches!(slot, Some(t) if t.state == State::Finished) {
+                *slot = None;
+            }
+        }
+    });
+}
+
+pub fn print_threads() {
+    without_interrupts(|| {
+        let sched = SCHEDULER.lock();
+        serial_println!("Thread table:");
+        for slot in sched.threads.iter() {
+            if let Some(t) = slot {
+                serial_println!(
+                    "  [{}] {:<10} {:?}  {} ticks",
+                    t.id,
+                    t.name,
+                    t.state,
+                    t.ticks
+                );
+            }
+        }
+        serial_println!("  context switches: {}", sched.switches);
+    });
+}

--- a/kernel/src/task/switch.rs
+++ b/kernel/src/task/switch.rs
@@ -1,0 +1,72 @@
+//! The context switch itself.
+//!
+//! Written as a `global_asm!` symbol rather than inline `asm!` inside a Rust
+//! function, because a context switch has to control the stack precisely and a
+//! compiler-generated prologue would get in the way.
+//!
+//! ## Why this is a plain `extern "C"` call and not interrupt magic
+//!
+//! `kosh_switch_context` follows the System V AMD64 C ABI, so the *caller*
+//! has already spilled anything it cares about in caller-saved registers. All
+//! this function must preserve is the callee-saved set — RBX, RBP, R12-R15 —
+//! plus RFLAGS. It pushes those onto the outgoing thread's stack, records RSP
+//! in the outgoing TCB, loads RSP from the incoming TCB, pops the same set back
+//! and returns.
+//!
+//! The consequence is the part worth internalising: **the incoming thread
+//! resumes by returning out of its own earlier call to this function.** Thread B
+//! returns into B's `schedule()`, which returns into B's timer handler, whose
+//! `iretq` resumes whatever B was doing when it was preempted. Nothing has to
+//! reconstruct an interrupt frame, because B's frame never left B's stack.
+//!
+//! ## What the previous implementation did
+//!
+//! `process/context.rs` had `save_current_context` / `restore_context` with 18
+//! identical `in(reg) context` operands, saved `[rsp]` as the resume address,
+//! never touched segment selectors — and had zero callers. Its
+//! "context switching test" built two `CpuContext` structs, printed them, and
+//! asserted the fields it had just set. No switch ever happened.
+
+/// Save the current thread's callee-saved state, then resume `next_rsp`.
+///
+/// # Safety
+/// `prev_rsp` must point at the outgoing thread's saved-RSP slot, and
+/// `next_rsp` must be a stack prepared either by a previous call to this
+/// function or by [`super::Thread::prepare_stack`]. Interrupts must be
+/// disabled: the scheduler's lock is released before the switch, so a timer
+/// tick landing here would re-enter the scheduler with half-updated state.
+extern "C" {
+    pub fn kosh_switch_context(prev_rsp: *mut u64, next_rsp: u64);
+}
+
+core::arch::global_asm!(
+    r#"
+.section .text.kosh_switch, "ax"
+.global kosh_switch_context
+.type kosh_switch_context, @function
+
+kosh_switch_context:
+    /* rdi = &prev.rsp, rsi = next.rsp */
+
+    pushq   %rbp
+    pushq   %rbx
+    pushq   %r12
+    pushq   %r13
+    pushq   %r14
+    pushq   %r15
+    pushfq
+
+    movq    %rsp, (%rdi)        /* outgoing thread: remember where we parked */
+    movq    %rsi, %rsp          /* incoming thread: adopt its stack           */
+
+    popfq
+    popq    %r15
+    popq    %r14
+    popq    %r13
+    popq    %r12
+    popq    %rbx
+    popq    %rbp
+    ret
+"#,
+    options(att_syntax)
+);

--- a/kernel/src/user_program.rs
+++ b/kernel/src/user_program.rs
@@ -1,0 +1,122 @@
+//! A ring-3 payload, in assembly.
+//!
+//! Assembly rather than Rust for one reason: this blob is *linked* inside the
+//! kernel image at ~1 MiB but *runs* at `usermode::USER_CODE_BASE`. Every
+//! reference here is RIP-relative, so it does not care. Rust compiled with
+//! `-C code-model=kernel` would happily emit an absolute reference to a static
+//! and fault the moment it ran at the wrong address.
+//!
+//! It exercises three things:
+//!
+//! 1. A syscall that works — `write(1, ...)`.
+//! 2. A syscall that returns a value — `getpid()`.
+//! 3. A syscall the kernel must *refuse* — `write(1, <kernel address>, 16)`.
+//!    That last one is the interesting case: it proves the user-pointer
+//!    validation in `syscall::uaccess` actually rejects a hostile pointer,
+//!    tested from the user side rather than by the kernel checking itself.
+
+core::arch::global_asm!(
+    r#"
+.section .user, "ax"
+.balign 4096
+
+.global kosh_user_entry
+.type kosh_user_entry, @function
+
+kosh_user_entry:
+    /* write(1, hello, len) */
+    movq    $1, %rdi
+    leaq    msg_hello(%rip), %rsi
+    movq    $msg_hello_len, %rdx
+    movq    $23, %rax                   /* SYS_WRITE */
+    syscall
+
+    /* getpid() */
+    movq    $5, %rax                    /* SYS_GETPID */
+    syscall
+    movq    %rax, %r12                  /* keep it; callee-saved across syscall */
+
+    /* write(1, <physmap base>, 16) -- the kernel must refuse this. */
+    movq    $1, %rdi
+    movabsq $0xFFFF800000000000, %rsi
+    movq    $16, %rdx
+    movq    $23, %rax
+    syscall
+
+    /* Linux convention: errors come back as a negative value. */
+    testq   %rax, %rax
+    jns     .Lnot_rejected
+
+    movq    $1, %rdi
+    leaq    msg_rejected(%rip), %rsi
+    movq    $msg_rejected_len, %rdx
+    movq    $23, %rax
+    syscall
+    jmp     .Ldone
+
+.Lnot_rejected:
+    movq    $1, %rdi
+    leaq    msg_leaked(%rip), %rsi
+    movq    $msg_leaked_len, %rdx
+    movq    $23, %rax
+    syscall
+
+.Ldone:
+    /* exit(0) */
+    xorq    %rdi, %rdi
+    movq    $1, %rax                    /* SYS_EXIT */
+    syscall
+
+    /* exit does not return. If it somehow does, spin rather than run off the
+       end of the mapping. */
+.Lhang:
+    jmp     .Lhang
+
+/* A second payload: touch kernel memory directly, with no syscall involved.
+   Page protection — not argument validation — has to stop this one. The kernel
+   must kill the process and carry on. */
+.global kosh_user_fault_entry
+.type kosh_user_fault_entry, @function
+kosh_user_fault_entry:
+    movq    $1, %rdi
+    leaq    msg_faulting(%rip), %rsi
+    movq    $msg_faulting_len, %rdx
+    movq    $23, %rax
+    syscall
+
+    movabsq $0xFFFF800000000000, %rax
+    movq    (%rax), %rbx                /* #PF: kernel page, no USER bit */
+
+    /* Never reached. */
+    movq    $1, %rdi
+    leaq    msg_survived(%rip), %rsi
+    movq    $msg_survived_len, %rdx
+    movq    $23, %rax
+    syscall
+.Lfault_hang:
+    jmp     .Lfault_hang
+
+msg_faulting:
+    .ascii  "about to dereference a kernel address directly\n"
+    .set    msg_faulting_len, . - msg_faulting
+
+msg_survived:
+    .ascii  "WARNING: ring 3 read kernel memory without faulting\n"
+    .set    msg_survived_len, . - msg_survived
+
+msg_hello:
+    .ascii  "hello from ring 3\n"
+    .set    msg_hello_len, . - msg_hello
+
+msg_rejected:
+    .ascii  "kernel rejected my out-of-bounds pointer\n"
+    .set    msg_rejected_len, . - msg_rejected
+
+msg_leaked:
+    .ascii  "WARNING: kernel accepted a kernel-half pointer from ring 3\n"
+    .set    msg_leaked_len, . - msg_leaked
+
+.balign 4096
+"#,
+    options(att_syntax)
+);

--- a/kernel/src/usermode.rs
+++ b/kernel/src/usermode.rs
@@ -1,0 +1,158 @@
+//! Ring 3.
+//!
+//! `iretq`, `sysretq`, `swapgs` and `user_code_segment` had zero occurrences in
+//! this repository before Phase 5. For a microkernel — an architecture whose
+//! entire premise is that services run *outside* the kernel — that was the
+//! single biggest gap in the project.
+//!
+//! ## Getting to ring 3
+//!
+//! There is no "jump to user mode" instruction. You fake a return from one:
+//! push the five words `iretq` expects (SS, RSP, RFLAGS, CS, RIP) with ring-3
+//! selectors, and execute it. The CPU cannot tell the difference between that
+//! and returning from a genuine interrupt.
+//!
+//! ## The payload
+//!
+//! `user_program.rs` assembles a small position-independent blob into its own
+//! `.user` linker section. Phase 5 maps that section's existing frames at a
+//! user virtual address rather than allocating and copying — the copying
+//! version is an ELF loader, which is Phase 6. The blob is written in assembly
+//! with every reference RIP-relative, so it runs correctly at an address it was
+//! not linked for.
+
+use x86_64::structures::paging::PageTableFlags;
+
+use crate::memory::paging;
+use crate::memory::PAGE_SIZE;
+use crate::serial_println;
+
+/// Where the user blob is mapped. 1 GiB — clear of the kernel's low identity
+/// window and nowhere near the higher half.
+pub const USER_CODE_BASE: u64 = 0x0000_0000_4000_0000;
+
+/// Top of the user stack, growing down.
+pub const USER_STACK_TOP: u64 = 0x0000_0000_5000_0000;
+
+/// Pages of user stack.
+const USER_STACK_PAGES: usize = 4;
+
+extern "C" {
+    static __user_start: u8;
+    static __user_end: u8;
+    fn kosh_user_entry();
+    fn kosh_user_fault_entry();
+}
+
+/// Which payload to run.
+#[derive(Debug, Clone, Copy)]
+pub enum Demo {
+    /// Syscalls, including one the kernel must refuse.
+    Syscalls,
+    /// Dereference a kernel address directly — must be killed, not survived.
+    Fault,
+}
+
+static CODE_MAPPED: core::sync::atomic::AtomicBool =
+    core::sync::atomic::AtomicBool::new(false);
+
+fn sym(s: &u8) -> u64 {
+    s as *const u8 as u64
+}
+
+/// Map the user blob and its stack, then drop to ring 3.
+///
+/// Runs as a kernel thread, so `sys_exit` can retire it through
+/// `task::exit_current()` and hand control back to the rest of the kernel —
+/// no unwinding required.
+pub fn run_user_demo(which: usize) {
+    use core::sync::atomic::Ordering;
+
+    let demo = if which == 0 { Demo::Syscalls } else { Demo::Fault };
+
+    let blob_start = sym(unsafe { &__user_start });
+    let blob_end = sym(unsafe { &__user_end });
+    let blob_pages = ((blob_end - blob_start) as usize).div_ceil(PAGE_SIZE).max(1);
+
+    // Offset of the entry point within the section, so we can find it again at
+    // the address the blob is actually mapped to.
+    let entry_fn = match demo {
+        Demo::Syscalls => kosh_user_entry as usize as u64,
+        Demo::Fault => kosh_user_fault_entry as usize as u64,
+    };
+    let user_entry = USER_CODE_BASE + (entry_fn - blob_start);
+
+    serial_println!("Preparing ring 3 ({:?}):", demo);
+
+    // Read + execute for the user, and NOT writable — W^X applies to userspace
+    // too.
+    let code_flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+    if !CODE_MAPPED.swap(true, Ordering::SeqCst) {
+        serial_println!(
+            "  .user section  : 0x{:x}..0x{:x} ({} page(s))",
+            blob_start,
+            blob_end,
+            blob_pages
+        );
+        if let Err(e) = paging::map_user_range(USER_CODE_BASE, blob_start, blob_pages, code_flags) {
+            serial_println!("  failed to map user code: {}", e);
+            return;
+        }
+        serial_println!("  code mapped at : 0x{:x} (R-X, user)", USER_CODE_BASE);
+    }
+    serial_println!("  entry          : 0x{:x}", user_entry);
+
+    // Each run gets its own stack region so the second demo cannot observe the
+    // first one's leftovers.
+    let stack_top = USER_STACK_TOP - (which as u64 * 0x10_0000);
+    let stack_bottom = stack_top - (USER_STACK_PAGES * PAGE_SIZE) as u64;
+    let stack_flags = PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE;
+    if let Err(e) = paging::map_user_pages(stack_bottom, USER_STACK_PAGES, stack_flags) {
+        serial_println!("  failed to map user stack: {}", e);
+        return;
+    }
+    serial_println!(
+        "  stack          : 0x{:x}..0x{:x} (RW-, user, NX)",
+        stack_bottom,
+        stack_top
+    );
+
+    serial_println!("Entering ring 3 via iretq...");
+    serial_println!("--- ring 3 output ---");
+
+    unsafe { enter_ring3(user_entry, stack_top) }
+}
+
+/// Drop to ring 3 at `entry` with `stack_top`.
+///
+/// # Safety
+/// `entry` and `stack_top` must be mapped `USER_ACCESSIBLE`, and the GDT must
+/// carry ring-3 code and data descriptors.
+unsafe fn enter_ring3(entry: u64, stack_top: u64) -> ! {
+    let sel = crate::gdt::selectors();
+    let user_cs = (sel.user_code.0 | 3) as u64;
+    let user_ss = (sel.user_data.0 | 3) as u64;
+
+    // Reserved bit 1 is always set; IF on so the timer can still preempt the
+    // user program. A ring-3 thread that cannot be preempted is a ring-3 thread
+    // that can hang the machine with `for {}`.
+    let rflags: u64 = 0x202;
+
+    core::arch::asm!(
+        "push {ss}",
+        "push {rsp}",
+        "push {rflags}",
+        "push {cs}",
+        "push {rip}",
+        "iretq",
+        ss = in(reg) user_ss,
+        rsp = in(reg) stack_top,
+        rflags = in(reg) rflags,
+        cs = in(reg) user_cs,
+        rip = in(reg) entry,
+        options(noreturn)
+    )
+}

--- a/kernel/src/vga_buffer.rs
+++ b/kernel/src/vga_buffer.rs
@@ -138,5 +138,14 @@ macro_rules! println {
 #[doc(hidden)]
 pub fn _print(args: fmt::Arguments) {
     use core::fmt::Write;
+
+    // See serial::_print — holding this lock across a preemption deadlocks the
+    // next thread that prints.
+    #[cfg(target_arch = "x86_64")]
+    x86_64::instructions::interrupts::without_interrupts(|| {
+        WRITER.lock().write_fmt(args).unwrap();
+    });
+
+    #[cfg(not(target_arch = "x86_64"))]
     WRITER.lock().write_fmt(args).unwrap();
 }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -134,6 +134,10 @@ check)
         "PIC remapped" \
         "PIT channel 0" \
         "Interrupts enabled" \
+        "kernel page tables active" \
+        "physmap aliases identity map: OK" \
+        "page 0 unmapped: OK" \
+        "PASS: heap fully reclaimed" \
         "Kernel initialization complete" \
         "uptime 1s"
     do

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -138,6 +138,7 @@ check)
         "physmap aliases identity map: OK" \
         "page 0 unmapped: OK" \
         "PASS: heap fully reclaimed" \
+        "Scheduler: PASS" \
         "Kernel initialization complete" \
         "uptime 1s"
     do

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -117,11 +117,11 @@ check)
     SERIAL="$BUILD_DIR/serial.txt"
     rm -f "$SERIAL"
     echo "==> boot check"
-    timeout 30 qemu-system-x86_64 "${QEMU_ARGS[@]}" \
+    timeout 20 qemu-system-x86_64 "${QEMU_ARGS[@]}" \
         -serial "file:$SERIAL" -display none >/dev/null 2>&1 || true
 
-    echo "--- serial output ---"
-    cat "$SERIAL" || true
+    echo "--- serial output (last 30 lines) ---"
+    tail -30 "$SERIAL" || true
     echo "---------------------"
 
     fail=0
@@ -129,7 +129,13 @@ check)
         "32-bit protected mode entry OK" \
         "long mode OK" \
         "Kosh Kernel Starting" \
-        "Kernel initialization complete"
+        "IDT installed" \
+        "returned from int3 handler" \
+        "PIC remapped" \
+        "PIT channel 0" \
+        "Interrupts enabled" \
+        "Kernel initialization complete" \
+        "uptime 1s"
     do
         if grep -qF "$marker" "$SERIAL" 2>/dev/null; then
             echo "  PASS  $marker"

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -139,6 +139,11 @@ check)
         "page 0 unmapped: OK" \
         "PASS: heap fully reclaimed" \
         "Scheduler: PASS" \
+        "hello from ring 3" \
+        "kernel rejected my out-of-bounds pointer" \
+        "ring 3 fault — terminating the process" \
+        "Ring 3: PASS" \
+        "kernel survived a ring 3 fault" \
         "Kernel initialization complete" \
         "uptime 1s"
     do

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+#
+# Kosh: build -> ISO -> QEMU, in one command.
+#
+#   ./scripts/run.sh              build, make an ISO, boot it, stream serial
+#   ./scripts/run.sh --debug      same, plus wait for gdb on :1234
+#   ./scripts/run.sh --check      boot headless and assert the boot markers
+#                                 appear on serial (this is the CI gate)
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+TARGET_JSON="x86_64-kosh.json"
+TARGET_NAME="x86_64-kosh"
+PROFILE="${PROFILE:-release}"
+BUILD_DIR="$ROOT/build"
+ISO_DIR="$BUILD_DIR/iso"
+ISO="$BUILD_DIR/kosh.iso"
+
+MODE="run"
+case "${1:-}" in
+    --debug) MODE="debug" ;;
+    --check) MODE="check" ;;
+    "")      ;;
+    *)       echo "unknown option: $1" >&2; exit 2 ;;
+esac
+
+# --- toolchain sanity -------------------------------------------------------
+
+need() {
+    command -v "$1" >/dev/null 2>&1 || { echo "error: '$1' not found. $2" >&2; exit 1; }
+}
+need cargo       "Install Rust: https://rustup.rs"
+need grub-mkrescue "Install GRUB tools (macOS: brew install i686-elf-grub xorriso)"
+need xorriso     "Install xorriso (macOS: brew install xorriso)"
+need qemu-system-x86_64 "Install QEMU (macOS: brew install qemu)"
+
+# --- build ------------------------------------------------------------------
+
+echo "==> building kernel ($PROFILE)"
+CARGO_FLAGS=(--package kosh-kernel --target "$TARGET_JSON" -Z build-std=core,alloc)
+[ "$PROFILE" = "release" ] && CARGO_FLAGS+=(--release)
+
+# Nightlies from mid-2025 onwards gate .json target specs behind an unstable
+# flag. Older ones reject the flag itself, so probe once and remember.
+if cargo build "${CARGO_FLAGS[@]}" -Z json-target-spec --quiet 2>/dev/null; then
+    :
+else
+    cargo build "${CARGO_FLAGS[@]}" -Z json-target-spec 2>&1 | tail -40
+    # If the failure was purely "unknown -Z flag", retry without it.
+    if cargo build "${CARGO_FLAGS[@]}" -Z json-target-spec 2>&1 | grep -q "unknown.*json-target-spec"; then
+        cargo build "${CARGO_FLAGS[@]}"
+    fi
+fi
+
+KERNEL="$ROOT/target/$TARGET_NAME/$PROFILE/kosh-kernel"
+[ -f "$KERNEL" ] || { echo "error: kernel binary not found at $KERNEL" >&2; exit 1; }
+
+# --- validate the multiboot2 header before we waste a boot ------------------
+
+if grub-file --is-x86-multiboot2 "$KERNEL"; then
+    echo "==> multiboot2 header OK"
+else
+    echo "error: kernel is not multiboot2-compliant" >&2
+    exit 1
+fi
+
+ENTRY=$(readelf -h "$KERNEL" 2>/dev/null | awk '/Entry point/ {print $4}')
+echo "==> entry point: $ENTRY"
+
+# --- ISO --------------------------------------------------------------------
+
+echo "==> building ISO"
+rm -rf "$ISO_DIR"
+mkdir -p "$ISO_DIR/boot/grub"
+cp "$KERNEL" "$ISO_DIR/boot/kosh-kernel"
+
+cat > "$ISO_DIR/boot/grub/grub.cfg" <<'EOF'
+set timeout=0
+set default=0
+
+menuentry "Kosh" {
+    multiboot2 /boot/kosh-kernel
+    boot
+}
+EOF
+
+grub-mkrescue -o "$ISO" "$ISO_DIR" >/dev/null 2>&1
+echo "==> $ISO ($(du -h "$ISO" | cut -f1))"
+
+# --- run --------------------------------------------------------------------
+
+QEMU_ARGS=(
+    -cdrom "$ISO"
+    -m 512M
+    -no-reboot
+    -no-shutdown
+    -device isa-debug-exit,iobase=0xf4,iosize=0x04
+    -d int,cpu_reset
+    -D "$BUILD_DIR/qemu.log"
+)
+
+case "$MODE" in
+run)
+    echo "==> booting (ctrl-a x to quit)"
+    exec qemu-system-x86_64 "${QEMU_ARGS[@]}" -serial mon:stdio -display none
+    ;;
+
+debug)
+    echo "==> booting, gdb stub on localhost:1234 (target remote :1234)"
+    exec qemu-system-x86_64 "${QEMU_ARGS[@]}" -serial mon:stdio -display none -s -S
+    ;;
+
+check)
+    SERIAL="$BUILD_DIR/serial.txt"
+    rm -f "$SERIAL"
+    echo "==> boot check"
+    timeout 30 qemu-system-x86_64 "${QEMU_ARGS[@]}" \
+        -serial "file:$SERIAL" -display none >/dev/null 2>&1 || true
+
+    echo "--- serial output ---"
+    cat "$SERIAL" || true
+    echo "---------------------"
+
+    fail=0
+    for marker in \
+        "32-bit protected mode entry OK" \
+        "long mode OK" \
+        "Kosh Kernel Starting" \
+        "Kernel initialization complete"
+    do
+        if grep -qF "$marker" "$SERIAL" 2>/dev/null; then
+            echo "  PASS  $marker"
+        else
+            echo "  FAIL  $marker"
+            fail=1
+        fi
+    done
+
+    if grep -q "Triple fault" "$BUILD_DIR/qemu.log" 2>/dev/null; then
+        echo "  FAIL  triple fault in qemu.log"
+        fail=1
+    fi
+
+    exit $fail
+    ;;
+esac

--- a/x86_64-kosh.json
+++ b/x86_64-kosh.json
@@ -3,7 +3,7 @@
   "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
   "arch": "x86_64",
   "target-endian": "little",
-  "target-pointer-width": "64",
+  "target-pointer-width": 64,
   "target-c-int-width": 32,
   "os": "none",
   "executables": true,
@@ -12,5 +12,9 @@
   "panic-strategy": "abort",
   "disable-redzone": true,
   "features": "-mmx",
-  "code-model": "kernel"
+  "code-model": "kernel",
+  "relocation-model": "static",
+  "position-independent-executables": false,
+  "static-position-independent-executables": false,
+  "dynamic-linking": false
 }


### PR DESCRIPTION
## Summary

The kernel has never executed a single instruction.

Multiboot2 hands control to the kernel in **32-bit protected mode with paging disabled**. `_start` is compiled 64-bit, and there was no trampoline anywhere in the tree — so the CPU decoded 64-bit opcodes as 32-bit instructions and wandered into an infinite loop inside serial init. Verified under QEMU: 16 seconds after boot, `EIP=0010dbd2` (inside `_start`), `CS32`, `EFER.LME` clear, no serial or VGA output at all.

Everything downstream of that — the frame allocator, the heap, the process table, the scheduler, the IPC queues, the syscall dispatcher — had therefore never run. This PR closes that gap and then builds up through interrupts, real page tables, preemptive scheduling and ring 3.

Five commits, one per layer, each independently verified in QEMU.

## What now works

```
[boot] 32-bit protected mode entry OK
[boot] long mode OK, entering Rust
...
IDT installed (20 exception vectors, 16 IRQ vectors)
[#BP breakpoint at 0x10b8af] — resuming
  PIC remapped: IRQ0..7 -> vectors 32..39
  PIT channel 0: divisor 11931 -> 100 Hz
  CR3 -> 0x157000 (kernel page tables active)
  physmap aliases identity map: OK
  page 0 unmapped: OK (null dereferences will fault)
  PASS: heap fully reclaimed, coalesced to a single free block
  A B C A B C A B C A B C A B C A B C A B C A B C
Scheduler: PASS — 36 real context switches
--- ring 3 output ---
hello from ring 3
kernel rejected my out-of-bounds pointer
--- kernel survived a ring 3 fault ---
```

`./scripts/run.sh --check` asserts 20 markers on the serial console and is wired to CI in `.github/workflows/boot.yml`. Zero triple faults.

## Commits

| Commit | What it does |
|---|---|
| `kernel: enter 64-bit long mode…` | 32-bit Multiboot2 trampoline; one-command build→ISO→QEMU loop; CI boot gate |
| `kernel: IDT, PIC remap, PIT timer…` | Exception handlers, 8259 remap, 100 Hz tick, real PS/2 keyboard input |
| `kernel: build and install our own page tables…` | W^X kernel mappings, physmap, heap on real virtual memory, allocator fixes |
| `kernel: preemptive kernel threads…` | Real context switch, timer-driven round-robin |
| `kernel: ring 3, SYSCALL/SYSRET…` | User descriptors, syscall MSRs, `copy_from_user`, ring-3 payloads |

## Bugs found along the way

Most of these were only findable by running the thing.

- **`used_frames` underflow** — the bitmap is filled `0xFF` (every frame used) but the counter started at `0`, so the first `mark_frame_free` underflowed. Release builds wrapped to `~u64::MAX` and every memory statistic was garbage.
- **The allocator would have overwritten the kernel** — the kernel image was never excluded from the free list, so the first `allocate_frames` for the heap would have returned the frames the kernel was executing from, and then zeroed them.
- **Heap init ran after VMM init** — which allocates. That is a `Vec::push` against a null heap on every boot.
- **A spinlock deadlock in the heap self-test** — `match KERNEL_HEAP.lock().allocate(..) { .. ptrs.push(..) }` holds the lock across a `Vec` growth that re-enters the global allocator, because match-scrutinee temporaries live until the end of the match. This hung the boot.
- **No null guard** — the first version of the trampoline identity-mapped the first 2 MiB as one huge page, so a deliberate `read_volatile(0)` succeeded. The first 2 MiB now uses 4 KiB pages with page 0 unmapped.
- **W^X was decorative without `CR0.WP`** — read-only page permissions do not apply to ring 0 unless it is set. A deliberate write to `.text` succeeded until it was.
- **`EFER.NXE`** — without it the NX bit is *reserved*, so every NX mapping becomes a reserved-bit fault rather than a protection.
- **The heap ignored `layout.align()`** — it aligned to `PAGE_SIZE` regardless of the request, then returned the *unaligned* pointer anyway. It both over-rejected and under-delivered. Fixing it also required making every block base 16-aligned, or payloads drift onto odd offsets and even 8-byte alignment fails after the first split.
- **`coalesce_free_blocks` was an empty function** with a comment describing what it would do, so the heap fragmented monotonically.
- **Double-negated errno** — `SyscallError::to_errno()` already returns negative numbers, so negating it in the syscall handler (the obvious thing, given the Linux convention) flipped every failure positive and userspace read errors as success.
- **The PIC remap is not cosmetic** — unremapped, IRQ0 arrives as vector 8, which *is* `#DF`, so the first timer tick after `sti` looks like a double fault.
- **`serial.rs:22`** — trailing semicolon in an expression-position macro, now a hard error on current nightly.
- **`build.rs`** emitted a linker-script path relative to the *linker's* cwd, so building from inside `kernel/` silently dropped the script and the multiboot2 header with it.
- **`linker.ld`** used `*(.text)` rather than `*(.text.*)`, so with function-sections every real section was orphan-placed by LLD, not by the script. It linked by luck.

## Design notes

**The context switch is a plain `extern "C"` call, not interrupt machinery.** It follows the System V ABI, so the caller has already spilled its caller-saved registers and the function only preserves RBX, RBP, R12–R15 and RFLAGS. The consequence worth internalising: *the incoming thread resumes by returning out of its own earlier call to this function.* B returns into B's `schedule()`, into B's timer handler, whose `iretq` resumes B. Nothing reconstructs an interrupt frame, because B's frame never left B's stack.

**The GDT order is load-bearing.** `sysret` computes CS as `STAR[63:48] + 16` and SS as `+ 8`, so the table must read kernel code, kernel data, **user data**, **user code**. User data before user code reads backwards until you write out the arithmetic.

**Three locking rules, each a hang if broken:** all scheduler access with interrupts disabled (the timer handler takes the same lock); drop the lock *before* switching (a spinlock held across a context switch is parked in a thread that is no longer running); EOI before scheduling (`on_tick` may not return to the handler for a long time). `serial::_print` and `vga_buffer::_print` now hold their port locks with interrupts disabled for the same reason.

**A userspace fault must not be fatal.** The page-fault handler checks `USER_MODE` and terminates the offending thread rather than halting. Any other behaviour means a userspace bug takes the whole system down, which is the thing a microkernel exists to prevent.

## How the ring-3 work is verified

Two payloads run back to back, because two different mechanisms need proving:

1. The first prints `hello from ring 3`, then asks the kernel to `write` from a physmap address and **reports back whether it was refused**. The pointer validation is tested from the *user* side, not by the kernel grading its own homework. Then it exits cleanly through `sys_exit`.
2. The second bypasses syscalls entirely and dereferences kernel memory directly, so page protection rather than argument validation has to stop it. It is killed by `#PF` and the kernel carries on.

## Deliberately not in this PR

- No ELF loader and no initrd — `init` is still not loaded from disk. That is the next step, via a GRUB `module2` entry.
- `process/scheduler.rs` is kept but documented as policy-only and unwired. `task` covers kernel threads in ring 0; `process` is meant to govern userspace processes, which arrive with the loader.
- Swap and power management are disabled in `init_kernel`. Both are entirely simulated, and swap tried to allocate 8 MiB from a 1 MiB heap.
- The userspace shell is untouched. Its input is still a hardcoded array and most commands return canned strings.

## Notes for review

- `docs/BOOT.md` documents the whole chain — boot, interrupts, paging, scheduling, ring 3 — including the flags and orderings that are easy to get wrong.
- Recent nightlies need `-Z json-target-spec` for `.json` target specs, and `x86_64-kosh.json` needed `"target-pointer-width"` as a number rather than a string.
- Suggested change to how this project tracks work: a task should not be `[x]` until it is observable in QEMU. Building is not evidence. Relatedly, there are still no `unimplemented!()` or `todo!()` calls anywhere in the repo — every stub returns `Ok(())` or a fabricated value, which is what made the project look far more finished than it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1GdpYMiKP5Gj1Jmub59gw
