### PR TITLE
ELF loader and an interactive console

### DIFF
--- a/.github/workflows/boot.yml
+++ b/.github/workflows/boot.yml
@@ -47,6 +47,12 @@ jobs:
       - name: Build, boot and assert serial markers
         run: ./scripts/run.sh --check
 
+      - name: Drive the console and assert what it answers
+        # Types at the kosh> prompt through QEMU's monitor. Without this the
+        # keyboard IRQ, the line editor and the command table are only ever
+        # exercised by a human, which means they rot quietly.
+        run: ./scripts/run.sh --check-cli
+
       - name: Upload boot logs on failure
         if: failure()
         uses: actions/upload-artifact@v4
@@ -54,4 +60,5 @@ jobs:
           name: boot-logs
           path: |
             build/serial.txt
+            build/serial-cli.txt
             build/qemu.log

--- a/.github/workflows/boot.yml
+++ b/.github/workflows/boot.yml
@@ -20,6 +20,15 @@ jobs:
         with:
           components: rust-src, llvm-tools-preview
 
+      - name: Record the toolchain in use
+        # Nightly floats, so record what this run actually used. If the build
+        # breaks later from an upstream change, pin rust-toolchain.toml to the
+        # date printed by the last green run.
+        run: |
+          echo "toolchain in use:"
+          rustc --version --verbose
+          cargo --version
+
       - name: Install GRUB and QEMU
         run: |
           sudo apt-get update -qq

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "drivers/graphics",
     "drivers/keyboard",
     "userspace/init",
+    "userspace/hello",
     "userspace/fs-service",
     "userspace/driver-manager",
     "userspace/shell",

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -409,10 +409,108 @@ by the kernel checking itself. The second bypasses syscalls entirely and touches
 kernel memory directly, so page protection rather than argument validation has
 to stop it.
 
+## Loading programs (Phase 6)
+
+`kernel/src/elf.rs` parses static `ET_EXEC` ELF64: walk the program headers, map
+each `PT_LOAD` at its `p_vaddr` with permissions from `p_flags`, copy
+`p_filesz` bytes, leave the rest zero. No dynamic linking, no relocations, no
+interpreter.
+
+Segments are populated **through the physmap**, not through the mapping being
+created — so a read-only segment never has to be temporarily writable just to be
+filled in. `map_user_pages` already zeroes each frame, which makes the `.bss`
+tail (`p_memsz > p_filesz`) correct without extra work.
+
+Two things about GRUB modules that are easy to get wrong:
+
+- **The frames must be reserved before the allocator starts.** The memory map
+  reports them as available, because from the firmware's point of view they are.
+  `physical.rs` claims them, or the first allocation lands on top of the binary.
+- **A module can land outside the low identity window**, so its bytes are read
+  through the physmap rather than by physical address.
+
+`userspace/hello` is the payload — an ordinary Rust binary linked at 4 MiB, not
+position-independent assembly. It only runs if the loader honoured `p_vaddr`,
+and it self-checks the three things the loader must get right: executing at the
+linked address, resolving `.rodata` through absolute addresses, and reading a
+`.bss` static that exists only because the loader zeroed the tail.
+
+**Its `_start` is assembly, exactly like a real crt0.** System V says RSP is
+16-byte aligned at process entry, but a Rust `extern "C"` function is compiled
+as an ordinary callee and assumes RSP is 8 *past* a boundary — the state a
+`call` leaves. Wiring Rust straight to the entry point makes the first `movaps`
+spill fault with #GP. That is what happened on the first run, and the symptom
+(a #GP deep inside integer formatting) points nowhere near the cause.
+
+## The console (Phase 7)
+
+`kernel/src/console/` is an in-kernel shell: `editor.rs` does line editing and
+history, `commands.rs` is the command table.
+
+```
+kosh> uname
+Kosh 0.1.0 x86_64
+  microkernel, Rust, multiboot2
+  running in ring 0
+  CR3            0x176000
+  physmap base   0xffff800000000000
+kosh> ps
+2 thread(s):
+   id  name         state        ticks
+    0  kmain        ready          642
+    1  console      running        616
+
+661 context switches since boot
+```
+
+**Why in-kernel, in a microkernel.** Because a kernel you can interrogate while
+it is running is worth more than architectural purity at this stage. Every
+command reports live state — real frame counts, real heap statistics, the real
+thread table, a real page-table walk. That makes it a debugging instrument, and
+it is why serious kernels keep a debug console permanently even after userspace
+exists. The userspace shell is still the goal; it needs a blocking read syscall
+and a filesystem to be worth using, and this is what lets you inspect the kernel
+while building those.
+
+**What it deliberately does not have:** `ls`, `cat`, `cd`. There is no
+filesystem, and inventing commands that return plausible-looking strings is
+exactly the habit that let this project accumulate 27 commits of code that had
+never run.
+
+The console runs on **its own kernel thread**, so the scheduler stays live while
+it blocks on the keyboard — timer ticks keep arriving, other threads keep
+running, and a wedged console does not wedge the machine.
+
+Two things it changed elsewhere:
+
+- The keyboard ring now carries a `Key` enum rather than a byte. A line editor
+  has to tell an arrow key from the character it would otherwise be conflated
+  with; squeezing cursor keys into spare ASCII control codes works right up
+  until something wants to type one of those codes.
+- The once-a-second tick heartbeat is now off by default once the console
+  starts. A line that appears in the middle of what you are typing makes the
+  console unusable. `heartbeat on` brings it back.
+
+### Testing it
+
+```bash
+./scripts/run.sh --check-cli
+```
+
+Boots, types at the `kosh>` prompt through QEMU's monitor, and asserts what the
+console answers. Both checks run in CI. A console only a human can test is a
+console that rots quietly.
+
 ## What is deliberately still missing
-- **`PHYSICAL_MEMORY_OFFSET` is 0**, because the map is flat identity. It
-  becomes `0xFFFF_8000_0000_0000` when the kernel builds its own page tables in
-  Phase 3.
+- **No filesystem, and no storage driver.** Which is why there is no `ls`.
+- **No `fork`/`exec`.** `userspace/init` cannot do its job until those exist, so
+  the ELF payload is `userspace/hello` rather than init.
+- **One address space.** Loaded programs share the kernel's page tables; they
+  are protected by page permissions, not by separation. Per-process address
+  spaces come with `fork`.
+- **One ring-3 thread at a time.** The syscall path uses a single static kernel
+  stack, which is only safe because `SFMASK` masks IF and nothing else is in
+  user mode. Several user threads need `swapgs` and per-CPU data.
 - **Swap and power management are disabled** in `init_kernel`. Both were
   simulated, and swap tried to allocate 8 MiB from a 1 MiB heap.
 - **Only IRQ0 and IRQ1 are unmasked.** Everything else on the PIC has a

--- a/kernel/Cargo.toml
+++ b/kernel/Cargo.toml
@@ -14,7 +14,24 @@ lazy_static = { version = "1.4", features = ["spin_no_std"] }
 
 [target.'cfg(target_arch = "x86_64")'.dependencies]
 multiboot2 = "0.24"
-x86_64 = "0.14"
+# default-features = false drops the crate's `nightly` feature, which pulls in
+# `step_trait`. x86_64 0.14.13 implements `Step` for VirtAddr and Page, and
+# nightly has since added two required methods to that trait
+# (`forward_overflowing` / `backward_overflowing`) — so the crate stops
+# compiling on newer nightlies through no fault of ours.
+#
+# We never iterate Page or VirtAddr ranges, so nothing here needs `Step`.
+#
+# Of the three features `nightly` bundles, we re-list the two we actually use.
+# `const_fn` is deliberately left off: nothing here needs the const
+# constructors, and it gates `feature(const_mut_refs)` — one more unstable
+# dependency that can rot the same way.
+#   instructions      — hlt, port I/O, segmentation, interrupt control
+#   abi_x86_interrupt — required by InterruptDescriptorTable::set_handler_fn
+x86_64 = { version = "0.14", default-features = false, features = [
+    "instructions",
+    "abi_x86_interrupt",
+] }
 uart_16550 = "0.3"
 pic8259 = "0.11"
 pc-keyboard = "0.7"
@@ -34,10 +51,6 @@ path = "src/lib.rs"
 
 [build-dependencies]
 cc = "1.0"
-
-# Test configuration
-[profile.test]
-panic = "abort"
 
 # Custom test harness configuration
 [[test]]

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -29,6 +29,11 @@ pub fn init_kernel(boot_info: BootInformation) {
     // Parse and display memory information
     parse_memory_map(&boot_info);
     
+    // Record where GRUB put the boot modules. `boot_info` borrows the
+    // multiboot2 structure and does not outlive this function, so the addresses
+    // are copied out now and read through the physmap later.
+    crate::usermode::record_boot_modules(&boot_info);
+    
     // Initialize physical memory manager
     init_physical_memory(&boot_info);
     
@@ -716,6 +721,35 @@ fn init_usermode() {
         serial_println!("Ring 3: PASS — {} syscalls serviced from user mode", serviced);
     } else {
         serial_println!("Ring 3: FAIL — only {} syscalls serviced", serviced);
+    }
+
+    // Demo 3: an ELF the kernel was not compiled with, loaded from a GRUB
+    // module. Reported separately, because it exercises the loader rather than
+    // the ring-3 mechanics above.
+    serial_println!();
+    let before_elf = crate::syscall::entry::syscall_count();
+
+    if let Err(e) = crate::task::spawn("elf-loader", crate::usermode::run_boot_module, 0) {
+        serial_println!("Failed to spawn ELF loader thread: {}", e);
+        return;
+    }
+    while crate::task::live_threads() > 0 {
+        x86_64::instructions::hlt();
+    }
+    serial_println!("--- back in ring 0 ---");
+    crate::task::reap_finished();
+
+    let elf_syscalls = crate::syscall::entry::syscall_count() - before_elf;
+    if elf_syscalls >= 5 {
+        serial_println!(
+            "ELF loader: PASS — loaded program ran and made {} syscalls",
+            elf_syscalls
+        );
+    } else {
+        serial_println!(
+            "ELF loader: FAIL — loaded program made only {} syscalls",
+            elf_syscalls
+        );
     }
 }
 

--- a/kernel/src/console/commands.rs
+++ b/kernel/src/console/commands.rs
@@ -1,0 +1,340 @@
+//! Console commands.
+//!
+//! Every one of these reports live kernel state or performs a real action.
+//! None of them return canned strings — if something is not implemented, it
+//! says so rather than printing a plausible-looking answer.
+
+use crate::console::editor::LineEditor;
+use crate::{print, println, serial_print, serial_println};
+
+/// Print to both the VGA console and the serial line.
+macro_rules! out {
+    () => {{
+        println!();
+        serial_println!();
+    }};
+    ($($arg:tt)*) => {{
+        println!($($arg)*);
+        serial_println!($($arg)*);
+    }};
+}
+
+pub fn execute(line: &str, editor: &LineEditor) {
+    let line = line.trim();
+    if line.is_empty() {
+        return;
+    }
+
+    let mut parts = line.split_whitespace();
+    let command = parts.next().unwrap_or("");
+    let args: [&str; 8] = {
+        let mut a = [""; 8];
+        for (i, s) in parts.take(8).enumerate() {
+            a[i] = s;
+        }
+        a
+    };
+    let arg_count = line.split_whitespace().count().saturating_sub(1).min(8);
+    let rest = line[command.len()..].trim_start();
+
+    match command {
+        "help" | "?" => help(),
+        "echo" => out!("{}", rest),
+        "clear" => clear(),
+
+        "uptime" => uptime(),
+        "ticks" => out!("{}", crate::interrupts::timer::ticks()),
+        "mem" | "free" => memory(),
+        "ps" | "threads" => threads(),
+        "uname" => uname(),
+
+        "heartbeat" => heartbeat(&args, arg_count),
+        "syscalls" => syscalls(),
+        "trace" => trace(&args, arg_count),
+
+        "translate" | "virt" => translate(&args, arg_count),
+        "modules" => modules(),
+        "history" => history(editor),
+
+        "fault" => fault(&args, arg_count),
+
+        "reboot" => reboot(),
+
+        _ => {
+            out!("unknown command: {}", command);
+            out!("type 'help' for the list");
+        }
+    }
+}
+
+fn help() {
+    out!("Kosh console commands:");
+    out!();
+    out!("  help                  this list");
+    out!("  echo <text>           print text");
+    out!("  clear                 clear the screen");
+    out!();
+    out!("  uptime                time since the timer started");
+    out!("  ticks                 raw timer tick count");
+    out!("  mem, free             physical and heap memory statistics");
+    out!("  ps, threads           kernel thread table");
+    out!("  uname                 system and platform information");
+    out!("  modules               boot modules supplied by the bootloader");
+    out!();
+    out!("  syscalls              syscalls serviced, and trace state");
+    out!("  trace on|off          per-syscall tracing to the serial line");
+    out!("  heartbeat on|off      once-a-second timer proof-of-life");
+    out!("  translate <hex>       walk the page tables for an address");
+    out!("  history               previous commands");
+    out!();
+    out!("  fault <kind>          deliberately fault: null, page, breakpoint");
+    out!("  reboot                triple-fault the machine");
+}
+
+fn clear() {
+    crate::vga_buffer::clear_screen();
+    // ANSI erase-screen plus cursor-home, for whatever is on the other end of
+    // the serial line.
+    serial_print!("\x1b[2J\x1b[H");
+}
+
+fn threads() {
+    let mut buf = [None; 16];
+    let count = crate::task::snapshot(&mut buf);
+
+    out!("{} thread(s):", count);
+    out!("  {:>3}  {:<12} {:<9} {:>8}", "id", "name", "state", "ticks");
+
+    for slot in buf.iter().flatten() {
+        out!(
+            "  {:>3}  {:<12} {:<9} {:>8}",
+            slot.id,
+            slot.name,
+            match slot.state {
+                crate::task::State::Running => "running",
+                crate::task::State::Ready => "ready",
+                crate::task::State::Finished => "finished",
+            },
+            slot.ticks
+        );
+    }
+
+    out!();
+    out!("{} context switches since boot", crate::task::switch_count());
+}
+
+fn uptime() {
+    let ms = crate::interrupts::timer::uptime_ms();
+    let seconds = ms / 1000;
+    let minutes = seconds / 60;
+    let hours = minutes / 60;
+
+    out!(
+        "up {}h {}m {}s ({} ms, {} ticks at {} Hz)",
+        hours,
+        minutes % 60,
+        seconds % 60,
+        ms,
+        crate::interrupts::timer::ticks(),
+        crate::interrupts::timer::TIMER_HZ
+    );
+}
+
+fn memory() {
+    if let Some(stats) = crate::memory::physical::memory_stats() {
+        out!("physical memory:");
+        out!(
+            "  total     {:>8} pages  {:>6} MB",
+            stats.total_pages,
+            stats.total_memory_mb()
+        );
+        out!(
+            "  used      {:>8} pages  {:>6} MB",
+            stats.used_pages,
+            stats.used_memory_mb()
+        );
+        out!(
+            "  free      {:>8} pages  {:>6} MB",
+            stats.free_pages,
+            stats.free_memory_mb()
+        );
+        out!("  reserved  {:>8} pages", stats.reserved_pages);
+    } else {
+        out!("physical memory manager not initialised");
+    }
+
+    let heap = crate::memory::heap::heap_stats();
+    let (blocks, free_blocks) = crate::memory::heap::block_census();
+
+    out!();
+    out!("kernel heap:");
+    out!("  size      {:>8} KB", heap.heap_size / 1024);
+    out!("  in use    {:>8} bytes across {} allocations", heap.current_bytes, heap.current_allocations);
+    out!("  free      {:>8} bytes", heap.free_bytes);
+    out!("  peak      {:>8} bytes", heap.peak_bytes);
+    out!("  blocks    {:>8} ({} free)", blocks, free_blocks);
+}
+
+fn uname() {
+    out!("Kosh 0.1.0 x86_64");
+    out!("  microkernel, Rust, multiboot2");
+
+    let cs: u16;
+    unsafe {
+        core::arch::asm!("mov {0:x}, cs", out(reg) cs, options(nomem, nostack, preserves_flags));
+    }
+    out!("  running in ring {}", cs & 3);
+
+    let (cr3, _) = x86_64::registers::control::Cr3::read();
+    out!("  CR3            0x{:x}", cr3.start_address().as_u64());
+    out!("  physmap base   0x{:x}", crate::memory::paging::PHYSMAP_BASE);
+    out!("  heap base      0x{:x}", crate::memory::paging::KERNEL_HEAP_BASE);
+    out!("  timer          {} Hz", crate::interrupts::timer::TIMER_HZ);
+}
+
+fn syscalls() {
+    out!(
+        "{} syscalls serviced since boot",
+        crate::syscall::entry::syscall_count()
+    );
+    out!(
+        "tracing is {}",
+        if crate::syscall::dispatcher::syscall_trace_enabled() {
+            "on"
+        } else {
+            "off"
+        }
+    );
+}
+
+fn heartbeat(args: &[&str; 8], count: usize) {
+    if count == 0 {
+        out!(
+            "heartbeat is {}",
+            if crate::interrupts::timer::heartbeat_enabled() { "on" } else { "off" }
+        );
+        out!("usage: heartbeat on|off");
+        return;
+    }
+
+    match args[0] {
+        "on" => {
+            crate::interrupts::timer::set_heartbeat(true);
+            out!("heartbeat on — it will interrupt what you are typing");
+        }
+        "off" => {
+            crate::interrupts::timer::set_heartbeat(false);
+            out!("heartbeat off");
+        }
+        other => out!("expected 'on' or 'off', got '{}'", other),
+    }
+}
+
+fn trace(args: &[&str; 8], count: usize) {
+    if count == 0 {
+        out!("usage: trace on|off");
+        return;
+    }
+
+    match args[0] {
+        "on" => {
+            crate::syscall::dispatcher::set_syscall_trace(true);
+            out!("syscall tracing on (serial only — it is verbose)");
+        }
+        "off" => {
+            crate::syscall::dispatcher::set_syscall_trace(false);
+            out!("syscall tracing off");
+        }
+        other => out!("expected 'on' or 'off', got '{}'", other),
+    }
+}
+
+fn translate(args: &[&str; 8], count: usize) {
+    if count == 0 {
+        out!("usage: translate <hex address>");
+        out!("  e.g. translate 100000     (the kernel image)");
+        out!("       translate ffff800000000000  (the physmap)");
+        return;
+    }
+
+    let text = args[0].trim_start_matches("0x");
+    let Ok(addr) = u64::from_str_radix(text, 16) else {
+        out!("not a hex address: {}", args[0]);
+        return;
+    };
+
+    match crate::memory::paging::translate(addr) {
+        Some(phys) => out!("0x{:x} -> physical 0x{:x}", addr, phys),
+        None => out!("0x{:x} is not mapped", addr),
+    }
+}
+
+fn modules() {
+    let mut found = false;
+    for i in 0..4 {
+        if let Some(m) = crate::usermode::boot_module(i) {
+            out!(
+                "module {}: 0x{:x}..0x{:x} ({} bytes)",
+                i,
+                m.start,
+                m.end,
+                m.len()
+            );
+            found = true;
+        }
+    }
+    if !found {
+        out!("no boot modules");
+    }
+}
+
+fn history(editor: &LineEditor) {
+    for (i, entry) in editor.history_entries().enumerate() {
+        out!("{:>4}  {}", i + 1, entry);
+    }
+}
+
+fn fault(args: &[&str; 8], count: usize) {
+    if count == 0 {
+        out!("usage: fault null|page|breakpoint");
+        out!("  breakpoint returns; the others halt the kernel by design");
+        return;
+    }
+
+    match args[0] {
+        "breakpoint" | "bp" => {
+            out!("raising int3 — the handler should print and resume");
+            x86_64::instructions::interrupts::int3();
+            out!("resumed");
+        }
+        "null" => {
+            out!("dereferencing a null pointer — this will halt the kernel");
+            unsafe {
+                core::ptr::read_volatile(0 as *const u64);
+            }
+            out!("no fault: page 0 is mapped, which it should not be");
+        }
+        "page" => {
+            out!("touching an unmapped higher-half address — this will halt the kernel");
+            unsafe {
+                core::ptr::read_volatile(0xFFFF_FF00_0000_0000u64 as *const u64);
+            }
+            out!("no fault: that address is mapped");
+        }
+        other => out!("unknown fault kind: {}", other),
+    }
+}
+
+fn reboot() {
+    out!("rebooting via triple fault...");
+
+    // Load an empty IDT and interrupt: no handler, no fallback, reset.
+    unsafe {
+        let idt = x86_64::structures::DescriptorTablePointer {
+            limit: 0,
+            base: x86_64::VirtAddr::new(0),
+        };
+        x86_64::instructions::tables::lidt(&idt);
+        core::arch::asm!("int3", options(noreturn));
+    }
+}

--- a/kernel/src/console/editor.rs
+++ b/kernel/src/console/editor.rs
@@ -1,0 +1,241 @@
+//! A line editor: the part of a shell that is not about commands.
+//!
+//! Cursor movement, insert and delete anywhere in the line, and a history ring
+//! you walk with the arrow keys. Fixed-size buffers throughout — this runs
+//! before the point where the kernel wants to be allocating on every keystroke,
+//! and a console that cannot fail is worth more than one with unbounded lines.
+
+use crate::interrupts::keyboard::{read_key_blocking, Key};
+use crate::{print, serial_print};
+
+/// Longest line the editor accepts.
+pub const MAX_LINE: usize = 256;
+
+/// Lines remembered.
+const HISTORY_DEPTH: usize = 32;
+
+pub struct LineEditor {
+    buffer: [u8; MAX_LINE],
+    len: usize,
+    cursor: usize,
+
+    history: [[u8; MAX_LINE]; HISTORY_DEPTH],
+    history_len: [usize; HISTORY_DEPTH],
+    /// Number of lines stored, saturating at HISTORY_DEPTH.
+    history_count: usize,
+    /// Where the next line goes; the ring wraps here.
+    history_head: usize,
+    /// How far back we have walked. 0 means "the line being typed".
+    history_pos: usize,
+}
+
+impl LineEditor {
+    pub const fn new() -> Self {
+        Self {
+            buffer: [0; MAX_LINE],
+            len: 0,
+            cursor: 0,
+            history: [[0; MAX_LINE]; HISTORY_DEPTH],
+            history_len: [0; HISTORY_DEPTH],
+            history_count: 0,
+            history_head: 0,
+            history_pos: 0,
+        }
+    }
+
+    /// Read one line, echoing as the user types. Blocks.
+    pub fn read_line(&mut self, prompt: &str) -> &str {
+        self.len = 0;
+        self.cursor = 0;
+        self.history_pos = 0;
+
+        print!("{}", prompt);
+        serial_print!("{}", prompt);
+
+        loop {
+            match read_key_blocking() {
+                Key::Enter => {
+                    print!("\n");
+                    serial_print!("\n");
+                    self.push_history();
+                    break;
+                }
+
+                Key::Char(c) if (c as u8) >= 0x20 && (c as u8) < 0x7f => {
+                    self.insert(c as u8, prompt);
+                }
+
+                Key::Backspace => {
+                    if self.cursor > 0 {
+                        self.cursor -= 1;
+                        self.remove_at_cursor(prompt);
+                    }
+                }
+
+                Key::Delete => {
+                    if self.cursor < self.len {
+                        self.remove_at_cursor(prompt);
+                    }
+                }
+
+                Key::Left => {
+                    if self.cursor > 0 {
+                        self.cursor -= 1;
+                        self.redraw(prompt);
+                    }
+                }
+
+                Key::Right => {
+                    if self.cursor < self.len {
+                        self.cursor += 1;
+                        self.redraw(prompt);
+                    }
+                }
+
+                Key::Home => {
+                    self.cursor = 0;
+                    self.redraw(prompt);
+                }
+
+                Key::End => {
+                    self.cursor = self.len;
+                    self.redraw(prompt);
+                }
+
+                Key::Up => self.history_step(1, prompt),
+                Key::Down => self.history_step(-1, prompt),
+
+                // Tab completion belongs with a filesystem to complete against.
+                Key::Tab | Key::Escape | Key::Char(_) => {}
+            }
+        }
+
+        core::str::from_utf8(&self.buffer[..self.len]).unwrap_or("")
+    }
+
+    fn insert(&mut self, byte: u8, prompt: &str) {
+        if self.len >= MAX_LINE {
+            return;
+        }
+
+        // Shift the tail right to make room.
+        let mut i = self.len;
+        while i > self.cursor {
+            self.buffer[i] = self.buffer[i - 1];
+            i -= 1;
+        }
+
+        self.buffer[self.cursor] = byte;
+        self.len += 1;
+        self.cursor += 1;
+
+        // Appending at the end is the common case and only needs one character
+        // echoed; anything else has to redraw the tail.
+        if self.cursor == self.len {
+            print!("{}", byte as char);
+            serial_print!("{}", byte as char);
+        } else {
+            self.redraw(prompt);
+        }
+    }
+
+    fn remove_at_cursor(&mut self, prompt: &str) {
+        let mut i = self.cursor;
+        while i + 1 < self.len {
+            self.buffer[i] = self.buffer[i + 1];
+            i += 1;
+        }
+        self.len -= 1;
+        self.redraw(prompt);
+    }
+
+    /// Repaint the whole line.
+    ///
+    /// Crude but honest: carriage return, rewrite, then walk the cursor back.
+    /// A terminal-aware editor would emit cursor-movement escapes, but this has
+    /// to drive a raw VGA text buffer as well as a serial line, and the two do
+    /// not agree on escape sequences.
+    fn redraw(&self, prompt: &str) {
+        print!("\r{}", prompt);
+        serial_print!("\r{}", prompt);
+
+        for i in 0..self.len {
+            print!("{}", self.buffer[i] as char);
+            serial_print!("{}", self.buffer[i] as char);
+        }
+
+        // Erase whatever the previous, longer line left behind.
+        print!(" ");
+        serial_print!(" ");
+
+        // Walk back to the cursor.
+        let back = self.len + 1 - self.cursor;
+        for _ in 0..back {
+            print!("\x08");
+            serial_print!("\x08");
+        }
+    }
+
+    fn push_history(&mut self) {
+        if self.len == 0 {
+            return;
+        }
+
+        // Skip consecutive duplicates: holding Up through ten identical lines
+        // is nobody's idea of history.
+        if self.history_count > 0 {
+            let last = (self.history_head + HISTORY_DEPTH - 1) % HISTORY_DEPTH;
+            if self.history_len[last] == self.len
+                && self.history[last][..self.len] == self.buffer[..self.len]
+            {
+                return;
+            }
+        }
+
+        self.history[self.history_head][..self.len].copy_from_slice(&self.buffer[..self.len]);
+        self.history_len[self.history_head] = self.len;
+        self.history_head = (self.history_head + 1) % HISTORY_DEPTH;
+        if self.history_count < HISTORY_DEPTH {
+            self.history_count += 1;
+        }
+    }
+
+    /// Walk history. `direction` is +1 for older, -1 for newer.
+    fn history_step(&mut self, direction: i32, prompt: &str) {
+        if self.history_count == 0 {
+            return;
+        }
+
+        let next = self.history_pos as i32 + direction;
+        if next < 0 || next > self.history_count as i32 {
+            return;
+        }
+        self.history_pos = next as usize;
+
+        if self.history_pos == 0 {
+            // Back to a fresh line.
+            self.len = 0;
+            self.cursor = 0;
+        } else {
+            let idx =
+                (self.history_head + HISTORY_DEPTH - self.history_pos) % HISTORY_DEPTH;
+            let n = self.history_len[idx];
+            self.buffer[..n].copy_from_slice(&self.history[idx][..n]);
+            self.len = n;
+            self.cursor = n;
+        }
+
+        self.redraw(prompt);
+    }
+
+    /// Iterate stored history, oldest first.
+    pub fn history_entries(&self) -> impl Iterator<Item = &str> {
+        let count = self.history_count;
+        let head = self.history_head;
+
+        (0..count).filter_map(move |i| {
+            let idx = (head + HISTORY_DEPTH - count + i) % HISTORY_DEPTH;
+            core::str::from_utf8(&self.history[idx][..self.history_len[idx]]).ok()
+        })
+    }
+}

--- a/kernel/src/console/mod.rs
+++ b/kernel/src/console/mod.rs
@@ -1,0 +1,65 @@
+//! The Kosh console: an in-kernel shell.
+//!
+//! ## Why in-kernel, in a microkernel
+//!
+//! Because a kernel you can interrogate while it is running is worth more than
+//! architectural purity at this stage. Every command here reports live kernel
+//! state — real frame counts, real heap statistics, the real thread table, the
+//! real page tables. That makes it a debugging instrument, not a demo, and it
+//! is the reason serious kernels keep a built-in debug console permanently
+//! even after userspace exists.
+//!
+//! The userspace shell is still the goal. It needs a blocking read syscall and
+//! a filesystem to be worth using; this console needs neither, and it is what
+//! lets you inspect the kernel *while* building those.
+//!
+//! ## What it deliberately does not do
+//!
+//! No `ls`, `cat`, or `cd`. There is no filesystem yet, and inventing commands
+//! that return plausible-looking strings is exactly the habit that let this
+//! project accumulate 27 commits of code that had never run. Every command
+//! below either reports something real or says it is not implemented.
+
+pub mod commands;
+pub mod editor;
+
+use editor::LineEditor;
+
+use crate::{println, serial_println};
+
+const PROMPT: &str = "kosh> ";
+
+/// Run the console. Never returns.
+///
+/// Runs as a kernel thread, so the timer keeps ticking and anything else that
+/// is runnable keeps running while this blocks on the keyboard.
+pub fn run(_arg: usize) {
+    let mut editor = LineEditor::new();
+
+    // The boot heartbeat has done its job. Leaving it on means a line lands in
+    // the middle of whatever is being typed, once a second, forever.
+    crate::interrupts::timer::set_heartbeat(false);
+
+    banner();
+
+    loop {
+        let line = editor.read_line(PROMPT);
+
+        // `read_line` borrows the editor for the lifetime of the returned
+        // string, but `history` needs to read the editor too. Copy the line out
+        // so the borrow ends here.
+        let mut owned = [0u8; editor::MAX_LINE];
+        let n = line.len().min(owned.len());
+        owned[..n].copy_from_slice(&line.as_bytes()[..n]);
+        let line = core::str::from_utf8(&owned[..n]).unwrap_or("");
+
+        commands::execute(line, &editor);
+    }
+}
+
+fn banner() {
+    println!();
+    println!("Kosh console. Type 'help' for commands.");
+    serial_println!();
+    serial_println!("Kosh console. Type 'help' for commands.");
+}

--- a/kernel/src/elf.rs
+++ b/kernel/src/elf.rs
@@ -1,0 +1,250 @@
+//! A minimal static ELF64 loader.
+//!
+//! Before this existed there was no way for the kernel to run a program it had
+//! not been compiled with. The only mentions of ELF loading in the tree were
+//! comments — `driver_loader.rs:21`, "in a real implementation, this would
+//! handle ELF loading" — and `sys_exec` returned `NotSupported`.
+//!
+//! ## Scope
+//!
+//! Static, non-relocatable `ET_EXEC` binaries only: parse the program headers,
+//! map each `PT_LOAD` segment at its `p_vaddr`, copy `p_filesz` bytes and zero
+//! the rest. No dynamic linking, no relocations, no interpreter. That is
+//! enough to run a `no_std` Rust binary linked at a fixed address, which is
+//! what userspace looks like here for the foreseeable future.
+//!
+//! ## Where the bytes come from
+//!
+//! GRUB loads modules into physical memory and reports them through multiboot2
+//! module tags. Two consequences the kernel has to respect:
+//!
+//! 1. Those frames must be marked used before the allocator starts handing out
+//!    memory, or the module gets overwritten by the first allocation. See
+//!    `physical.rs`.
+//! 2. A module can land anywhere in RAM, including outside the low identity
+//!    window, so it is read through the physmap rather than by physical
+//!    address.
+
+use x86_64::structures::paging::PageTableFlags;
+
+use crate::memory::paging::{self, PHYSMAP_BASE};
+use crate::memory::PAGE_SIZE;
+use crate::serial_println;
+
+const ELF_MAGIC: [u8; 4] = [0x7F, b'E', b'L', b'F'];
+
+const ELFCLASS64: u8 = 2;
+const ELFDATA2LSB: u8 = 1;
+const ET_EXEC: u16 = 2;
+const EM_X86_64: u16 = 0x3E;
+
+const PT_LOAD: u32 = 1;
+
+const PF_X: u32 = 1;
+const PF_W: u32 = 2;
+const PF_R: u32 = 4;
+
+#[derive(Debug)]
+pub enum ElfError {
+    TooSmall,
+    BadMagic,
+    Not64Bit,
+    NotLittleEndian,
+    NotExecutable,
+    WrongArchitecture,
+    NoLoadableSegments,
+    SegmentOutOfRange,
+    /// A segment wants to live where the kernel already is.
+    SegmentInKernelSpace,
+    MappingFailed(&'static str),
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct Elf64Header {
+    ident: [u8; 16],
+    e_type: u16,
+    machine: u16,
+    version: u32,
+    entry: u64,
+    phoff: u64,
+    shoff: u64,
+    flags: u32,
+    ehsize: u16,
+    phentsize: u16,
+    phnum: u16,
+    shentsize: u16,
+    shnum: u16,
+    shstrndx: u16,
+}
+
+#[repr(C)]
+#[derive(Clone, Copy)]
+struct Elf64ProgramHeader {
+    p_type: u32,
+    flags: u32,
+    offset: u64,
+    vaddr: u64,
+    paddr: u64,
+    filesz: u64,
+    memsz: u64,
+    align: u64,
+}
+
+/// A program that has been loaded and is ready to enter.
+pub struct LoadedImage {
+    pub entry: u64,
+    pub segments: usize,
+    pub bytes_mapped: usize,
+}
+
+/// Everything at or above this is kernel territory; a user segment claiming to
+/// live here is rejected rather than mapped.
+const USER_ADDRESS_LIMIT: u64 = 0x0000_8000_0000_0000;
+
+/// Load a static ELF64 executable from a byte slice into the current address
+/// space, mapped for ring 3.
+///
+/// # Safety
+/// The caller must ensure no existing user mapping overlaps the segments this
+/// image declares. Phase 6 runs one program at a time, so that holds trivially.
+pub unsafe fn load(image: &[u8]) -> Result<LoadedImage, ElfError> {
+    let header = parse_header(image)?;
+
+    serial_println!(
+        "  ELF: type {} machine 0x{:x}, entry 0x{:x}, {} program headers",
+        header.e_type,
+        header.machine,
+        header.entry,
+        header.phnum
+    );
+
+    let mut segments = 0usize;
+    let mut bytes_mapped = 0usize;
+
+    for i in 0..header.phnum as usize {
+        let offset = header.phoff as usize + i * header.phentsize as usize;
+        if offset + core::mem::size_of::<Elf64ProgramHeader>() > image.len() {
+            return Err(ElfError::TooSmall);
+        }
+
+        let ph: Elf64ProgramHeader =
+            core::ptr::read_unaligned(image.as_ptr().add(offset) as *const _);
+
+        if ph.p_type != PT_LOAD || ph.memsz == 0 {
+            continue;
+        }
+
+        load_segment(image, &ph)?;
+
+        segments += 1;
+        bytes_mapped += ph.memsz as usize;
+    }
+
+    if segments == 0 {
+        return Err(ElfError::NoLoadableSegments);
+    }
+
+    Ok(LoadedImage {
+        entry: header.entry,
+        segments,
+        bytes_mapped,
+    })
+}
+
+fn parse_header(image: &[u8]) -> Result<Elf64Header, ElfError> {
+    if image.len() < core::mem::size_of::<Elf64Header>() {
+        return Err(ElfError::TooSmall);
+    }
+
+    let header: Elf64Header = unsafe { core::ptr::read_unaligned(image.as_ptr() as *const _) };
+
+    if header.ident[0..4] != ELF_MAGIC {
+        return Err(ElfError::BadMagic);
+    }
+    if header.ident[4] != ELFCLASS64 {
+        return Err(ElfError::Not64Bit);
+    }
+    if header.ident[5] != ELFDATA2LSB {
+        return Err(ElfError::NotLittleEndian);
+    }
+    if header.e_type != ET_EXEC {
+        // ET_DYN would need relocation processing, which this loader does not do.
+        return Err(ElfError::NotExecutable);
+    }
+    if header.machine != EM_X86_64 {
+        return Err(ElfError::WrongArchitecture);
+    }
+
+    Ok(header)
+}
+
+/// Map one `PT_LOAD` segment and populate it.
+///
+/// Pages are written through the physmap rather than through the mapping being
+/// created. That keeps the final page permissions honest — a read-only or
+/// non-writable segment never has to be temporarily writable just so the loader
+/// can fill it in.
+unsafe fn load_segment(image: &[u8], ph: &Elf64ProgramHeader) -> Result<(), ElfError> {
+    if ph.vaddr >= USER_ADDRESS_LIMIT || ph.vaddr.saturating_add(ph.memsz) >= USER_ADDRESS_LIMIT {
+        return Err(ElfError::SegmentInKernelSpace);
+    }
+    if (ph.offset + ph.filesz) as usize > image.len() {
+        return Err(ElfError::SegmentOutOfRange);
+    }
+
+    let start = ph.vaddr & !(PAGE_SIZE as u64 - 1);
+    let end = (ph.vaddr + ph.memsz + PAGE_SIZE as u64 - 1) & !(PAGE_SIZE as u64 - 1);
+    let pages = ((end - start) / PAGE_SIZE as u64) as usize;
+
+    let mut flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+    if ph.flags & PF_W != 0 {
+        flags |= PageTableFlags::WRITABLE;
+    }
+    if ph.flags & PF_X == 0 {
+        flags |= PageTableFlags::NO_EXECUTE;
+    }
+
+    serial_println!(
+        "  segment: vaddr 0x{:x} filesz {} memsz {} [{}{}{}] -> {} page(s)",
+        ph.vaddr,
+        ph.filesz,
+        ph.memsz,
+        if ph.flags & PF_R != 0 { "r" } else { "-" },
+        if ph.flags & PF_W != 0 { "w" } else { "-" },
+        if ph.flags & PF_X != 0 { "x" } else { "-" },
+        pages
+    );
+
+    // Allocate and map the whole span with its final permissions.
+    paging::map_user_pages(start, pages, flags).map_err(ElfError::MappingFailed)?;
+
+    // Fill it in through the physmap. `map_user_pages` already zeroed every
+    // frame, which is what makes the .bss tail correct without extra work: we
+    // only have to write the `p_filesz` bytes that come from the file.
+    for i in 0..ph.filesz as usize {
+        let vaddr = ph.vaddr + i as u64;
+        let phys = paging::translate(vaddr).ok_or(ElfError::MappingFailed("segment unmapped"))?;
+        core::ptr::write_volatile(
+            (PHYSMAP_BASE + phys) as *mut u8,
+            image[ph.offset as usize + i],
+        );
+    }
+
+    Ok(())
+}
+
+/// Report what a module looks like without loading it — used for diagnostics
+/// when loading fails.
+pub fn describe(image: &[u8]) {
+    serial_println!("  module: {} bytes", image.len());
+    if image.len() >= 4 {
+        serial_println!(
+            "  first 4 bytes: {:02x} {:02x} {:02x} {:02x}",
+            image[0],
+            image[1],
+            image[2],
+            image[3]
+        );
+    }
+}

--- a/kernel/src/interrupts/keyboard.rs
+++ b/kernel/src/interrupts/keyboard.rs
@@ -6,13 +6,18 @@
 //! is the real thing: an interrupt handler reading port 0x60.
 //!
 //! The handler does the minimum possible work — read the port, decode, push a
-//! byte — and never allocates or blocks. Everything else happens in
-//! `read_char()`, called from normal kernel context.
+//! key — and never allocates or blocks. Everything else happens in
+//! [`read_key`], called from normal kernel context.
+//!
+//! The buffer carries a [`Key`] rather than a byte, because a line editor needs
+//! to tell an arrow key from the character it would otherwise be conflated
+//! with. Squeezing cursor keys into spare ASCII control codes works right up
+//! until something wants to type one of those control codes.
 
 use core::sync::atomic::{AtomicUsize, Ordering};
 
 use lazy_static::lazy_static;
-use pc_keyboard::{layouts, DecodedKey, HandleControl, Keyboard, ScancodeSet1};
+use pc_keyboard::{layouts, DecodedKey, HandleControl, KeyCode, Keyboard, ScancodeSet1};
 use spin::Mutex;
 use x86_64::instructions::port::Port;
 use x86_64::structures::idt::InterruptStackFrame;
@@ -22,9 +27,26 @@ use crate::serial_println;
 
 const PS2_DATA_PORT: u16 = 0x60;
 
-/// Capacity of the decoded-character ring. A power of two so the modulo is a
-/// mask. 128 characters is far more than a human can type between polls.
+/// Capacity of the key ring. A power of two so the modulo is a mask. 128 keys
+/// is far more than a human can type between polls.
 const BUFFER_SIZE: usize = 128;
+
+/// A decoded keypress.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Key {
+    Char(char),
+    Enter,
+    Backspace,
+    Delete,
+    Tab,
+    Escape,
+    Up,
+    Down,
+    Left,
+    Right,
+    Home,
+    End,
+}
 
 lazy_static! {
     static ref KEYBOARD: Mutex<Keyboard<layouts::Us104Key, ScancodeSet1>> = Mutex::new(
@@ -35,7 +57,7 @@ lazy_static! {
 /// Lock-free-ish SPSC ring: the IRQ handler is the only producer, kernel
 /// context is the only consumer.
 struct KeyBuffer {
-    data: [u8; BUFFER_SIZE],
+    data: [Key; BUFFER_SIZE],
     read: AtomicUsize,
     write: AtomicUsize,
 }
@@ -43,13 +65,13 @@ struct KeyBuffer {
 impl KeyBuffer {
     const fn new() -> Self {
         Self {
-            data: [0; BUFFER_SIZE],
+            data: [Key::Char('\0'); BUFFER_SIZE],
             read: AtomicUsize::new(0),
             write: AtomicUsize::new(0),
         }
     }
 
-    fn push(&mut self, byte: u8) {
+    fn push(&mut self, key: Key) {
         let write = self.write.load(Ordering::Relaxed);
         let next = (write + 1) % BUFFER_SIZE;
 
@@ -59,19 +81,19 @@ impl KeyBuffer {
             return;
         }
 
-        self.data[write] = byte;
+        self.data[write] = key;
         self.write.store(next, Ordering::Release);
     }
 
-    fn pop(&self) -> Option<u8> {
+    fn pop(&self) -> Option<Key> {
         let read = self.read.load(Ordering::Relaxed);
         if read == self.write.load(Ordering::Acquire) {
             return None;
         }
 
-        let byte = self.data[read];
+        let key = self.data[read];
         self.read.store((read + 1) % BUFFER_SIZE, Ordering::Release);
-        Some(byte)
+        Some(key)
     }
 
     fn is_empty(&self) -> bool {
@@ -91,27 +113,59 @@ pub fn init() {
     serial_println!("  PS/2 keyboard: IRQ1 handler installed (US layout, set 1)");
 }
 
-/// Take one decoded character, if any is waiting. Non-blocking.
-pub fn read_char() -> Option<char> {
-    crate::interrupts::without_interrupts(|| BUFFER.lock().pop().map(|b| b as char))
+/// Take one key, if any is waiting. Non-blocking.
+pub fn read_key() -> Option<Key> {
+    crate::interrupts::without_interrupts(|| BUFFER.lock().pop())
 }
 
-/// Block until a character is available.
+/// Block until a key is available.
 ///
-/// Uses `hlt` rather than a spin so an idle wait does not burn the CPU. This
-/// is the primitive the shell's line editor will sit on in Phase 7.
-pub fn read_char_blocking() -> char {
+/// Uses `hlt` rather than a spin so an idle wait does not burn the CPU — and,
+/// now that the kernel is preemptive, so other threads keep running while the
+/// console waits for a human.
+pub fn read_key_blocking() -> Key {
     loop {
-        if let Some(c) = read_char() {
-            return c;
+        if let Some(key) = read_key() {
+            return key;
         }
         x86_64::instructions::hlt();
     }
 }
 
+/// Take one character, ignoring keys that have no character. Non-blocking.
+pub fn read_char() -> Option<char> {
+    match read_key() {
+        Some(Key::Char(c)) => Some(c),
+        Some(Key::Enter) => Some('\n'),
+        Some(Key::Backspace) => Some('\x08'),
+        _ => None,
+    }
+}
+
 /// Whether any input is pending.
 pub fn has_input() -> bool {
-    crate::interrupts::without_interrupts(|| BUFFER.lock().is_empty()) == false
+    !crate::interrupts::without_interrupts(|| BUFFER.lock().is_empty())
+}
+
+fn translate(key: DecodedKey) -> Option<Key> {
+    match key {
+        DecodedKey::Unicode('\n') | DecodedKey::Unicode('\r') => Some(Key::Enter),
+        DecodedKey::Unicode('\u{8}') | DecodedKey::Unicode('\u{7f}') => Some(Key::Backspace),
+        DecodedKey::Unicode('\t') => Some(Key::Tab),
+        DecodedKey::Unicode('\u{1b}') => Some(Key::Escape),
+        DecodedKey::Unicode(c) if c.is_ascii() => Some(Key::Char(c)),
+        DecodedKey::Unicode(_) => None,
+
+        DecodedKey::RawKey(KeyCode::ArrowUp) => Some(Key::Up),
+        DecodedKey::RawKey(KeyCode::ArrowDown) => Some(Key::Down),
+        DecodedKey::RawKey(KeyCode::ArrowLeft) => Some(Key::Left),
+        DecodedKey::RawKey(KeyCode::ArrowRight) => Some(Key::Right),
+        DecodedKey::RawKey(KeyCode::Home) => Some(Key::Home),
+        DecodedKey::RawKey(KeyCode::End) => Some(Key::End),
+        DecodedKey::RawKey(KeyCode::Delete) => Some(Key::Delete),
+        DecodedKey::RawKey(KeyCode::Backspace) => Some(Key::Backspace),
+        DecodedKey::RawKey(_) => None,
+    }
 }
 
 pub extern "x86-interrupt" fn keyboard_interrupt_handler(_frame: InterruptStackFrame) {
@@ -125,23 +179,10 @@ pub extern "x86-interrupt" fn keyboard_interrupt_handler(_frame: InterruptStackF
     // machine. Dropping a keystroke is the correct trade.
     if let Some(mut keyboard) = KEYBOARD.try_lock() {
         if let Ok(Some(key_event)) = keyboard.add_byte(scancode) {
-            if let Some(key) = keyboard.process_keyevent(key_event) {
-                let byte = match key {
-                    DecodedKey::Unicode(c) => {
-                        if c.is_ascii() {
-                            Some(c as u8)
-                        } else {
-                            None
-                        }
-                    }
-                    // Arrow keys, function keys and friends have no ASCII
-                    // encoding. Phase 7 will map these to editor commands.
-                    DecodedKey::RawKey(_) => None,
-                };
-
-                if let Some(byte) = byte {
+            if let Some(decoded) = keyboard.process_keyevent(key_event) {
+                if let Some(key) = translate(decoded) {
                     if let Some(mut buffer) = BUFFER.try_lock() {
-                        buffer.push(byte);
+                        buffer.push(key);
                     }
                 }
             }

--- a/kernel/src/interrupts/mod.rs
+++ b/kernel/src/interrupts/mod.rs
@@ -133,6 +133,27 @@ pub fn enable_hardware_interrupts() {
 
     x86_64::instructions::interrupts::enable();
     serial_println!("Interrupts enabled");
+
+    verify_timer();
+}
+
+/// Prove the timer is actually advancing.
+///
+/// This used to be inferred from a once-a-second heartbeat line, which stopped
+/// being a reliable signal the moment the console started before the first
+/// second elapsed. Measuring directly is both faster and unambiguous.
+fn verify_timer() {
+    let before = timer::ticks();
+    timer::sleep_ms(50);
+    let elapsed = timer::ticks() - before;
+
+    // 50 ms at 100 Hz is 5 ticks. Allow slack for a slow emulator, but any
+    // movement at all is the thing being tested.
+    if elapsed >= 3 {
+        serial_println!("Timer: PASS — {} ticks in 50 ms", elapsed);
+    } else {
+        serial_println!("Timer: FAIL — only {} ticks in 50 ms", elapsed);
+    }
 }
 
 /// Run `f` with interrupts disabled, restoring the previous state afterwards.

--- a/kernel/src/interrupts/timer.rs
+++ b/kernel/src/interrupts/timer.rs
@@ -5,7 +5,7 @@
 //! `scheduler::handle_timer_tick()` had zero callers, so nothing in the kernel
 //! could ever be preempted or timed.
 
-use core::sync::atomic::{AtomicU64, Ordering};
+use core::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 
 use x86_64::instructions::port::Port;
 use x86_64::structures::idt::InterruptStackFrame;
@@ -26,6 +26,21 @@ const PIT_COMMAND: u16 = 0x43;
 /// Ticks since the timer was started. Monotonic; wraps after ~5.8 billion
 /// years at 100 Hz, so not a practical concern.
 static TICKS: AtomicU64 = AtomicU64::new(0);
+
+/// Whether to print a once-a-second proof-of-life on the serial line.
+///
+/// On during boot, where it is the only sign the timer is alive. The console
+/// turns it off when it starts, because a line that appears in the middle of
+/// whatever you are typing makes the console unusable.
+static HEARTBEAT: AtomicBool = AtomicBool::new(true);
+
+pub fn set_heartbeat(enabled: bool) {
+    HEARTBEAT.store(enabled, Ordering::Relaxed);
+}
+
+pub fn heartbeat_enabled() -> bool {
+    HEARTBEAT.load(Ordering::Relaxed)
+}
 
 /// Program PIT channel 0 for periodic interrupts at `TIMER_HZ`.
 pub fn init() {
@@ -72,9 +87,9 @@ pub fn sleep_ms(ms: u64) {
 pub extern "x86-interrupt" fn timer_interrupt_handler(_frame: InterruptStackFrame) {
     let tick = TICKS.fetch_add(1, Ordering::Relaxed) + 1;
 
-    // Proof of life, once a second. This is temporary scaffolding — it comes
-    // out when the scheduler takes over the tick in Phase 4.
-    if tick % TIMER_HZ as u64 == 0 {
+    // Proof of life, once a second, until something more useful owns the
+    // console.
+    if heartbeat_enabled() && tick % TIMER_HZ as u64 == 0 {
         serial_println!("[tick] uptime {}s ({} ticks)", tick / TIMER_HZ as u64, tick);
     }
 

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -21,6 +21,8 @@ mod task;
 #[cfg(target_arch = "x86_64")]
 mod gdt;
 #[cfg(target_arch = "x86_64")]
+mod elf;
+#[cfg(target_arch = "x86_64")]
 mod usermode;
 #[cfg(target_arch = "x86_64")]
 mod user_program;

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -21,6 +21,8 @@ mod task;
 #[cfg(target_arch = "x86_64")]
 mod gdt;
 #[cfg(target_arch = "x86_64")]
+mod console;
+#[cfg(target_arch = "x86_64")]
 mod elf;
 #[cfg(target_arch = "x86_64")]
 mod usermode;
@@ -270,38 +272,25 @@ pub extern "C" fn _start(multiboot_info_addr: usize) -> ! {
     idle_loop()
 }
 
-/// Idle loop.
+/// Hand over to the console.
 ///
-/// There is no scheduler yet, so the kernel's "steady state" is to wait for
-/// interrupts. The timer ticks in the background; anything typed on the PS/2
-/// keyboard is echoed here, which proves the IRQ path end to end and is the
-/// beginning of the console the shell will use in Phase 7.
+/// The console runs on its own kernel thread rather than here, so that the
+/// scheduler stays live while it blocks on the keyboard: timer ticks keep
+/// arriving, other threads keep running, and a wedged console does not wedge
+/// the machine. This thread becomes the idle task.
 #[cfg(target_arch = "x86_64")]
 fn idle_loop() -> ! {
-    serial_println!("Kosh: idle loop — timer is ticking, type to echo keystrokes");
-    println!("Kosh ready. Type something:");
+    match task::spawn("console", console::run, 0) {
+        Ok(_) => serial_println!("Kosh: console started on its own thread"),
+        Err(e) => {
+            serial_println!("Kosh: could not start the console: {}", e);
+            serial_println!("Kosh: falling back to the idle loop");
+        }
+    }
 
     loop {
-        while let Some(c) = interrupts::keyboard::read_char() {
-            match c {
-                // Enter
-                '\n' | '\r' => {
-                    println!();
-                    serial_println!();
-                }
-                // Backspace
-                '\x08' | '\x7f' => {
-                    print!("\x08 \x08");
-                    serial_print!("\x08 \x08");
-                }
-                c => {
-                    print!("{}", c);
-                    serial_print!("{}", c);
-                }
-            }
-        }
-
-        // Sleep until the next interrupt rather than spinning.
+        // Nothing to do but wait for an interrupt. The scheduler will preempt
+        // us into the console as soon as there is a key to handle.
         x86_64::instructions::hlt();
     }
 }

--- a/kernel/src/memory/heap.rs
+++ b/kernel/src/memory/heap.rs
@@ -214,11 +214,20 @@ impl KernelHeapAllocator {
         // Remove from free list
         self.remove_from_free_list(block);
 
-        // Update statistics
+        // Account for what the block actually holds, not what was asked for.
+        //
+        // `deallocate` credits back `(*block).size`, and after the alignment
+        // carve and the split that is not the same as the requested `size`.
+        // Charging one and crediting the other made `current_bytes` drift
+        // downwards until it underflowed, and `peak_bytes` then latched onto
+        // the wrapped value — which is how the console ended up reporting a
+        // peak of 18446744073709551568 bytes.
+        let charged = unsafe { (*block.as_ptr()).size };
+
         self.stats.total_allocations += 1;
         self.stats.current_allocations += 1;
-        self.stats.bytes_allocated += size;
-        self.stats.current_bytes += size;
+        self.stats.bytes_allocated += charged;
+        self.stats.current_bytes += charged;
 
         if self.stats.current_bytes > self.stats.peak_bytes {
             self.stats.peak_bytes = self.stats.current_bytes;

--- a/kernel/src/memory/physical.rs
+++ b/kernel/src/memory/physical.rs
@@ -163,6 +163,12 @@ impl PhysicalMemoryManager {
         
         // Mark available memory areas as free
         manager.parse_memory_map(&memory_map)?;
+
+        // Boot modules live in RAM that the memory map reports as *available*,
+        // because from the firmware's point of view it is. If we do not claim
+        // them here, the first allocation lands on top of the init binary we
+        // are about to load.
+        manager.reserve_boot_modules(boot_info);
         
         serial_println!("Physical memory manager initialized:");
         serial_println!("  Total frames: {}", manager.total_frames);
@@ -219,6 +225,32 @@ impl PhysicalMemoryManager {
         Ok(())
     }
     
+    /// Mark every frame holding a multiboot2 boot module as used.
+    fn reserve_boot_modules(&mut self, boot_info: &BootInformation) {
+        for module in boot_info.module_tags() {
+            let start = module.start_address() as usize;
+            let end = module.end_address() as usize;
+
+            let first = PageFrame::from_address(start);
+            let last = PageFrame::from_address(end.saturating_sub(1));
+
+            let mut count = 0usize;
+            for frame_num in first.0..=last.0 {
+                if frame_num < self.total_frames {
+                    self.mark_frame_used(PageFrame(frame_num));
+                    count += 1;
+                }
+            }
+
+            serial_println!(
+                "  reserved boot module 0x{:x}..0x{:x} ({} frames)",
+                start,
+                end,
+                count
+            );
+        }
+    }
+
     /// Allocate a single page frame
     pub fn allocate_frame(&mut self) -> Option<PageFrame> {
         if self.free_frames == 0 {

--- a/kernel/src/syscall/dispatcher.rs
+++ b/kernel/src/syscall/dispatcher.rs
@@ -4,6 +4,23 @@ use crate::syscall::numbers::*;
 use crate::syscall::validation::validate_syscall_args;
 use crate::{serial_println, println};
 use alloc::format;
+use core::sync::atomic::{AtomicBool, Ordering};
+
+/// Per-syscall tracing.
+///
+/// Off by default. It is genuinely useful while bringing a syscall up, but a
+/// program that writes one character at a time — a console, say — produces two
+/// log lines per keystroke, interleaved with its own output on the same line.
+/// That makes the thing you are trying to read unreadable.
+static SYSCALL_TRACE: AtomicBool = AtomicBool::new(false);
+
+pub fn set_syscall_trace(enabled: bool) {
+    SYSCALL_TRACE.store(enabled, Ordering::Relaxed);
+}
+
+pub fn syscall_trace_enabled() -> bool {
+    SYSCALL_TRACE.load(Ordering::Relaxed)
+}
 
 /// Initialize the system call dispatcher
 pub fn init_syscall_dispatcher() -> Result<(), &'static str> {
@@ -22,14 +39,15 @@ pub fn dispatch_syscall(
     syscall_number: u64,
     args: [u64; 6],
 ) -> SyscallResult {
-    // Log the system call for debugging
-    serial_println!(
-        "Process {} calling syscall {} ({}) with args [{}, {}, {}, {}, {}, {}]",
-        process_id.0,
-        syscall_number,
-        syscall_name(syscall_number),
-        args[0], args[1], args[2], args[3], args[4], args[5]
-    );
+    if syscall_trace_enabled() {
+        serial_println!(
+            "Process {} calling syscall {} ({}) with args [{}, {}, {}, {}, {}, {}]",
+            process_id.0,
+            syscall_number,
+            syscall_name(syscall_number),
+            args[0], args[1], args[2], args[3], args[4], args[5]
+        );
+    }
     
     // Validate system call arguments
     validate_syscall_args(process_id, syscall_number, &args)?;
@@ -101,13 +119,16 @@ pub fn dispatch_syscall(
         }
     };
     
-    // Log the result
+    // Failures are always reported; successes only when tracing. A syscall
+    // that fails is news, one that works is not.
     match &result {
         Ok(value) => {
-            serial_println!(
-                "Process {} syscall {} completed successfully, returned {}",
-                process_id.0, syscall_name(syscall_number), value
-            );
+            if syscall_trace_enabled() {
+                serial_println!(
+                    "Process {} syscall {} completed successfully, returned {}",
+                    process_id.0, syscall_name(syscall_number), value
+                );
+            }
         }
         Err(error) => {
             serial_println!(

--- a/kernel/src/syscall/entry.rs
+++ b/kernel/src/syscall/entry.rs
@@ -150,7 +150,9 @@ pub extern "C" fn kosh_syscall_handler(frame: &mut SyscallFrame) -> u64 {
     match crate::syscall::dispatcher::dispatch_syscall(pid, number, args) {
         Ok(value) => value,
         Err(err) => {
-            serial_println!("syscall {} failed: {:?}", number, err);
+            if crate::syscall::dispatcher::syscall_trace_enabled() {
+                serial_println!("syscall {} returning error {:?}", number, err);
+            }
 
             // Linux convention: errors come back as a negative value in RAX,
             // successes as a non-negative one, and userspace tests the sign.

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -368,6 +368,45 @@ pub fn reap_finished() {
     });
 }
 
+/// A snapshot of one thread, for callers that want to format it themselves
+/// (the console renders to VGA as well as serial, which `print_threads` does
+/// not).
+#[derive(Debug, Clone, Copy)]
+pub struct ThreadInfo {
+    pub id: usize,
+    pub name: &'static str,
+    pub state: State,
+    pub ticks: u64,
+}
+
+/// Copy the thread table out under the lock, so callers can print without
+/// holding it. Returns how many entries were filled.
+pub fn snapshot(out: &mut [Option<ThreadInfo>; MAX_THREADS]) -> usize {
+    without_interrupts(|| {
+        let sched = SCHEDULER.lock();
+        let mut n = 0;
+        for (i, slot) in sched.threads.iter().enumerate() {
+            if let Some(t) = slot {
+                out[i] = Some(ThreadInfo {
+                    id: t.id,
+                    name: t.name,
+                    state: t.state,
+                    ticks: t.ticks,
+                });
+                n += 1;
+            } else {
+                out[i] = None;
+            }
+        }
+        n
+    })
+}
+
+/// Maximum threads, for callers sizing a snapshot buffer.
+pub const fn max_threads() -> usize {
+    MAX_THREADS
+}
+
 pub fn print_threads() {
     without_interrupts(|| {
         let sched = SCHEDULER.lock();

--- a/kernel/src/usermode.rs
+++ b/kernel/src/usermode.rs
@@ -21,11 +21,77 @@
 //! with every reference RIP-relative, so it runs correctly at an address it was
 //! not linked for.
 
+use spin::Mutex;
 use x86_64::structures::paging::PageTableFlags;
 
-use crate::memory::paging;
+use crate::memory::paging::{self, PHYSMAP_BASE};
 use crate::memory::PAGE_SIZE;
 use crate::serial_println;
+
+/// A boot module as GRUB placed it, copied out of the multiboot2 structure
+/// before that borrow ends.
+#[derive(Debug, Clone, Copy)]
+pub struct BootModule {
+    pub start: u64,
+    pub end: u64,
+}
+
+impl BootModule {
+    pub fn len(&self) -> usize {
+        (self.end - self.start) as usize
+    }
+
+    /// The module's bytes, viewed through the physmap.
+    ///
+    /// # Safety
+    /// Only valid after `paging::init`, and only while the frames remain
+    /// reserved — which `physical::reserve_boot_modules` guarantees.
+    pub unsafe fn bytes(&self) -> &'static [u8] {
+        core::slice::from_raw_parts((PHYSMAP_BASE + self.start) as *const u8, self.len())
+    }
+}
+
+const MAX_BOOT_MODULES: usize = 4;
+static BOOT_MODULES: Mutex<[Option<BootModule>; MAX_BOOT_MODULES]> =
+    Mutex::new([None; MAX_BOOT_MODULES]);
+
+/// Copy the module table out of the multiboot2 info.
+pub fn record_boot_modules(boot_info: &multiboot2::BootInformation) {
+    let mut slots = BOOT_MODULES.lock();
+    let mut n = 0;
+
+    for module in boot_info.module_tags() {
+        if n >= MAX_BOOT_MODULES {
+            serial_println!("  (ignoring boot modules beyond {})", MAX_BOOT_MODULES);
+            break;
+        }
+
+        let name = module.cmdline().unwrap_or("<no cmdline>");
+        slots[n] = Some(BootModule {
+            start: module.start_address() as u64,
+            end: module.end_address() as u64,
+        });
+
+        serial_println!(
+            "Boot module {}: 0x{:x}..0x{:x} ({} bytes) '{}'",
+            n,
+            module.start_address(),
+            module.end_address(),
+            module.end_address() - module.start_address(),
+            name
+        );
+        n += 1;
+    }
+
+    if n == 0 {
+        serial_println!("No boot modules supplied by the bootloader");
+    }
+}
+
+/// The nth boot module, if present.
+pub fn boot_module(index: usize) -> Option<BootModule> {
+    BOOT_MODULES.lock().get(index).copied().flatten()
+}
 
 /// Where the user blob is mapped. 1 GiB — clear of the kernel's low identity
 /// window and nowhere near the higher half.
@@ -126,7 +192,72 @@ pub fn run_user_demo(which: usize) {
     unsafe { enter_ring3(user_entry, stack_top) }
 }
 
+/// Load boot module 0 as an ELF and run it in ring 3.
+///
+/// This is the real path: a program the kernel was not compiled with, parsed
+/// out of an ELF, mapped at the addresses it was linked for, and entered.
+pub fn run_boot_module(_arg: usize) {
+    let Some(module) = boot_module(0) else {
+        serial_println!("No boot module to load — skipping ELF loader demo.");
+        serial_println!("  (add `module2 /boot/init` to grub.cfg)");
+        return;
+    };
+
+    serial_println!("Loading boot module 0 as ELF:");
+    let image = unsafe { module.bytes() };
+    crate::elf::describe(image);
+
+    let loaded = match unsafe { crate::elf::load(image) } {
+        Ok(l) => l,
+        Err(e) => {
+            serial_println!("  ELF load FAILED: {:?}", e);
+            return;
+        }
+    };
+
+    serial_println!(
+        "  loaded {} segment(s), {} bytes, entry 0x{:x}",
+        loaded.segments,
+        loaded.bytes_mapped,
+        loaded.entry
+    );
+
+    // A fresh stack, well clear of the image's own segments.
+    let stack_top = ELF_USER_STACK_TOP;
+    let stack_bottom = stack_top - (USER_STACK_PAGES * PAGE_SIZE) as u64;
+    let stack_flags = PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE;
+
+    if let Err(e) = paging::map_user_pages(stack_bottom, USER_STACK_PAGES, stack_flags) {
+        serial_println!("  failed to map stack for loaded image: {}", e);
+        return;
+    }
+    serial_println!(
+        "  stack          : 0x{:x}..0x{:x} (RW-, user, NX)",
+        stack_bottom,
+        stack_top
+    );
+
+    serial_println!("Entering loaded ELF in ring 3...");
+    serial_println!("--- loaded program output ---");
+
+    unsafe { enter_ring3(loaded.entry, stack_top) }
+}
+
+/// Stack for the ELF-loaded program. Separate from the built-in payload's, so
+/// the two demos cannot interfere.
+const ELF_USER_STACK_TOP: u64 = 0x0000_0000_6000_0000;
+
 /// Drop to ring 3 at `entry` with `stack_top`.
+///
+/// `stack_top` is passed through as RSP unchanged, so the contract with
+/// userspace is the System V one: **RSP is 16-byte aligned at process entry**.
+/// It is the program's `_start` that must then establish the call-boundary
+/// alignment its compiled code expects — which is exactly what a real crt0
+/// does, and what `userspace/hello` does. Getting this wrong shows up as a #GP
+/// on the first `movaps` spill, not as anything obviously stack-related.
 ///
 /// # Safety
 /// `entry` and `stack_top` must be mapped `USER_ACCESSIBLE`, and the GDT must

--- a/kernel/src/vga_buffer.rs
+++ b/kernel/src/vga_buffer.rs
@@ -106,6 +106,14 @@ impl Writer {
         self.column_position = 0;
     }
 
+    /// Blank the whole screen and put the cursor back at the top.
+    pub fn clear_screen(&mut self) {
+        for row in 0..BUFFER_HEIGHT {
+            self.clear_row(row);
+        }
+        self.column_position = 0;
+    }
+
     fn clear_row(&mut self, row: usize) {
         let blank = ScreenChar {
             ascii_character: b' ',
@@ -133,6 +141,17 @@ macro_rules! print {
 macro_rules! println {
     () => ($crate::print!("\n"));
     ($($arg:tt)*) => ($crate::print!("{}\n", format_args!($($arg)*)));
+}
+
+/// Blank the VGA text buffer.
+pub fn clear_screen() {
+    #[cfg(target_arch = "x86_64")]
+    x86_64::instructions::interrupts::without_interrupts(|| {
+        WRITER.lock().clear_screen();
+    });
+
+    #[cfg(not(target_arch = "x86_64"))]
+    WRITER.lock().clear_screen();
 }
 
 #[doc(hidden)]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,15 @@
 [toolchain]
+# Floating nightly. Bare-metal Rust needs nightly for `-Z build-std`, but that
+# also means an upstream change can break the build on a day you touched
+# nothing — which is exactly what happened when nightly added two required
+# methods to `Step` and the x86_64 crate's (feature-gated, now disabled)
+# impls stopped satisfying it.
+#
+# To stop that recurring, pin to a nightly you have seen pass. The CI job
+# prints the exact version it used ("toolchain in use"), so take the date from
+# a green run and put it here:
+#
+#     channel = "nightly-YYYY-MM-DD"
+#
 channel = "nightly"
-components = ["rust-src"]
+components = ["rust-src", "llvm-tools-preview"]

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -58,6 +58,18 @@ fi
 KERNEL="$ROOT/target/$TARGET_NAME/$PROFILE/kosh-kernel"
 [ -f "$KERNEL" ] || { echo "error: kernel binary not found at $KERNEL" >&2; exit 1; }
 
+# Userspace programs shipped as GRUB modules. These are ordinary static ELF
+# binaries; the kernel parses and maps them at run time.
+echo "==> building userspace programs"
+USER_FLAGS=(--package kosh-hello --target "$TARGET_JSON" -Z build-std=core)
+[ "$PROFILE" = "release" ] && USER_FLAGS+=(--release)
+cargo build "${USER_FLAGS[@]}" -Z json-target-spec 2>/dev/null \
+    || cargo build "${USER_FLAGS[@]}"
+
+HELLO="$ROOT/target/$TARGET_NAME/$PROFILE/kosh-hello"
+[ -f "$HELLO" ] || { echo "error: userspace binary not found at $HELLO" >&2; exit 1; }
+echo "==> $(basename "$HELLO"): $(readelf -h "$HELLO" | awk '/Entry point/ {print $4}')"
+
 # --- validate the multiboot2 header before we waste a boot ------------------
 
 if grub-file --is-x86-multiboot2 "$KERNEL"; then
@@ -76,6 +88,7 @@ echo "==> building ISO"
 rm -rf "$ISO_DIR"
 mkdir -p "$ISO_DIR/boot/grub"
 cp "$KERNEL" "$ISO_DIR/boot/kosh-kernel"
+cp "$HELLO" "$ISO_DIR/boot/init"
 
 cat > "$ISO_DIR/boot/grub/grub.cfg" <<'EOF'
 set timeout=0
@@ -83,6 +96,7 @@ set default=0
 
 menuentry "Kosh" {
     multiboot2 /boot/kosh-kernel
+    module2 /boot/init init
     boot
 }
 EOF
@@ -144,6 +158,10 @@ check)
         "ring 3 fault — terminating the process" \
         "Ring 3: PASS" \
         "kernel survived a ring 3 fault" \
+        "hello from a loaded ELF binary" \
+        ".bss was zeroed correctly" \
+        "stack is writable and readable" \
+        "ELF loader: PASS" \
         "Kernel initialization complete" \
         "uptime 1s"
     do

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -21,10 +21,11 @@ ISO="$BUILD_DIR/kosh.iso"
 
 MODE="run"
 case "${1:-}" in
-    --debug) MODE="debug" ;;
-    --check) MODE="check" ;;
-    "")      ;;
-    *)       echo "unknown option: $1" >&2; exit 2 ;;
+    --debug)     MODE="debug" ;;
+    --check)     MODE="check" ;;
+    --check-cli) MODE="check-cli" ;;
+    "")          ;;
+    *)           echo "unknown option: $1" >&2; exit 2 ;;
 esac
 
 # --- toolchain sanity -------------------------------------------------------
@@ -148,6 +149,7 @@ check)
         "PIC remapped" \
         "PIT channel 0" \
         "Interrupts enabled" \
+        "Timer: PASS" \
         "kernel page tables active" \
         "physmap aliases identity map: OK" \
         "page 0 unmapped: OK" \
@@ -163,7 +165,7 @@ check)
         "stack is writable and readable" \
         "ELF loader: PASS" \
         "Kernel initialization complete" \
-        "uptime 1s"
+        "console started on its own thread"
     do
         if grep -qF "$marker" "$SERIAL" 2>/dev/null; then
             echo "  PASS  $marker"
@@ -177,6 +179,89 @@ check)
         echo "  FAIL  triple fault in qemu.log"
         fail=1
     fi
+
+    exit $fail
+    ;;
+
+check-cli)
+    # Boot, then type at the console through QEMU's monitor and check what it
+    # answers. Nothing else in this repo exercises the keyboard IRQ, the line
+    # editor and the command table end to end — and a console that only a human
+    # can test is a console that silently rots.
+    SERIAL="$BUILD_DIR/serial-cli.txt"
+    rm -f "$SERIAL"
+    echo "==> console check"
+
+    # QEMU's `sendkey` speaks key names, not characters.
+    keyname() {
+        case "$1" in
+            " ") echo "spc" ;;
+            ".") echo "dot" ;;
+            "-") echo "minus" ;;
+            "/") echo "slash" ;;
+            [a-z0-9]) echo "$1" ;;
+            *) echo "" ;;
+        esac
+    }
+
+    type_line() {
+        local text="$1" i c k
+        for (( i=0; i<${#text}; i++ )); do
+            c="${text:$i:1}"
+            k="$(keyname "$c")"
+            [ -n "$k" ] && echo "sendkey $k"
+            # Deliberately unhurried. QEMU drops sendkeys if you push them
+            # faster than the guest drains the PS/2 controller, and a flaky
+            # console test is worse than a slow one.
+            sleep 0.04
+        done
+        sleep 0.2
+        echo "sendkey ret"
+        sleep 0.8
+    }
+
+    {
+        # Let the boot demos finish before typing.
+        sleep 12
+        type_line "uname"
+        type_line "mem"
+        type_line "ticks"
+        type_line "echo kosh cli works"
+        type_line "modules"
+        type_line "ps"
+        type_line "history"
+        type_line "nosuchcommand"
+        type_line "fault bp"
+        sleep 1
+        echo quit
+    } | timeout 90 qemu-system-x86_64 "${QEMU_ARGS[@]}" \
+            -serial "file:$SERIAL" -display none -monitor stdio >/dev/null 2>&1 || true
+
+    echo "--- console session ---"
+    sed -n '/Kosh console/,$p' "$SERIAL" 2>/dev/null | head -60
+    echo "-----------------------"
+
+    fail=0
+    for marker in \
+        "Kosh console" \
+        "kosh>" \
+        "Kosh 0.1.0 x86_64" \
+        "running in ring 0" \
+        "physical memory:" \
+        "kernel heap:" \
+        "kosh cli works" \
+        "module 0:" \
+        "context switches since boot" \
+        "unknown command: nosuchcommand" \
+        "resumed"
+    do
+        if grep -qF "$marker" "$SERIAL" 2>/dev/null; then
+            echo "  PASS  $marker"
+        else
+            echo "  FAIL  $marker"
+            fail=1
+        fi
+    done
 
     exit $fail
     ;;

--- a/userspace/hello/Cargo.toml
+++ b/userspace/hello/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "kosh-hello"
+version = "0.1.0"
+edition = "2021"
+
+# A deliberately tiny userspace program: no dependencies, no allocator, no
+# runtime. Its whole job is to be a real static ELF that the kernel's loader has
+# to parse, map and enter — so that when it prints, the loader is proven.
+
+[dependencies]
+
+[[bin]]
+name = "kosh-hello"
+path = "src/main.rs"

--- a/userspace/hello/build.rs
+++ b/userspace/hello/build.rs
@@ -1,0 +1,8 @@
+use std::path::PathBuf;
+
+fn main() {
+    let dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    println!("cargo:rustc-link-arg=-T{}", dir.join("user.ld").display());
+    println!("cargo:rerun-if-changed=user.ld");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/userspace/hello/src/main.rs
+++ b/userspace/hello/src/main.rs
@@ -1,0 +1,163 @@
+//! A minimal userspace program, loaded from an ELF module by the kernel.
+//!
+//! Unlike the Phase 5 payload — hand-written position-independent assembly that
+//! the kernel mapped wherever it liked — this is an ordinary Rust binary linked
+//! at a fixed address (see `user.ld`). It only runs if the loader actually
+//! parsed the ELF headers and honoured `p_vaddr`, so its output is evidence
+//! that the loader works rather than that a memcpy worked.
+//!
+//! It deliberately exercises three things the loader has to get right:
+//!
+//! * `.text` — executing at the linked address at all.
+//! * `.rodata` — string literals resolved through absolute addresses.
+//! * `.bss` — a zero-initialised static, which lives in `p_memsz` beyond
+//!   `p_filesz` and therefore exists only if the loader zeroed the tail.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+const SYS_EXIT: u64 = 1;
+const SYS_GETPID: u64 = 5;
+const SYS_WRITE: u64 = 23;
+
+/// Zero-initialised, so it occupies no space in the file. If the loader forgets
+/// to zero the gap between `p_filesz` and `p_memsz`, this reads as garbage.
+static mut BSS_CANARY: [u64; 64] = [0; 64];
+
+#[inline(always)]
+unsafe fn syscall3(number: u64, a1: u64, a2: u64, a3: u64) -> i64 {
+    let ret: i64;
+    core::arch::asm!(
+        "syscall",
+        inlateout("rax") number => ret,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        // The instruction clobbers these; the compiler has to know.
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack)
+    );
+    ret
+}
+
+fn write(fd: u64, bytes: &[u8]) -> i64 {
+    unsafe { syscall3(SYS_WRITE, fd, bytes.as_ptr() as u64, bytes.len() as u64) }
+}
+
+fn getpid() -> i64 {
+    unsafe { syscall3(SYS_GETPID, 0, 0, 0) }
+}
+
+fn exit(code: u64) -> ! {
+    unsafe { syscall3(SYS_EXIT, code, 0, 0) };
+    // The kernel does not return from exit, but the type system does not know.
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+fn print(s: &str) {
+    write(1, s.as_bytes());
+}
+
+/// Print a signed integer without an allocator or `core::fmt`.
+fn print_i64(mut value: i64) {
+    let mut buf = [0u8; 24];
+    let mut i = buf.len();
+
+    let negative = value < 0;
+    if negative {
+        value = -value;
+    }
+
+    if value == 0 {
+        i -= 1;
+        buf[i] = b'0';
+    }
+    while value > 0 {
+        i -= 1;
+        buf[i] = b'0' + (value % 10) as u8;
+        value /= 10;
+    }
+    if negative {
+        i -= 1;
+        buf[i] = b'-';
+    }
+
+    write(1, &buf[i..]);
+}
+
+// The process entry point.
+//
+// System V says RSP is 16-byte aligned when the kernel enters a new process.
+// But a Rust `extern "C"` function is compiled as an ordinary callee, so LLVM
+// assumes RSP is 8 *past* a 16-byte boundary — the state left by a `call`. Wire
+// a Rust function straight to the entry point and its first SSE spill
+// (`movaps`, which requires 16-byte alignment) faults with #GP.
+//
+// So `_start` is asm, exactly like a real crt0: normalise the alignment, then
+// `call` the Rust entry so it sees the boundary it was compiled for.
+core::arch::global_asm!(
+    r#"
+.section .text._start, "ax"
+.global _start
+.type _start, @function
+_start:
+    xorq    %rbp, %rbp          /* end of the frame-pointer chain */
+    andq    $-16, %rsp          /* System V: 16-byte aligned at process entry */
+    call    kosh_main           /* ...and `call` makes it 8 past, as ABI wants */
+1:
+    jmp     1b                  /* kosh_main does not return */
+"#,
+    options(att_syntax)
+);
+
+#[no_mangle]
+pub extern "C" fn kosh_main() -> ! {
+    print("hello from a loaded ELF binary\n");
+
+    print("  my pid is ");
+    print_i64(getpid());
+    print("\n");
+
+    // .bss check: every byte should be zero because the loader zeroed it, not
+    // because anything in the file said so.
+    let mut nonzero = 0usize;
+    for i in 0..64 {
+        if unsafe { core::ptr::read_volatile(&raw const BSS_CANARY[i]) } != 0 {
+            nonzero += 1;
+        }
+    }
+    if nonzero == 0 {
+        print("  .bss was zeroed correctly\n");
+    } else {
+        print("  WARNING: .bss contains garbage\n");
+    }
+
+    // Stack check: the kernel has to have given us a mapped, writable stack.
+    let mut on_stack = [0u64; 32];
+    for (i, slot) in on_stack.iter_mut().enumerate() {
+        *slot = (i as u64) * 7 + 1;
+    }
+    let mut sum = 0u64;
+    for slot in on_stack.iter() {
+        sum += unsafe { core::ptr::read_volatile(slot) };
+    }
+    if sum == (0..32u64).map(|i| i * 7 + 1).sum() {
+        print("  stack is writable and readable\n");
+    } else {
+        print("  WARNING: stack check failed\n");
+    }
+
+    print("  exiting cleanly\n");
+    exit(0)
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    print("userspace panic\n");
+    exit(1)
+}

--- a/userspace/hello/user.ld
+++ b/userspace/hello/user.ld
@@ -1,0 +1,21 @@
+/* Link userspace programs at 4 MiB.
+ *
+ * Clear of the kernel's low identity window (which ends around 4 MiB) and far
+ * below the higher half. The ELF loader honours p_vaddr, so this is where the
+ * program genuinely runs — unlike the Phase 5 payload, which was
+ * position-independent assembly mapped wherever we liked.
+ */
+
+ENTRY(_start)
+
+SECTIONS
+{
+    . = 0x400000;
+
+    .text ALIGN(4K) : { *(.text .text.*) }
+    .rodata ALIGN(4K) : { *(.rodata .rodata.*) }
+    .data ALIGN(4K) : { *(.data .data.*) }
+    .bss ALIGN(4K) : { *(COMMON) *(.bss .bss.*) }
+
+    /DISCARD/ : { *(.comment) *(.eh_frame) *(.eh_frame_hdr) *(.note .note.*) }
+}

--- a/userspace/init/Cargo.toml
+++ b/userspace/init/Cargo.toml
@@ -7,9 +7,3 @@ edition = "2021"
 kosh-types = { path = "../../shared/kosh-types" }
 kosh-ipc = { path = "../../shared/kosh-ipc" }
 linked_list_allocator = "0.10"
-
-[profile.dev]
-panic = "abort"
-
-[profile.release]
-panic = "abort"


### PR DESCRIPTION
## Summary

Three commits. The first unbreaks CI; the other two are Phases 6 and 7 of the roadmap — loading programs from disk, and a console you can actually type at.

```
kosh> uname
Kosh 0.1.0 x86_64
  microkernel, Rust, multiboot2
  running in ring 0
  CR3            0x176000
  physmap base   0xffff800000000000
  heap base      0xffff900000000000
  timer          100 Hz
kosh> ps
2 thread(s):
   id  name         state        ticks
    0  kmain        ready          642
    1  console      running        616

661 context switches since boot
kosh> uptime
up 0h 0m 14s (14690 ms, 1469 ticks at 100 Hz)
```

25 boot markers and 11 console markers pass, from a clean rebuild.

---

## 1. `ci:` stop depending on the x86_64 crate's `step_trait` feature

CI broke with no change on our side:

```
error[E0046]: not all trait items implemented, missing:
  `forward_overflowing`, `backward_overflowing`
  --> x86_64-0.14.13/src/addr.rs:386:1  impl Step for VirtAddr
```

Nightly added two required methods to the unstable `Step` trait, and `x86_64 0.14.13` implements `Step` for `VirtAddr` and `Page`. Those impls are behind the crate's `step_trait` feature, which its default `nightly` bundle pulls in — and this kernel never iterates page ranges, so `Step` was never used here.

Turning off default features and re-listing what we actually use drops it. `const_fn`, the third feature `nightly` bundles, is left off too: the kernel builds without it, and it gates `feature(const_mut_refs)` — one more unstable dependency that can rot the same way. Verified by building with it removed.

Also: `rust-toolchain.toml` now explains the drift risk and how to pin, CI prints `rustc --version --verbose` so the nightly of a green run is recoverable, and the `[profile.*]` sections are gone from `kernel/` and `userspace/init/` (cargo ignores profiles in non-root packages and warned about them on every build).

## 2. `kernel:` load and run a static ELF from a GRUB module

The kernel could only run code it had been compiled with. There was no ELF loader anywhere — the only mentions were comments — `sys_exec` returned `NotSupported`, and `grub.cfg` had no `module2` line.

`kernel/src/elf.rs` parses static `ET_EXEC` ELF64: walk the program headers, map each `PT_LOAD` at its `p_vaddr` with permissions from `p_flags`, copy `p_filesz` bytes, leave the rest zero.

Segments are populated **through the physmap**, not through the mapping being created, so a read-only segment never has to be temporarily writable just to be filled in. `map_user_pages` already zeroes each frame, which makes the `.bss` tail correct for free.

Two things about GRUB modules that are easy to get wrong, both fixed here:

- **The frames must be reserved before the allocator starts.** The memory map reports them as available, because from the firmware's point of view they are. Without this the first allocation lands on top of the binary you are about to load.
- **A module can land outside the low identity window**, so its bytes are read through the physmap rather than by physical address.

`userspace/hello` is the payload: an ordinary Rust binary linked at 4 MiB, not position-independent assembly. It only runs if the loader honoured `p_vaddr`, and it self-checks the three things the loader has to get right — executing at the linked address, resolving `.rodata` through absolute addresses, and reading a `.bss` static that exists only because the loader zeroed the tail.

```
  ELF: type 2 machine 0x3e, entry 0x400000, 4 program headers
  segment: vaddr 0x400000 filesz 2908 memsz 2908 [r-x] -> 1 page(s)
  segment: vaddr 0x401000 filesz  202 memsz  202 [r--] -> 1 page(s)
  segment: vaddr 0x402000 filesz    0 memsz  512 [rw-] -> 1 page(s)
--- loaded program output ---
hello from a loaded ELF binary
  my pid is 1
  .bss was zeroed correctly
  stack is writable and readable
```

**A bug worth knowing about.** The program's `_start` is assembly, exactly like a real crt0. System V says RSP is 16-byte aligned at process entry, but a Rust `extern "C"` function is compiled as an ordinary callee and assumes RSP is 8 *past* a boundary — the state a `call` leaves. Wiring Rust straight to the entry point makes the first `movaps` spill fault with `#GP`. That is what happened on the first run, and the symptom (a `#GP` deep inside integer formatting) points nowhere near the cause.

Also gates per-syscall tracing behind a flag, default off. A program that writes one character at a time produces two log lines per keystroke, interleaved with its own output on the same line. Failures are still always reported: a syscall that fails is news, one that works is not.

## 3. `kernel:` an interactive console

Kosh had no way to answer a question. Every diagnostic was a `serial_println!` fixed at compile time, printed once during boot, in an order nobody chose.

`kernel/src/console/` is an in-kernel shell — `editor.rs` for line editing (insert and delete anywhere, cursor movement, Home/End, a 32-entry history ring on the arrow keys) and `commands.rs` for the command table. Fixed-size buffers throughout; a console that cannot fail is worth more than one with unbounded lines.

Every command reports live kernel state or performs a real action:

| | |
|---|---|
| `mem`, `free` | frame allocator and heap statistics |
| `ps`, `threads` | the thread table and context-switch count |
| `translate <hex>` | walks the real page tables |
| `uname` | reads CR3 and the current ring out of the hardware |
| `uptime`, `ticks` | the timer |
| `modules` | boot modules |
| `syscalls`, `trace on\|off` | syscall count and tracing |
| `fault null\|page\|bp` | deliberately raise one |
| `history`, `echo`, `clear`, `heartbeat`, `reboot` | |

**There is deliberately no `ls`, `cat` or `cd`.** There is no filesystem, and inventing commands that return plausible-looking strings is the exact habit that let this project accumulate 27 commits of code that had never run.

**Why in-kernel, in a microkernel.** A kernel you can interrogate while it is running is worth more than architectural purity at this stage, and serious kernels keep a debug console permanently even after userspace exists. The userspace shell is still the goal — it needs a blocking read syscall and a filesystem to be worth using, and this is what lets you inspect the kernel while building those.

The console runs on its own kernel thread, so the scheduler stays live while it blocks on the keyboard: ticks keep arriving, other threads keep running, and a wedged console does not wedge the machine.

### Supporting changes

- The keyboard ring carries a `Key` enum rather than a byte. A line editor has to tell an arrow key from the character it would otherwise be conflated with, and squeezing cursor keys into spare ASCII control codes works right up until something wants to type one of those codes.
- The tick heartbeat is off once the console starts — a line appearing in the middle of what you are typing makes the console unusable. `heartbeat on` brings it back.
- Boot now asserts the timer directly (sleep 50 ms, check the counter moved) instead of waiting for a heartbeat line. The old signal stopped being reliable the moment the console started before the first second elapsed.
- `vga_buffer` gained a real `clear_screen`, and `task` a `snapshot` so callers can render the thread table themselves — `print_threads` only wrote to serial, so `ps` printed nothing on the screen.
- **Fixed a heap statistics underflow.** `allocate` charged the requested size while `deallocate` credited the block's actual size, and those differ after the alignment carve and the split. `current_bytes` drifted down until it wrapped, and `peak_bytes` latched onto the wrapped value. The console reporting a peak of 18446744073709551568 bytes is how it was noticed — which is rather the point of having one.

## Testing

```bash
./scripts/run.sh --check       # 25 boot markers
./scripts/run.sh --check-cli   # 11 console markers
```

`--check-cli` boots, types at the `kosh>` prompt through QEMU's monitor, and asserts what the console answers. Both run in CI. A console only a human can test is a console that rots quietly.

## Deliberately still missing

- **No filesystem and no storage driver** — which is why there is no `ls`.
- **No `fork`/`exec`**, so `userspace/init` cannot do its job yet and the ELF payload is `userspace/hello`.
- **One address space.** Loaded programs share the kernel's page tables; they are protected by page permissions, not separation. Per-process address spaces come with `fork`.
- **One ring-3 thread at a time.** The syscall path uses a single static kernel stack, safe only because `SFMASK` masks IF and nothing else is in user mode. Several user threads need `swapgs` and per-CPU data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1GdpYMiKP5Gj1Jmub59gw
