### PR TITLE
A disk driver and a FAT32 filesystem: ls, cat and cd for real

### DIFF
--- a/.github/workflows/boot.yml
+++ b/.github/workflows/boot.yml
@@ -29,11 +29,11 @@ jobs:
           rustc --version --verbose
           cargo --version
 
-      - name: Install GRUB and QEMU
+      - name: Install GRUB, QEMU and filesystem tools
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y --no-install-recommends \
-            qemu-system-x86 grub-pc-bin grub-common xorriso mtools
+            qemu-system-x86 grub-pc-bin grub-common xorriso mtools dosfstools
 
       - name: Cache cargo
         uses: actions/cache@v4

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -501,8 +501,92 @@ Boots, types at the `kosh>` prompt through QEMU's monitor, and asserts what the
 console answers. Both checks run in CI. A console only a human can test is a
 console that rots quietly.
 
+## Storage and a filesystem (Phase 8)
+
+```
+kosh:/> df
+FAT32 'KOSHDISK', 64 MB, 512 B/cluster, 2 FAT(s) of 1009 sectors, root at cluster 2
+kosh:/> ls
+drw         -  DOCS
+-rw       199  README.TXT
+-rw     22000  BIG.TXT
+-rw        26  A Long File Name.txt
+
+6 entries, 22280 bytes
+kosh:/> cat lines.txt
+line one
+line two
+line three
+kosh:/> cd docs
+kosh:/docs> ls
+-rw        26  NOTES.TXT
+```
+
+| File | Role |
+|---|---|
+| `block/ata.rs` | Polled PIO driver for the legacy IDE ports |
+| `block/mod.rs` | `BlockDevice` trait and the registered device |
+| `fs/fat32.rs` | FAT32, read-only: mount, chain walk, directories, long names, file reads |
+| `fs/mod.rs` | The mounted volume, and a self-test against the known test image |
+
+### Why PIO, and why FAT32
+
+**Polled PIO on the legacy ports** rather than DMA over PCI. It is the smallest
+thing that really reads a disk: no PCI enumeration, no interrupt plumbing, no
+bus-master buffers. It is also slow — one 16-bit port read per two bytes with the
+CPU spinning on a status register — which is fine for reading a filesystem and
+wrong for anything performance-sensitive. DMA and virtio-blk are for later.
+
+**FAT32 rather than ext4.** `userspace/fs-service/src/ext4.rs` already claims to
+implement ext4, and is instructive about why: `read_block` fills the buffer with
+zeroes, `write_block` returns success without writing, the superblock is
+fabricated in code, `mtime` is the literal `1234567890`, and `read_dir` returns
+only `.` and `..`. It was never connected to a disk, because there was no disk
+driver. FAT32 is a few hundred lines to read correctly, and the image can be
+mounted on the development host — so every answer the kernel gives is checkable
+against what is actually on the disk. ext4 is a lot of surface area to get wrong
+silently.
+
+### Things that cost time
+
+- **The test disk is bootable, and that broke everything.** `mkfs.vfat` writes a
+  `0xAA55` signature at offset 510, so SeaBIOS considered the FAT image bootable,
+  tried it before the CD, and hung — producing *no serial output at all*, which
+  looks exactly like a kernel that failed to start. `-boot order=d` fixes it.
+- **Validate the BPB before doing arithmetic with it.** A corrupt or hostile
+  boot sector otherwise turns directly into out-of-range reads. `mount` checks
+  sector size, cluster size, FAT count and region sizes, and rejects a root
+  cluster past the end of the volume.
+- **FAT32 is identified by `root_entry_count == 0` and `sectors_per_fat_16 == 0`**,
+  not by the filesystem-type string, which is informational and routinely wrong.
+- **Mask the top four bits of a FAT entry.** They are reserved. A free (`0`) or
+  out-of-range entry found *inside* a chain means the FAT is damaged, and saying
+  so beats reading whatever sector that implies.
+- **A zero-length file has no cluster allocated**, so the chain walk must not be
+  attempted on it.
+- **Long filenames were passing without being tested.** Every name on the first
+  test image (`DOCS`, `README.TXT`) is a valid 8.3 short name, so the ~80 lines
+  of long-filename assembly never ran. The image now contains
+  `A Long File Name.txt`, and the self-test asserts both that it lists and that
+  it opens by that name.
+
+### The self-test
+
+`fs::selftest` runs at boot and asserts against facts `scripts/run.sh`
+guarantees when it builds the image: a file whose exact contents it controls, a
+22 KB file that forces a cluster-chain walk, a subdirectory, a long filename, and
+a path that must report `NotFound`. A filesystem that returned an empty root
+without complaining would otherwise look like a pass.
+
 ## What is deliberately still missing
-- **No filesystem, and no storage driver.** Which is why there is no `ls`.
+- **The filesystem is read-only.** Allocating clusters and keeping both FAT
+  copies consistent is a separate problem, and a read-only filesystem that is
+  correct beats a read-write one that is not.
+- **No partition table support.** The BPB is read from LBA 0, so the image is a
+  bare filesystem rather than a partitioned disk.
+- **The VFS is still unwired.** `userspace/fs-service/src/vfs.rs` has a mount
+  table; it has never had a real filesystem underneath it, and connecting the
+  two is separate work from making FAT32 correct.
 - **No `fork`/`exec`.** `userspace/init` cannot do its job until those exist, so
   the ELF payload is `userspace/hello` rather than init.
 - **One address space.** Loaded programs share the kernel's page tables; they

--- a/kernel/src/block/ata.rs
+++ b/kernel/src/block/ata.rs
@@ -1,0 +1,334 @@
+//! ATA PIO driver for the legacy IDE interface.
+//!
+//! Polled PIO rather than DMA, and the fixed legacy port addresses rather than
+//! PCI enumeration. Both are deliberate: it is the smallest thing that really
+//! reads a disk, it needs no PCI, no interrupt plumbing and no bus-master
+//! buffers, and every emulator and every PC chipset since 1990 supports it.
+//!
+//! It is also slow — one 16-bit port read per two bytes, with the CPU spinning
+//! on a status register. That is fine for reading a filesystem at boot and
+//! wrong for anything performance-sensitive, which is what DMA and a real
+//! virtio-blk driver are for later.
+//!
+//! LBA28 addressing, so 128 GiB is the ceiling. LBA48 is a different command
+//! and an extra round of register writes; nothing here needs it yet.
+
+use x86_64::instructions::port::{Port, PortReadOnly, PortWriteOnly};
+
+use super::{BlockDevice, BlockError, BLOCK_SIZE};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Channel {
+    Primary,
+    Secondary,
+}
+
+impl Channel {
+    /// Base of the command register block.
+    const fn io_base(self) -> u16 {
+        match self {
+            Channel::Primary => 0x1F0,
+            Channel::Secondary => 0x170,
+        }
+    }
+
+    /// Base of the control register block, which holds the alternate status
+    /// register. Reading *that* does not acknowledge an interrupt, which is why
+    /// it is the one to use for delays.
+    const fn control_base(self) -> u16 {
+        match self {
+            Channel::Primary => 0x3F6,
+            Channel::Secondary => 0x376,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Drive {
+    Master,
+    Slave,
+}
+
+impl Drive {
+    const fn select_bit(self) -> u8 {
+        match self {
+            Drive::Master => 0x00,
+            Drive::Slave => 0x10,
+        }
+    }
+}
+
+// Status register bits.
+const STATUS_ERR: u8 = 0x01;
+const STATUS_DRQ: u8 = 0x08;
+const STATUS_DF: u8 = 0x20;
+const STATUS_DRDY: u8 = 0x40;
+const STATUS_BSY: u8 = 0x80;
+
+const CMD_READ_SECTORS: u8 = 0x20;
+const CMD_WRITE_SECTORS: u8 = 0x30;
+const CMD_FLUSH_CACHE: u8 = 0xE7;
+const CMD_IDENTIFY: u8 = 0xEC;
+
+/// Spin limit while waiting on the drive. Generous: a real spinning disk can
+/// take tens of milliseconds to answer, and this loop is only entered at boot
+/// and during filesystem reads.
+const POLL_LIMIT: u32 = 10_000_000;
+
+pub struct AtaDisk {
+    channel: Channel,
+    drive: Drive,
+    blocks: u64,
+    model: [u8; 41],
+    name: [u8; 8],
+}
+
+impl AtaDisk {
+    /// Look for a drive and read its parameters with IDENTIFY.
+    pub fn probe(channel: Channel, drive: Drive) -> Result<Self, BlockError> {
+        let io = channel.io_base();
+
+        unsafe {
+            // A floating bus reads back 0xFF: nothing is driving the lines, so
+            // there is no controller here at all. Checking this first avoids
+            // spinning POLL_LIMIT times on a channel that does not exist.
+            let status: u8 = PortReadOnly::<u8>::new(io + 7).read();
+            if status == 0xFF {
+                return Err(BlockError::NoDevice);
+            }
+
+            // Select the drive, and zero the LBA registers — a drive that is
+            // present will leave them zero, while an ATAPI device signs them.
+            PortWriteOnly::<u8>::new(io + 6).write(0xA0 | drive.select_bit());
+            PortWriteOnly::<u8>::new(io + 2).write(0);
+            PortWriteOnly::<u8>::new(io + 3).write(0);
+            PortWriteOnly::<u8>::new(io + 4).write(0);
+            PortWriteOnly::<u8>::new(io + 5).write(0);
+
+            PortWriteOnly::<u8>::new(io + 7).write(CMD_IDENTIFY);
+
+            // Status 0 after IDENTIFY means no drive.
+            let status: u8 = PortReadOnly::<u8>::new(io + 7).read();
+            if status == 0 {
+                return Err(BlockError::NoDevice);
+            }
+
+            Self::wait_not_busy(channel)?;
+
+            // Non-zero LBA mid/high here means an ATAPI or SATA device replying
+            // to a command it does not implement. Reading it as a disk would
+            // produce garbage.
+            let lba_mid: u8 = PortReadOnly::<u8>::new(io + 4).read();
+            let lba_high: u8 = PortReadOnly::<u8>::new(io + 5).read();
+            if lba_mid != 0 || lba_high != 0 {
+                return Err(BlockError::NoDevice);
+            }
+
+            Self::wait_ready_for_data(channel)?;
+
+            // IDENTIFY returns 256 little-endian words.
+            let mut data = [0u16; 256];
+            let mut port: Port<u16> = Port::new(io);
+            for word in data.iter_mut() {
+                *word = port.read();
+            }
+
+            // Words 60..61 hold the LBA28 sector count.
+            let blocks = (data[60] as u64) | ((data[61] as u64) << 16);
+            if blocks == 0 {
+                return Err(BlockError::NoDevice);
+            }
+
+            // Words 27..46 hold the model string, byte-swapped within each word.
+            let mut model = [0u8; 41];
+            for i in 0..20 {
+                let w = data[27 + i];
+                model[i * 2] = (w >> 8) as u8;
+                model[i * 2 + 1] = (w & 0xFF) as u8;
+            }
+            // Trim the trailing padding the standard mandates.
+            let mut end = 40;
+            while end > 0 && (model[end - 1] == b' ' || model[end - 1] == 0) {
+                end -= 1;
+            }
+            model[end] = 0;
+
+            let name = match (channel, drive) {
+                (Channel::Primary, Drive::Master) => *b"hda\0\0\0\0\0",
+                (Channel::Primary, Drive::Slave) => *b"hdb\0\0\0\0\0",
+                (Channel::Secondary, Drive::Master) => *b"hdc\0\0\0\0\0",
+                (Channel::Secondary, Drive::Slave) => *b"hdd\0\0\0\0\0",
+            };
+
+            Ok(Self {
+                channel,
+                drive,
+                blocks,
+                model,
+                name,
+            })
+        }
+    }
+
+    pub fn model(&self) -> &str {
+        let end = self.model.iter().position(|&b| b == 0).unwrap_or(40);
+        core::str::from_utf8(&self.model[..end]).unwrap_or("<unreadable>")
+    }
+
+    /// Read the alternate status register four times: ~400 ns, which is what the
+    /// specification requires between selecting a drive and trusting its status.
+    ///
+    /// The *alternate* status register specifically — reading the ordinary one
+    /// acknowledges a pending interrupt, which is not what a delay should do.
+    fn delay_400ns(channel: Channel) {
+        let mut port: PortReadOnly<u8> = PortReadOnly::new(channel.control_base());
+        for _ in 0..4 {
+            unsafe {
+                let _ = port.read();
+            }
+        }
+    }
+
+    fn status(channel: Channel) -> u8 {
+        unsafe {
+            let mut port: PortReadOnly<u8> = PortReadOnly::new(channel.io_base() + 7);
+            port.read()
+        }
+    }
+
+    fn wait_not_busy(channel: Channel) -> Result<(), BlockError> {
+        for _ in 0..POLL_LIMIT {
+            let status = Self::status(channel);
+            if status & STATUS_BSY == 0 {
+                return Ok(());
+            }
+        }
+        Err(BlockError::Timeout)
+    }
+
+    /// Wait until the drive has data for us, distinguishing "not yet" from
+    /// "failed". Returning Timeout for a drive that has actually set ERR would
+    /// send whoever is debugging in the wrong direction.
+    fn wait_ready_for_data(channel: Channel) -> Result<(), BlockError> {
+        for _ in 0..POLL_LIMIT {
+            let status = Self::status(channel);
+
+            if status & (STATUS_ERR | STATUS_DF) != 0 {
+                return Err(BlockError::DeviceError);
+            }
+            if status & STATUS_BSY == 0 && status & STATUS_DRQ != 0 {
+                return Ok(());
+            }
+        }
+        Err(BlockError::Timeout)
+    }
+
+    fn wait_ready(channel: Channel) -> Result<(), BlockError> {
+        for _ in 0..POLL_LIMIT {
+            let status = Self::status(channel);
+
+            if status & (STATUS_ERR | STATUS_DF) != 0 {
+                return Err(BlockError::DeviceError);
+            }
+            if status & STATUS_BSY == 0 && status & STATUS_DRDY != 0 {
+                return Ok(());
+            }
+        }
+        Err(BlockError::Timeout)
+    }
+
+    /// Program the LBA registers and issue `command` for `count` sectors.
+    fn issue(&self, lba: u64, count: u8, command: u8) -> Result<(), BlockError> {
+        let io = self.channel.io_base();
+
+        Self::wait_not_busy(self.channel)?;
+
+        unsafe {
+            // 0xE0 selects LBA mode; the low nibble carries LBA bits 24..27.
+            PortWriteOnly::<u8>::new(io + 6)
+                .write(0xE0 | self.drive.select_bit() | (((lba >> 24) & 0x0F) as u8));
+            PortWriteOnly::<u8>::new(io + 1).write(0); // features
+            PortWriteOnly::<u8>::new(io + 2).write(count);
+            PortWriteOnly::<u8>::new(io + 3).write((lba & 0xFF) as u8);
+            PortWriteOnly::<u8>::new(io + 4).write(((lba >> 8) & 0xFF) as u8);
+            PortWriteOnly::<u8>::new(io + 5).write(((lba >> 16) & 0xFF) as u8);
+
+            Self::delay_400ns(self.channel);
+            PortWriteOnly::<u8>::new(io + 7).write(command);
+        }
+
+        Ok(())
+    }
+}
+
+impl BlockDevice for AtaDisk {
+    fn name(&self) -> &str {
+        let end = self.name.iter().position(|&b| b == 0).unwrap_or(3);
+        core::str::from_utf8(&self.name[..end]).unwrap_or("hd?")
+    }
+
+    fn block_count(&self) -> u64 {
+        self.blocks
+    }
+
+    fn read_blocks(&self, lba: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        if buf.len() % BLOCK_SIZE != 0 {
+            return Err(BlockError::BadBufferSize);
+        }
+        let sectors = buf.len() / BLOCK_SIZE;
+        if sectors == 0 {
+            return Ok(());
+        }
+        if lba + sectors as u64 > self.blocks {
+            return Err(BlockError::OutOfRange);
+        }
+
+        // One sector at a time. A multi-sector transfer is faster, but it makes
+        // error recovery ambiguous — the drive can fail partway and there is no
+        // clean way to say which sector — and correctness matters more here.
+        for (i, chunk) in buf.chunks_mut(BLOCK_SIZE).enumerate() {
+            self.issue(lba + i as u64, 1, CMD_READ_SECTORS)?;
+            Self::wait_ready_for_data(self.channel)?;
+
+            let mut port: Port<u16> = Port::new(self.channel.io_base());
+            for pair in chunk.chunks_mut(2) {
+                let word = unsafe { port.read() };
+                pair[0] = (word & 0xFF) as u8;
+                pair[1] = (word >> 8) as u8;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn write_blocks(&self, lba: u64, buf: &[u8]) -> Result<(), BlockError> {
+        if buf.len() % BLOCK_SIZE != 0 {
+            return Err(BlockError::BadBufferSize);
+        }
+        let sectors = buf.len() / BLOCK_SIZE;
+        if sectors == 0 {
+            return Ok(());
+        }
+        if lba + sectors as u64 > self.blocks {
+            return Err(BlockError::OutOfRange);
+        }
+
+        for (i, chunk) in buf.chunks(BLOCK_SIZE).enumerate() {
+            self.issue(lba + i as u64, 1, CMD_WRITE_SECTORS)?;
+            Self::wait_ready_for_data(self.channel)?;
+
+            let mut port: Port<u16> = Port::new(self.channel.io_base());
+            for pair in chunk.chunks(2) {
+                let word = (pair[0] as u16) | ((pair[1] as u16) << 8);
+                unsafe { port.write(word) };
+            }
+        }
+
+        // Without a cache flush the drive may acknowledge writes it has not
+        // committed, and a reset loses them.
+        self.issue(lba, 1, CMD_FLUSH_CACHE)?;
+        Self::wait_ready(self.channel)?;
+
+        Ok(())
+    }
+}

--- a/kernel/src/block/mod.rs
+++ b/kernel/src/block/mod.rs
@@ -1,0 +1,105 @@
+//! Block devices.
+//!
+//! A filesystem should not know what kind of disk it is sitting on, and a disk
+//! driver should not know what is stored on it. [`BlockDevice`] is the seam.
+//!
+//! `drivers/storage` already declared a `KoshDriver` trait for this, but its
+//! `init` set a boolean, its `handle_request` returned an empty success, and the
+//! whole file was 76 lines with no port I/O and no PCI. This is the first code
+//! in the project that actually moves bytes off a disk.
+
+pub mod ata;
+
+use alloc::boxed::Box;
+use spin::Mutex;
+
+/// Bytes per block. 512 everywhere this kernel cares about.
+pub const BLOCK_SIZE: usize = 512;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockError {
+    /// No device present at that address.
+    NoDevice,
+    /// The drive reported an error for this request.
+    DeviceError,
+    /// The drive did not become ready in time.
+    Timeout,
+    /// Request runs past the end of the device.
+    OutOfRange,
+    /// Buffer length is not a whole number of blocks.
+    BadBufferSize,
+    /// The device is read-only.
+    ReadOnly,
+}
+
+pub trait BlockDevice: Send + Sync {
+    /// Human-readable identification, for `lsblk`-ish output.
+    fn name(&self) -> &str;
+
+    /// Total addressable blocks.
+    fn block_count(&self) -> u64;
+
+    /// Read `buf.len() / BLOCK_SIZE` blocks starting at `lba`.
+    fn read_blocks(&self, lba: u64, buf: &mut [u8]) -> Result<(), BlockError>;
+
+    /// Write blocks. Default implementation refuses, so a read-only device does
+    /// not have to pretend.
+    fn write_blocks(&self, _lba: u64, _buf: &[u8]) -> Result<(), BlockError> {
+        Err(BlockError::ReadOnly)
+    }
+
+    /// Convenience: read exactly one block.
+    fn read_block(&self, lba: u64, buf: &mut [u8; BLOCK_SIZE]) -> Result<(), BlockError> {
+        self.read_blocks(lba, buf)
+    }
+}
+
+/// The system's block device. One is enough for now; a real device list arrives
+/// with PCI enumeration.
+static DEVICE: Mutex<Option<Box<dyn BlockDevice>>> = Mutex::new(None);
+
+pub fn register(device: Box<dyn BlockDevice>) {
+    *DEVICE.lock() = Some(device);
+}
+
+pub fn is_present() -> bool {
+    DEVICE.lock().is_some()
+}
+
+/// Run `f` against the registered device, if there is one.
+pub fn with_device<T>(f: impl FnOnce(&dyn BlockDevice) -> T) -> Option<T> {
+    let guard = DEVICE.lock();
+    guard.as_ref().map(|d| f(d.as_ref()))
+}
+
+/// Read one block from the registered device.
+pub fn read_block(lba: u64, buf: &mut [u8; BLOCK_SIZE]) -> Result<(), BlockError> {
+    with_device(|d| d.read_block(lba, buf)).unwrap_or(Err(BlockError::NoDevice))
+}
+
+/// Read a run of blocks from the registered device.
+pub fn read_blocks(lba: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+    with_device(|d| d.read_blocks(lba, buf)).unwrap_or(Err(BlockError::NoDevice))
+}
+
+/// Probe for disks and register the first one found.
+pub fn init() {
+    crate::serial_println!("Probing for block devices...");
+
+    match ata::AtaDisk::probe(ata::Channel::Primary, ata::Drive::Master) {
+        Ok(disk) => {
+            crate::serial_println!(
+                "  {}: {} blocks ({} MB), {}",
+                disk.name(),
+                disk.block_count(),
+                disk.block_count() * BLOCK_SIZE as u64 / (1024 * 1024),
+                disk.model()
+            );
+            register(Box::new(disk));
+        }
+        Err(e) => {
+            crate::serial_println!("  no ATA disk on the primary channel ({:?})", e);
+            crate::serial_println!("  (attach one with -drive file=disk.img,format=raw,if=ide,index=0,media=disk)");
+        }
+    }
+}

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -53,6 +53,11 @@ pub fn init_kernel(boot_info: BootInformation) {
     // Initialize virtual memory management bookkeeping
     init_virtual_memory();
     
+    // Storage. Needs the heap (the device is boxed), nothing else.
+    crate::block::init();
+    init_storage_selftest();
+    crate::fs::init();
+    
     // DISABLED (Phase 1): init_swap_management() allocates an 8 MiB Vec as a
     // "swap file" out of a 1 MiB kernel heap whose MAX_ALLOC_SIZE is 1 MiB.
     // It cannot succeed. Re-enable once there is a real block device.
@@ -683,6 +688,44 @@ fn test_virtual_memory() {
     }
     
     serial_println!("Virtual memory management test complete");
+}
+
+/// Read the first sector and check it looks like something.
+///
+/// The point is to prove the ATA driver moves real bytes before any filesystem
+/// code is written on top of it. A boot sector is a convenient oracle: it has a
+/// fixed signature at a fixed offset, so a driver that is silently returning
+/// zeroes or reading the wrong sector cannot pass.
+#[cfg(target_arch = "x86_64")]
+fn init_storage_selftest() {
+    use crate::block::BLOCK_SIZE;
+
+    if !crate::block::is_present() {
+        serial_println!("Storage: no device, skipping self-test");
+        return;
+    }
+
+    let mut sector = [0u8; BLOCK_SIZE];
+    match crate::block::read_block(0, &mut sector) {
+        Ok(()) => {
+            let signature = u16::from_le_bytes([sector[510], sector[511]]);
+            let oem = core::str::from_utf8(&sector[3..11]).unwrap_or("????????");
+
+            serial_println!("Storage self-test:");
+            serial_println!("  LBA 0 signature : 0x{:04x}", signature);
+            serial_println!("  OEM name        : '{}'", oem.trim());
+
+            if signature == 0xAA55 {
+                serial_println!("Storage: PASS — read a valid boot sector from LBA 0");
+            } else {
+                serial_println!(
+                    "Storage: FAIL — LBA 0 signature is 0x{:04x}, expected 0xaa55",
+                    signature
+                );
+            }
+        }
+        Err(e) => serial_println!("Storage: FAIL — read error {:?}", e),
+    }
 }
 
 /// Drop into ring 3 and run the user payload.

--- a/kernel/src/console/commands.rs
+++ b/kernel/src/console/commands.rs
@@ -4,6 +4,9 @@
 //! None of them return canned strings — if something is not implemented, it
 //! says so rather than printing a plausible-looking answer.
 
+use alloc::string::String;
+use alloc::vec::Vec;
+
 use crate::console::editor::LineEditor;
 use crate::{print, println, serial_print, serial_println};
 
@@ -19,7 +22,7 @@ macro_rules! out {
     }};
 }
 
-pub fn execute(line: &str, editor: &LineEditor) {
+pub fn execute(line: &str, cwd: &mut String, editor: &LineEditor) {
     let line = line.trim();
     if line.is_empty() {
         return;
@@ -56,6 +59,15 @@ pub fn execute(line: &str, editor: &LineEditor) {
         "modules" => modules(),
         "history" => history(editor),
 
+        // Filesystem. These exist now because there is a disk underneath them.
+        "ls" | "dir" => ls(cwd, &args, arg_count),
+        "cd" => cd(cwd, &args, arg_count),
+        "pwd" => out!("{}", cwd),
+        "cat" => cat(cwd, &args, arg_count),
+        "stat" => stat(cwd, &args, arg_count),
+        "lsblk" => lsblk(),
+        "df" | "mount" => df(),
+
         "fault" => fault(&args, arg_count),
 
         "reboot" => reboot(),
@@ -86,6 +98,14 @@ fn help() {
     out!("  heartbeat on|off      once-a-second timer proof-of-life");
     out!("  translate <hex>       walk the page tables for an address");
     out!("  history               previous commands");
+    out!();
+    out!("  ls [-a] [path]        list a directory");
+    out!("  cd <path>             change directory");
+    out!("  pwd                   print the working directory");
+    out!("  cat <path>            print a file");
+    out!("  stat <path>           file or directory details");
+    out!("  lsblk                 block devices");
+    out!("  df, mount             mounted filesystem");
     out!();
     out!("  fault <kind>          deliberately fault: null, page, breakpoint");
     out!("  reboot                triple-fault the machine");
@@ -336,5 +356,261 @@ fn reboot() {
         };
         x86_64::instructions::tables::lidt(&idt);
         core::arch::asm!("int3", options(noreturn));
+    }
+}
+
+
+// --- filesystem ------------------------------------------------------------
+
+/// Turn a user-supplied path into an absolute, normalised one.
+///
+/// Relative paths, `.` and `..` are resolved here rather than in the
+/// filesystem layer: FAT has no notion of a working directory, and neither
+/// should a filesystem driver.
+fn resolve(cwd: &str, arg: &str) -> String {
+    let combined = if arg.starts_with('/') {
+        String::from(arg)
+    } else {
+        let mut s = String::from(cwd);
+        if !s.ends_with('/') {
+            s.push('/');
+        }
+        s.push_str(arg);
+        s
+    };
+
+    let mut parts: Vec<&str> = Vec::new();
+    for component in combined.split('/') {
+        match component {
+            "" | "." => {}
+            ".." => {
+                // `..` at the root stays at the root, as it does everywhere else.
+                parts.pop();
+            }
+            other => parts.push(other),
+        }
+    }
+
+    if parts.is_empty() {
+        return String::from("/");
+    }
+
+    let mut out = String::new();
+    for part in parts {
+        out.push('/');
+        out.push_str(part);
+    }
+    out
+}
+
+fn require_fs() -> bool {
+    if crate::fs::is_mounted() {
+        return true;
+    }
+    out!("no filesystem mounted");
+    out!("(attach a disk: -drive file=disk.img,format=raw,if=ide,index=0,media=disk)");
+    false
+}
+
+fn ls(cwd: &str, args: &[&str; 8], count: usize) {
+    if !require_fs() {
+        return;
+    }
+
+    // Only one flag so far, so this stays a simple scan rather than a parser.
+    let mut show_all = false;
+    let mut target: Option<&str> = None;
+    for i in 0..count {
+        match args[i] {
+            "-a" | "--all" => show_all = true,
+            other if other.starts_with('-') => {
+                out!("ls: unknown option {}", other);
+                return;
+            }
+            other => target = Some(other),
+        }
+    }
+
+    let path = match target {
+        Some(t) => resolve(cwd, t),
+        None => String::from(cwd),
+    };
+
+    match crate::fs::read_dir(&path) {
+        Ok(entries) => {
+            let mut shown = 0;
+            let mut bytes = 0u64;
+
+            for entry in entries.iter() {
+                if !show_all && (entry.name == "." || entry.name == "..") {
+                    continue;
+                }
+
+                out!(
+                    "{}{}{:>10}  {}",
+                    if entry.is_dir { "d" } else { "-" },
+                    if entry.is_read_only() { "r-" } else { "rw" },
+                    if entry.is_dir {
+                        String::from("-")
+                    } else {
+                        let mut s = String::new();
+                        use core::fmt::Write;
+                        let _ = write!(s, "{}", entry.size);
+                        s
+                    },
+                    entry.name
+                );
+
+                shown += 1;
+                bytes += entry.size as u64;
+            }
+
+            out!();
+            out!(
+                "{} {}, {} bytes",
+                shown,
+                if shown == 1 { "entry" } else { "entries" },
+                bytes
+            );
+        }
+        Err(e) => out!("ls: {}: {}", path, describe_error(e)),
+    }
+}
+
+fn cd(cwd: &mut String, args: &[&str; 8], count: usize) {
+    if !require_fs() {
+        return;
+    }
+
+    // Bare `cd` goes to the root, since there are no home directories.
+    let target = if count == 0 { "/" } else { args[0] };
+    let path = resolve(cwd, target);
+
+    match crate::fs::lookup(&path) {
+        Ok(entry) if entry.is_dir => {
+            *cwd = path;
+        }
+        Ok(_) => out!("cd: {}: not a directory", path),
+        Err(e) => out!("cd: {}: {}", path, describe_error(e)),
+    }
+}
+
+/// Largest file `cat` will print. Big enough for anything on the test image,
+/// small enough that a stray `cat` of a huge file does not lock up the console
+/// for a minute of PIO reads.
+const CAT_LIMIT: usize = 64 * 1024;
+
+fn cat(cwd: &str, args: &[&str; 8], count: usize) {
+    if !require_fs() {
+        return;
+    }
+    if count == 0 {
+        out!("usage: cat <path>");
+        return;
+    }
+
+    for i in 0..count {
+        let path = resolve(cwd, args[i]);
+
+        match crate::fs::read_file(&path, CAT_LIMIT) {
+            Ok(bytes) => {
+                if bytes.is_empty() {
+                    continue;
+                }
+
+                // Print a line at a time. Character by character would be two
+                // lock acquisitions and a format call per byte, which is
+                // painfully slow for anything but the smallest file.
+                let mut line = String::new();
+                let mut binary = 0usize;
+
+                for &b in bytes.iter() {
+                    match b {
+                        b'\n' => {
+                            out!("{}", line);
+                            line.clear();
+                        }
+                        b'\r' => {}
+                        b'\t' => line.push('\t'),
+                        0x20..=0x7e => line.push(b as char),
+                        _ => {
+                            binary += 1;
+                            line.push('.');
+                        }
+                    }
+                }
+                if !line.is_empty() {
+                    out!("{}", line);
+                }
+
+                if binary > 0 {
+                    out!("[{} non-printable byte(s) shown as '.']", binary);
+                }
+                if bytes.len() == CAT_LIMIT {
+                    out!("[truncated at {} bytes]", CAT_LIMIT);
+                }
+            }
+            Err(e) => out!("cat: {}: {}", path, describe_error(e)),
+        }
+    }
+}
+
+fn stat(cwd: &str, args: &[&str; 8], count: usize) {
+    if !require_fs() {
+        return;
+    }
+    if count == 0 {
+        out!("usage: stat <path>");
+        return;
+    }
+
+    let path = resolve(cwd, args[0]);
+    match crate::fs::lookup(&path) {
+        Ok(entry) => {
+            out!("{}", path);
+            out!("  name          {}", entry.name);
+            out!("  type          {}", if entry.is_dir { "directory" } else { "file" });
+            out!("  size          {} bytes", entry.size);
+            out!("  first cluster {}", entry.first_cluster);
+            out!("  attributes    0x{:02x}{}", entry.attributes,
+                 if entry.is_read_only() { " (read-only)" } else { "" });
+        }
+        Err(e) => out!("stat: {}: {}", path, describe_error(e)),
+    }
+}
+
+fn lsblk() {
+    match crate::block::with_device(|d| (String::from(d.name()), d.block_count())) {
+        Some((name, blocks)) => {
+            out!(
+                "{}  {} blocks x {} bytes  ({} MB)",
+                name,
+                blocks,
+                crate::block::BLOCK_SIZE,
+                blocks * crate::block::BLOCK_SIZE as u64 / (1024 * 1024)
+            );
+        }
+        None => out!("no block devices"),
+    }
+}
+
+fn df() {
+    match crate::fs::describe() {
+        Some(d) => out!("{}", d),
+        None => out!("nothing mounted"),
+    }
+}
+
+fn describe_error(e: crate::fs::fat32::FsError) -> &'static str {
+    use crate::fs::fat32::FsError;
+    match e {
+        FsError::NotFound => "no such file or directory",
+        FsError::NotADirectory => "not a directory",
+        FsError::IsADirectory => "is a directory",
+        FsError::NotFat32 => "not a FAT32 filesystem",
+        FsError::BadGeometry(why) => why,
+        FsError::CorruptChain => "corrupt cluster chain",
+        FsError::NameTooLong => "name too long",
+        FsError::Block(_) => "disk read error",
     }
 }

--- a/kernel/src/console/mod.rs
+++ b/kernel/src/console/mod.rs
@@ -23,11 +23,11 @@
 pub mod commands;
 pub mod editor;
 
+use alloc::string::String;
+
 use editor::LineEditor;
 
-use crate::{println, serial_println};
-
-const PROMPT: &str = "kosh> ";
+use crate::{print, println, serial_print, serial_println};
 
 /// Run the console. Never returns.
 ///
@@ -35,6 +35,7 @@ const PROMPT: &str = "kosh> ";
 /// is runnable keeps running while this blocks on the keyboard.
 pub fn run(_arg: usize) {
     let mut editor = LineEditor::new();
+    let mut cwd = String::from("/");
 
     // The boot heartbeat has done its job. Leaving it on means a line lands in
     // the middle of whatever is being typed, once a second, forever.
@@ -43,7 +44,9 @@ pub fn run(_arg: usize) {
     banner();
 
     loop {
-        let line = editor.read_line(PROMPT);
+        // The prompt carries the working directory, so `pwd` is rarely needed.
+        let prompt = build_prompt(&cwd);
+        let line = editor.read_line(&prompt);
 
         // `read_line` borrows the editor for the lifetime of the returned
         // string, but `history` needs to read the editor too. Copy the line out
@@ -53,8 +56,17 @@ pub fn run(_arg: usize) {
         owned[..n].copy_from_slice(&line.as_bytes()[..n]);
         let line = core::str::from_utf8(&owned[..n]).unwrap_or("");
 
-        commands::execute(line, &editor);
+        commands::execute(line, &mut cwd, &editor);
     }
+}
+
+/// `kosh:/docs> ` — short enough to keep the line usable, informative enough to
+/// know where `ls` will look.
+fn build_prompt(cwd: &str) -> String {
+    let mut p = String::from("kosh:");
+    p.push_str(cwd);
+    p.push_str("> ");
+    p
 }
 
 fn banner() {

--- a/kernel/src/fs/fat32.rs
+++ b/kernel/src/fs/fat32.rs
@@ -1,0 +1,549 @@
+//! FAT32, read-only.
+//!
+//! ## Why FAT32 and not ext4
+//!
+//! `userspace/fs-service/src/ext4.rs` already claims to implement ext4, and it
+//! is instructive about why this file exists instead: `read_block` fills the
+//! buffer with zeroes, `write_block` returns success without writing, the
+//! superblock is fabricated in code, `mtime` is the literal 1234567890, and
+//! `read_dir` returns only `.` and `..`. It was never connected to a disk,
+//! because there was no disk driver.
+//!
+//! FAT32 is a few hundred lines to read correctly, and — more usefully — the
+//! image can be mounted on the development host, so every answer the kernel
+//! gives can be checked against what is actually on the disk. ext4 is a lot of
+//! surface area to get wrong silently.
+//!
+//! ## What is here
+//!
+//! Mount (BPB parsing and validation), cluster chain walking, directory
+//! iteration including long filenames, path lookup, and file reads. No writing:
+//! allocating clusters and updating both FAT copies is a separate problem, and
+//! a read-only filesystem that is correct beats a read-write one that is not.
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use crate::block::{self, BlockError, BLOCK_SIZE};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FsError {
+    Block(BlockError),
+    /// Sector 0 does not describe a FAT32 filesystem.
+    NotFat32,
+    /// The BPB contains values that cannot be right.
+    BadGeometry(&'static str),
+    NotFound,
+    NotADirectory,
+    IsADirectory,
+    /// The cluster chain is circular or points outside the volume.
+    CorruptChain,
+    NameTooLong,
+}
+
+impl From<BlockError> for FsError {
+    fn from(e: BlockError) -> Self {
+        FsError::Block(e)
+    }
+}
+
+// Directory entry attribute bits.
+const ATTR_READ_ONLY: u8 = 0x01;
+const ATTR_HIDDEN: u8 = 0x02;
+const ATTR_SYSTEM: u8 = 0x04;
+const ATTR_VOLUME_ID: u8 = 0x08;
+const ATTR_DIRECTORY: u8 = 0x10;
+const ATTR_ARCHIVE: u8 = 0x20;
+/// A "file" with this exact attribute set is not a file at all — it is a
+/// fragment of a long filename belonging to the entry that follows it.
+const ATTR_LONG_NAME: u8 = ATTR_READ_ONLY | ATTR_HIDDEN | ATTR_SYSTEM | ATTR_VOLUME_ID;
+
+/// End-of-chain marker. Anything at or above this ends the chain.
+const CLUSTER_EOC: u32 = 0x0FFF_FFF8;
+const CLUSTER_MASK: u32 = 0x0FFF_FFFF;
+
+/// Guard against a corrupt FAT sending the chain walker into a loop.
+const MAX_CHAIN_LENGTH: usize = 1 << 20;
+
+/// A mounted FAT32 volume.
+pub struct Fat32 {
+    bytes_per_sector: u32,
+    sectors_per_cluster: u32,
+    reserved_sectors: u32,
+    num_fats: u32,
+    sectors_per_fat: u32,
+    root_cluster: u32,
+    total_sectors: u32,
+
+    /// LBA of the first data sector — where cluster 2 begins.
+    first_data_sector: u32,
+    /// Highest valid cluster number.
+    max_cluster: u32,
+
+    label: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct DirEntry {
+    pub name: String,
+    pub is_dir: bool,
+    pub size: u32,
+    pub first_cluster: u32,
+    pub attributes: u8,
+}
+
+impl DirEntry {
+    pub fn is_read_only(&self) -> bool {
+        self.attributes & ATTR_READ_ONLY != 0
+    }
+}
+
+impl Fat32 {
+    /// Read and validate the BPB at `lba`.
+    pub fn mount(lba: u64) -> Result<Self, FsError> {
+        let mut sector = [0u8; BLOCK_SIZE];
+        block::read_block(lba, &mut sector)?;
+
+        let u16_at = |o: usize| u16::from_le_bytes([sector[o], sector[o + 1]]) as u32;
+        let u32_at = |o: usize| {
+            u32::from_le_bytes([sector[o], sector[o + 1], sector[o + 2], sector[o + 3]])
+        };
+
+        // Signature first: it is the cheapest way to reject something that is
+        // not a filesystem at all.
+        if u16::from_le_bytes([sector[510], sector[511]]) != 0xAA55 {
+            return Err(FsError::NotFat32);
+        }
+
+        let bytes_per_sector = u16_at(11);
+        let sectors_per_cluster = sector[13] as u32;
+        let reserved_sectors = u16_at(14);
+        let num_fats = sector[16] as u32;
+        let root_entry_count = u16_at(17);
+        let total_sectors_16 = u16_at(19);
+        let sectors_per_fat_16 = u16_at(22);
+        let total_sectors_32 = u32_at(32);
+        let sectors_per_fat_32 = u32_at(36);
+        let root_cluster = u32_at(44);
+
+        // FAT32 is identified by these two being zero and their 32-bit
+        // counterparts being non-zero — not by the string in the filesystem type
+        // field, which is informational and routinely wrong.
+        if root_entry_count != 0 || sectors_per_fat_16 != 0 {
+            return Err(FsError::NotFat32);
+        }
+
+        let total_sectors = if total_sectors_16 != 0 {
+            total_sectors_16
+        } else {
+            total_sectors_32
+        };
+        let sectors_per_fat = sectors_per_fat_32;
+
+        // Validate the geometry before doing arithmetic with it. A corrupt or
+        // hostile BPB otherwise turns into out-of-range reads.
+        if bytes_per_sector as usize != BLOCK_SIZE {
+            return Err(FsError::BadGeometry("bytes per sector is not 512"));
+        }
+        if sectors_per_cluster == 0 || !sectors_per_cluster.is_power_of_two() {
+            return Err(FsError::BadGeometry("sectors per cluster is not a power of two"));
+        }
+        if num_fats == 0 || num_fats > 2 {
+            return Err(FsError::BadGeometry("implausible FAT count"));
+        }
+        if sectors_per_fat == 0 || reserved_sectors == 0 || total_sectors == 0 {
+            return Err(FsError::BadGeometry("zero-sized region"));
+        }
+        if root_cluster < 2 {
+            return Err(FsError::BadGeometry("root cluster below 2"));
+        }
+
+        let first_data_sector = reserved_sectors + num_fats * sectors_per_fat;
+        if first_data_sector >= total_sectors {
+            return Err(FsError::BadGeometry("no data region"));
+        }
+
+        let data_sectors = total_sectors - first_data_sector;
+        let cluster_count = data_sectors / sectors_per_cluster;
+        let max_cluster = cluster_count + 1; // clusters are numbered from 2
+
+        if root_cluster > max_cluster {
+            return Err(FsError::BadGeometry("root cluster past the volume"));
+        }
+
+        // Bytes 71..82 hold the volume label, space-padded.
+        let mut label = String::new();
+        for &b in &sector[71..82] {
+            if b != 0 {
+                label.push(b as char);
+            }
+        }
+        let label = String::from(label.trim_end());
+
+        Ok(Self {
+            bytes_per_sector,
+            sectors_per_cluster,
+            reserved_sectors,
+            num_fats,
+            sectors_per_fat,
+            root_cluster,
+            total_sectors,
+            first_data_sector,
+            max_cluster,
+            label,
+        })
+    }
+
+    pub fn label(&self) -> &str {
+        &self.label
+    }
+
+    pub fn cluster_size(&self) -> u32 {
+        self.sectors_per_cluster * self.bytes_per_sector
+    }
+
+    pub fn total_bytes(&self) -> u64 {
+        self.total_sectors as u64 * self.bytes_per_sector as u64
+    }
+
+    pub fn describe(&self) -> String {
+        use core::fmt::Write;
+        let mut s = String::new();
+        let _ = write!(
+            s,
+            "FAT32 '{}', {} MB, {} B/cluster, {} FAT(s) of {} sectors, root at cluster {}",
+            self.label,
+            self.total_bytes() / (1024 * 1024),
+            self.cluster_size(),
+            self.num_fats,
+            self.sectors_per_fat,
+            self.root_cluster
+        );
+        s
+    }
+
+    fn cluster_to_lba(&self, cluster: u32) -> u64 {
+        (self.first_data_sector + (cluster - 2) * self.sectors_per_cluster) as u64
+    }
+
+    /// The next cluster in the chain, or `None` at the end.
+    fn next_cluster(&self, cluster: u32) -> Result<Option<u32>, FsError> {
+        if cluster < 2 || cluster > self.max_cluster {
+            return Err(FsError::CorruptChain);
+        }
+
+        // Each FAT32 entry is 4 bytes, so 128 fit in a 512-byte sector.
+        let byte_offset = cluster as u64 * 4;
+        let sector = self.reserved_sectors as u64 + byte_offset / BLOCK_SIZE as u64;
+        let offset = (byte_offset % BLOCK_SIZE as u64) as usize;
+
+        let mut buf = [0u8; BLOCK_SIZE];
+        block::read_block(sector, &mut buf)?;
+
+        let raw = u32::from_le_bytes([
+            buf[offset],
+            buf[offset + 1],
+            buf[offset + 2],
+            buf[offset + 3],
+        ]);
+        // The top four bits are reserved and must be ignored, not trusted.
+        let entry = raw & CLUSTER_MASK;
+
+        if entry >= CLUSTER_EOC {
+            Ok(None)
+        } else if entry < 2 || entry > self.max_cluster {
+            // A free (0) or out-of-range entry inside a chain means the FAT is
+            // damaged. Saying so beats reading whatever sector that implies.
+            Err(FsError::CorruptChain)
+        } else {
+            Ok(Some(entry))
+        }
+    }
+
+    /// Every cluster in a chain, starting at `first`.
+    fn chain(&self, first: u32) -> Result<Vec<u32>, FsError> {
+        let mut clusters = Vec::new();
+        let mut current = first;
+
+        loop {
+            clusters.push(current);
+            if clusters.len() > MAX_CHAIN_LENGTH {
+                return Err(FsError::CorruptChain);
+            }
+            match self.next_cluster(current)? {
+                Some(next) => current = next,
+                None => break,
+            }
+        }
+
+        Ok(clusters)
+    }
+
+    /// Read a whole cluster.
+    fn read_cluster(&self, cluster: u32, buf: &mut [u8]) -> Result<(), FsError> {
+        let size = self.cluster_size() as usize;
+        if buf.len() < size {
+            return Err(FsError::BadGeometry("cluster buffer too small"));
+        }
+        block::read_blocks(self.cluster_to_lba(cluster), &mut buf[..size])?;
+        Ok(())
+    }
+
+    /// List a directory, given its first cluster.
+    pub fn read_dir(&self, first_cluster: u32) -> Result<Vec<DirEntry>, FsError> {
+        let mut entries = Vec::new();
+        let mut long_name = LongName::new();
+        let cluster_size = self.cluster_size() as usize;
+        let mut buf = vec![0u8; cluster_size];
+
+        for cluster in self.chain(first_cluster)? {
+            self.read_cluster(cluster, &mut buf)?;
+
+            for raw in buf.chunks_exact(32) {
+                match classify(raw) {
+                    Slot::End => return Ok(entries),
+                    Slot::Free => {
+                        long_name.reset();
+                    }
+                    Slot::LongName => long_name.absorb(raw),
+                    Slot::Short => {
+                        // A long name only applies to the entry immediately
+                        // after it, so take it and clear it either way.
+                        let name = long_name.take().unwrap_or_else(|| short_name(raw));
+                        if let Some(entry) = short_entry(raw, name) {
+                            entries.push(entry);
+                        }
+                    }
+                }
+            }
+        }
+
+        Ok(entries)
+    }
+
+    /// The root directory.
+    pub fn read_root(&self) -> Result<Vec<DirEntry>, FsError> {
+        self.read_dir(self.root_cluster)
+    }
+
+    /// Resolve an absolute path to its directory entry.
+    ///
+    /// `/` resolves to a synthetic entry for the root, which has no directory
+    /// entry of its own on disk.
+    pub fn lookup(&self, path: &str) -> Result<DirEntry, FsError> {
+        let mut current = DirEntry {
+            name: String::from("/"),
+            is_dir: true,
+            size: 0,
+            first_cluster: self.root_cluster,
+            attributes: ATTR_DIRECTORY,
+        };
+
+        for component in path.split('/') {
+            if component.is_empty() || component == "." {
+                continue;
+            }
+
+            if !current.is_dir {
+                return Err(FsError::NotADirectory);
+            }
+
+            let entries = self.read_dir(current.first_cluster)?;
+            let found = entries
+                .into_iter()
+                // FAT is case-insensitive, and users type lowercase.
+                .find(|e| e.name.eq_ignore_ascii_case(component))
+                .ok_or(FsError::NotFound)?;
+
+            current = found;
+        }
+
+        Ok(current)
+    }
+
+    /// Read up to `limit` bytes of a file.
+    pub fn read_file(&self, entry: &DirEntry, limit: usize) -> Result<Vec<u8>, FsError> {
+        if entry.is_dir {
+            return Err(FsError::IsADirectory);
+        }
+
+        let want = core::cmp::min(entry.size as usize, limit);
+        let mut out = Vec::with_capacity(want);
+
+        // A zero-length file has no cluster allocated at all, so the chain walk
+        // must not be attempted.
+        if want == 0 || entry.first_cluster == 0 {
+            return Ok(out);
+        }
+
+        let cluster_size = self.cluster_size() as usize;
+        let mut buf = vec![0u8; cluster_size];
+
+        for cluster in self.chain(entry.first_cluster)? {
+            if out.len() >= want {
+                break;
+            }
+            self.read_cluster(cluster, &mut buf)?;
+            let take = core::cmp::min(cluster_size, want - out.len());
+            out.extend_from_slice(&buf[..take]);
+        }
+
+        Ok(out)
+    }
+}
+
+enum Slot {
+    /// No entry here, and none after it.
+    End,
+    /// Deleted entry.
+    Free,
+    LongName,
+    Short,
+}
+
+fn classify(raw: &[u8]) -> Slot {
+    match raw[0] {
+        0x00 => Slot::End,
+        0xE5 => Slot::Free,
+        _ if raw[11] == ATTR_LONG_NAME => Slot::LongName,
+        _ => Slot::Short,
+    }
+}
+
+/// Build a `DirEntry` from a short-name directory entry, or `None` if it is not
+/// a real file or directory.
+fn short_entry(raw: &[u8], name: String) -> Option<DirEntry> {
+    let attributes = raw[11];
+
+    // The volume label is stored as a pseudo-entry in the root directory. It is
+    // metadata, not a file.
+    if attributes & ATTR_VOLUME_ID != 0 {
+        return None;
+    }
+
+    let first_cluster = ((u16::from_le_bytes([raw[20], raw[21]]) as u32) << 16)
+        | (u16::from_le_bytes([raw[26], raw[27]]) as u32);
+    let size = u32::from_le_bytes([raw[28], raw[29], raw[30], raw[31]]);
+
+    Some(DirEntry {
+        name,
+        is_dir: attributes & ATTR_DIRECTORY != 0,
+        // Directories report size 0 on disk regardless of their contents.
+        size: if attributes & ATTR_DIRECTORY != 0 { 0 } else { size },
+        first_cluster,
+        attributes,
+    })
+}
+
+/// Decode an 8.3 name into something printable.
+fn short_name(raw: &[u8]) -> String {
+    let mut name = String::new();
+
+    for &b in &raw[0..8] {
+        if b == b' ' {
+            break;
+        }
+        name.push(b as char);
+    }
+
+    let has_ext = raw[8] != b' ';
+    if has_ext {
+        name.push('.');
+        for &b in &raw[8..11] {
+            if b == b' ' {
+                break;
+            }
+            name.push(b as char);
+        }
+    }
+
+    name
+}
+
+/// Accumulator for long filename entries.
+///
+/// They appear *before* the short entry they belong to, in reverse order, with
+/// a sequence number in the first byte and the last one flagged 0x40. Each
+/// carries 13 UTF-16 code units split awkwardly across three ranges of the
+/// 32-byte slot.
+struct LongName {
+    /// Indexed by sequence number, so out-of-order entries still land right.
+    parts: [[u16; 13]; 20],
+    present: [bool; 20],
+    highest: usize,
+}
+
+impl LongName {
+    fn new() -> Self {
+        Self {
+            parts: [[0u16; 13]; 20],
+            present: [false; 20],
+            highest: 0,
+        }
+    }
+
+    fn reset(&mut self) {
+        self.present = [false; 20];
+        self.highest = 0;
+    }
+
+    fn absorb(&mut self, raw: &[u8]) {
+        let sequence = (raw[0] & 0x1F) as usize;
+        if sequence == 0 || sequence > 20 {
+            return;
+        }
+        let index = sequence - 1;
+
+        let mut chars = [0u16; 13];
+        let offsets: [usize; 13] = [1, 3, 5, 7, 9, 14, 16, 18, 20, 22, 24, 28, 30];
+        for (i, &off) in offsets.iter().enumerate() {
+            chars[i] = u16::from_le_bytes([raw[off], raw[off + 1]]);
+        }
+
+        self.parts[index] = chars;
+        self.present[index] = true;
+        if sequence > self.highest {
+            self.highest = sequence;
+        }
+    }
+
+    /// Assemble and clear. `None` if no long name was accumulated, or if the
+    /// sequence has a hole in it — in which case the short name is more
+    /// trustworthy than a name with a piece missing.
+    fn take(&mut self) -> Option<String> {
+        if self.highest == 0 {
+            return None;
+        }
+
+        let complete = (0..self.highest).all(|i| self.present[i]);
+        if !complete {
+            self.reset();
+            return None;
+        }
+
+        let mut units: Vec<u16> = Vec::new();
+        for i in 0..self.highest {
+            for &unit in self.parts[i].iter() {
+                // 0x0000 terminates, 0xFFFF pads.
+                if unit == 0x0000 || unit == 0xFFFF {
+                    break;
+                }
+                units.push(unit);
+            }
+        }
+
+        self.reset();
+
+        let mut name = String::new();
+        for result in char::decode_utf16(units.into_iter()) {
+            name.push(result.unwrap_or('\u{FFFD}'));
+        }
+
+        if name.is_empty() {
+            None
+        } else {
+            Some(name)
+        }
+    }
+}

--- a/kernel/src/fs/mod.rs
+++ b/kernel/src/fs/mod.rs
@@ -1,0 +1,241 @@
+//! The filesystem layer.
+//!
+//! One mounted volume, reached through a global. That is a deliberate limit
+//! rather than a design: a mount table belongs with a VFS, and
+//! `userspace/fs-service/src/vfs.rs` already has one — but it has never had a
+//! real filesystem underneath it, so wiring the two together is a separate
+//! piece of work from making FAT32 correct.
+//!
+//! Paths here are absolute and `/`-separated. Resolution of `.` and `..` and of
+//! relative paths happens above this layer, in the console.
+
+pub mod fat32;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+use spin::Mutex;
+
+use fat32::{DirEntry, Fat32, FsError};
+
+static MOUNTED: Mutex<Option<Fat32>> = Mutex::new(None);
+
+/// Try to mount a filesystem from the registered block device.
+pub fn init() {
+    use crate::serial_println;
+
+    if !crate::block::is_present() {
+        serial_println!("Filesystem: no block device, nothing to mount");
+        return;
+    }
+
+    serial_println!("Mounting filesystem...");
+
+    // The image is a bare filesystem, not a partitioned disk, so the BPB is at
+    // LBA 0. A partition table would mean reading the MBR first and mounting at
+    // the partition's start sector.
+    match Fat32::mount(0) {
+        Ok(fs) => {
+            serial_println!("  {}", fs.describe());
+            *MOUNTED.lock() = Some(fs);
+            selftest();
+        }
+        Err(e) => {
+            serial_println!("  no FAT32 filesystem at LBA 0: {:?}", e);
+        }
+    }
+}
+
+pub fn is_mounted() -> bool {
+    MOUNTED.lock().is_some()
+}
+
+/// Run `f` against the mounted filesystem.
+fn with_fs<T>(f: impl FnOnce(&Fat32) -> Result<T, FsError>) -> Result<T, FsError> {
+    let guard = MOUNTED.lock();
+    match guard.as_ref() {
+        Some(fs) => f(fs),
+        None => Err(FsError::NotFound),
+    }
+}
+
+/// Describe the mounted volume.
+pub fn describe() -> Option<String> {
+    MOUNTED.lock().as_ref().map(|fs| fs.describe())
+}
+
+pub fn label() -> Option<String> {
+    MOUNTED.lock().as_ref().map(|fs| String::from(fs.label()))
+}
+
+/// List a directory by absolute path.
+pub fn read_dir(path: &str) -> Result<Vec<DirEntry>, FsError> {
+    with_fs(|fs| {
+        let entry = fs.lookup(path)?;
+        if !entry.is_dir {
+            return Err(FsError::NotADirectory);
+        }
+        fs.read_dir(entry.first_cluster)
+    })
+}
+
+/// Look up a path.
+pub fn lookup(path: &str) -> Result<DirEntry, FsError> {
+    with_fs(|fs| fs.lookup(path))
+}
+
+/// Read a file by absolute path, up to `limit` bytes.
+pub fn read_file(path: &str, limit: usize) -> Result<Vec<u8>, FsError> {
+    with_fs(|fs| {
+        let entry = fs.lookup(path)?;
+        fs.read_file(&entry, limit)
+    })
+}
+
+/// Check the mount against facts the build script guarantees.
+///
+/// `scripts/run.sh` builds the test image with a known label and known files, so
+/// this can assert against real expected values rather than just "no error was
+/// returned". A filesystem that returns an empty root without complaining would
+/// otherwise look like a pass.
+fn selftest() {
+    use crate::serial_println;
+
+    serial_println!("Filesystem self-test:");
+
+    let entries = match read_dir("/") {
+        Ok(e) => e,
+        Err(e) => {
+            serial_println!("Filesystem: FAIL — cannot read the root directory: {:?}", e);
+            return;
+        }
+    };
+
+    serial_println!("  root has {} entries:", entries.len());
+    for entry in entries.iter() {
+        serial_println!(
+            "    {:<14} {:>8} {}",
+            entry.name,
+            entry.size,
+            if entry.is_dir { "<DIR>" } else { "" }
+        );
+    }
+
+    let mut failures = 0;
+
+    // A file whose contents the build script controls.
+    match read_file("/HELLO.TXT", 4096) {
+        Ok(bytes) => {
+            let text = core::str::from_utf8(&bytes).unwrap_or("<not utf-8>");
+            if text.trim() == "hello from the filesystem" {
+                serial_println!("  PASS read /HELLO.TXT: '{}'", text.trim());
+            } else {
+                serial_println!("  FAIL /HELLO.TXT contains '{}'", text.trim());
+                failures += 1;
+            }
+        }
+        Err(e) => {
+            serial_println!("  FAIL cannot read /HELLO.TXT: {:?}", e);
+            failures += 1;
+        }
+    }
+
+    // A file larger than one cluster, so the FAT chain has to be walked.
+    match lookup("/BIG.TXT") {
+        Ok(entry) => match read_file("/BIG.TXT", 1 << 20) {
+            Ok(bytes) => {
+                let lines = bytes.iter().filter(|&&b| b == b'\n').count();
+                if bytes.len() == entry.size as usize && lines == 400 {
+                    serial_println!(
+                        "  PASS read /BIG.TXT: {} bytes, {} lines across the cluster chain",
+                        bytes.len(),
+                        lines
+                    );
+                } else {
+                    serial_println!(
+                        "  FAIL /BIG.TXT: {} bytes ({} expected), {} lines (400 expected)",
+                        bytes.len(),
+                        entry.size,
+                        lines
+                    );
+                    failures += 1;
+                }
+            }
+            Err(e) => {
+                serial_println!("  FAIL cannot read /BIG.TXT: {:?}", e);
+                failures += 1;
+            }
+        },
+        Err(e) => {
+            serial_println!("  FAIL cannot find /BIG.TXT: {:?}", e);
+            failures += 1;
+        }
+    }
+
+    // A subdirectory, which means the lookup recursed.
+    match read_dir("/docs") {
+        Ok(entries) => {
+            // `.` and `..` are real entries in a FAT subdirectory.
+            let named = entries.iter().filter(|e| e.name == "NOTES.TXT").count();
+            if named == 1 {
+                serial_println!("  PASS /docs contains NOTES.TXT ({} entries total)", entries.len());
+            } else {
+                serial_println!("  FAIL /docs does not contain NOTES.TXT");
+                for e in entries.iter() {
+                    serial_println!("       saw '{}'", e.name);
+                }
+                failures += 1;
+            }
+        }
+        Err(e) => {
+            serial_println!("  FAIL cannot read /docs: {:?}", e);
+            failures += 1;
+        }
+    }
+
+    // A name that does not fit 8.3, so it is stored as long-filename entries.
+    // Every other name on the image is a valid short name, which means this is
+    // the only thing exercising the LFN assembly.
+    const LONG: &str = "A Long File Name.txt";
+    match entries.iter().find(|e| e.name == LONG) {
+        Some(_) => serial_println!("  PASS long filename read back as '{}'", LONG),
+        None => {
+            serial_println!("  FAIL no entry named '{}' in the root", LONG);
+            serial_println!("       (long-filename assembly is wrong, or mcopy stored it differently)");
+            failures += 1;
+        }
+    }
+
+    // ...and it has to be openable by that name, not just listable.
+    match read_file("/A Long File Name.txt", 4096) {
+        Ok(bytes) if !bytes.is_empty() => {
+            serial_println!("  PASS opened it by long name, {} bytes", bytes.len())
+        }
+        Ok(_) => {
+            serial_println!("  FAIL long-name file opened but read empty");
+            failures += 1;
+        }
+        Err(e) => {
+            serial_println!("  FAIL cannot open by long name: {:?}", e);
+            failures += 1;
+        }
+    }
+
+    // A path that does not exist must fail, not return something plausible.
+    match lookup("/NOPE.TXT") {
+        Err(FsError::NotFound) => serial_println!("  PASS /NOPE.TXT reports NotFound"),
+        Err(e) => {
+            serial_println!("  FAIL /NOPE.TXT reported {:?}, expected NotFound", e);
+            failures += 1;
+        }
+        Ok(_) => {
+            serial_println!("  FAIL /NOPE.TXT resolved to something");
+            failures += 1;
+        }
+    }
+
+    if failures == 0 {
+        serial_println!("Filesystem: PASS — all checks against the known test image");
+    } else {
+        serial_println!("Filesystem: FAIL — {} check(s) failed", failures);
+    }
+}

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -21,9 +21,13 @@ mod task;
 #[cfg(target_arch = "x86_64")]
 mod gdt;
 #[cfg(target_arch = "x86_64")]
+mod block;
+#[cfg(target_arch = "x86_64")]
 mod console;
 #[cfg(target_arch = "x86_64")]
 mod elf;
+#[cfg(target_arch = "x86_64")]
+mod fs;
 #[cfg(target_arch = "x86_64")]
 mod usermode;
 #[cfg(target_arch = "x86_64")]

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -18,6 +18,7 @@ PROFILE="${PROFILE:-release}"
 BUILD_DIR="$ROOT/build"
 ISO_DIR="$BUILD_DIR/iso"
 ISO="$BUILD_DIR/kosh.iso"
+DISK="$BUILD_DIR/disk.img"
 
 MODE="run"
 case "${1:-}" in
@@ -37,6 +38,8 @@ need cargo       "Install Rust: https://rustup.rs"
 need grub-mkrescue "Install GRUB tools (macOS: brew install i686-elf-grub xorriso)"
 need xorriso     "Install xorriso (macOS: brew install xorriso)"
 need qemu-system-x86_64 "Install QEMU (macOS: brew install qemu)"
+need mkfs.vfat  "Install dosfstools (macOS: brew install dosfstools)"
+need mcopy      "Install mtools (macOS: brew install mtools)"
 
 # --- build ------------------------------------------------------------------
 
@@ -105,10 +108,70 @@ EOF
 grub-mkrescue -o "$ISO" "$ISO_DIR" >/dev/null 2>&1
 echo "==> $ISO ($(du -h "$ISO" | cut -f1))"
 
+# --- test disk ---------------------------------------------------------------
+#
+# A FAT32 image with known contents, attached as a legacy IDE hard disk. FAT32
+# rather than ext4 on purpose: it is a few hundred lines to read, and the image
+# can be mounted on the host to check what the kernel says against what is
+# actually there.
+
+if [ ! -f "$DISK" ] || [ "${REBUILD_DISK:-0}" = "1" ]; then
+    echo "==> building FAT32 test disk"
+    STAGE="$(mktemp -d)"
+
+    cat > "$STAGE/README.TXT" <<'TXT'
+Kosh test disk.
+
+This file lives in a FAT32 filesystem on a virtual IDE disk. If you are reading
+it from the kosh> prompt, then the ATA driver, the block layer and the FAT32
+implementation all work.
+TXT
+
+    printf 'hello from the filesystem
+' > "$STAGE/HELLO.TXT"
+    printf 'line one
+line two
+line three
+' > "$STAGE/LINES.TXT"
+    # A file that spans more than one cluster, to exercise the FAT chain walk.
+    for i in $(seq 1 400); do
+        printf 'This is line %03d of a deliberately multi-cluster file.
+' "$i"
+    done > "$STAGE/BIG.TXT"
+
+    dd if=/dev/zero of="$DISK" bs=1M count=64 status=none
+    mkfs.vfat -F 32 -n KOSHDISK "$DISK" >/dev/null
+
+    mmd   -i "$DISK" ::/docs
+    mcopy -i "$DISK" "$STAGE/README.TXT" ::/README.TXT
+    mcopy -i "$DISK" "$STAGE/HELLO.TXT"  ::/HELLO.TXT
+    mcopy -i "$DISK" "$STAGE/LINES.TXT"  ::/LINES.TXT
+    mcopy -i "$DISK" "$STAGE/BIG.TXT"    ::/BIG.TXT
+    mcopy -i "$DISK" "$STAGE/HELLO.TXT"  ::/docs/NOTES.TXT
+    # A name that does not fit 8.3, so FAT has to store it as long-filename
+    # entries. Without this the LFN assembly code is never exercised — every
+    # other name here is a valid short name.
+    mcopy -i "$DISK" "$STAGE/HELLO.TXT"  "::/A Long File Name.txt"
+
+    rm -rf "$STAGE"
+    echo "==> $DISK ($(du -h "$DISK" | cut -f1)), label KOSHDISK"
+else
+    echo "==> reusing $DISK (REBUILD_DISK=1 to regenerate)"
+fi
+
 # --- run --------------------------------------------------------------------
 
 QEMU_ARGS=(
     -cdrom "$ISO"
+    # Primary IDE master, so it answers on the legacy ports at 0x1F0. The CD is
+    # on the secondary channel, which is why the driver finds the disk and not
+    # the ISO.
+    -drive "file=$DISK,format=raw,if=ide,index=0,media=disk"
+    # Boot the CD, not the disk. mkfs.vfat writes a 0xAA55 signature at offset
+    # 510, so SeaBIOS considers the test disk bootable and will happily try it
+    # first — which hangs, with no output, looking exactly like a kernel that
+    # failed to start.
+    -boot order=d
     -m 512M
     -no-reboot
     -no-shutdown
@@ -164,6 +227,8 @@ check)
         ".bss was zeroed correctly" \
         "stack is writable and readable" \
         "ELF loader: PASS" \
+        "Storage: PASS" \
+        "Filesystem: PASS" \
         "Kernel initialization complete" \
         "console started on its own thread"
     do
@@ -229,6 +294,15 @@ check-cli)
         type_line "echo kosh cli works"
         type_line "modules"
         type_line "ps"
+        type_line "lsblk"
+        type_line "df"
+        type_line "ls"
+        type_line "cat hello.txt"
+        type_line "cd docs"
+        type_line "pwd"
+        type_line "ls"
+        type_line "cd .."
+        type_line "cat nope.txt"
         type_line "history"
         type_line "nosuchcommand"
         type_line "fault bp"
@@ -244,7 +318,7 @@ check-cli)
     fail=0
     for marker in \
         "Kosh console" \
-        "kosh>" \
+        "kosh:/>" \
         "Kosh 0.1.0 x86_64" \
         "running in ring 0" \
         "physical memory:" \
@@ -252,6 +326,13 @@ check-cli)
         "kosh cli works" \
         "module 0:" \
         "context switches since boot" \
+        "QEMU HARDDISK" \
+        "FAT32 'KOSHDISK'" \
+        "README.TXT" \
+        "hello from the filesystem" \
+        "kosh:/docs>" \
+        "NOTES.TXT" \
+        "no such file or directory" \
         "unknown command: nosuchcommand" \
         "resumed"
     do


### PR DESCRIPTION
## Summary

The console had no `ls`, `cat` or `cd`, on the grounds that inventing commands which return plausible-looking strings is the habit that let this project accumulate 27 commits of code that had never run. This PR earns them: a real disk driver, a real filesystem, and commands backed by both.

```
kosh:/> lsblk
hda  131072 blocks x 512 bytes  (64 MB)
kosh:/> df
FAT32 'KOSHDISK', 64 MB, 512 B/cluster, 2 FAT(s) of 1009 sectors, root at cluster 2
kosh:/> ls
drw         -  DOCS
-rw       199  README.TXT
-rw        26  HELLO.TXT
-rw     22000  BIG.TXT
-rw        26  A Long File Name.txt

6 entries, 22280 bytes
kosh:/> cat lines.txt
line one
line two
line three
kosh:/> cd docs
kosh:/docs> ls
-rw        26  NOTES.TXT
```

27 boot markers and 18 console markers pass, from a clean rebuild.

## What's here

| File | Role |
|---|---|
| `kernel/src/block/ata.rs` | Polled PIO driver for the legacy IDE ports |
| `kernel/src/block/mod.rs` | `BlockDevice` trait and the registered device |
| `kernel/src/fs/fat32.rs` | FAT32 read support: mount, chain walk, directories, long names, file reads |
| `kernel/src/fs/mod.rs` | The mounted volume, and a self-test against the known test image |
| `kernel/src/console/commands.rs` | `ls`, `cd`, `pwd`, `cat`, `stat`, `lsblk`, `df` |

## Two choices worth explaining

**Polled PIO on the legacy ports, not DMA over PCI.** It is the smallest thing that really reads a disk — no PCI enumeration, no interrupt plumbing, no bus-master buffers. It is also slow: one 16-bit port read per two bytes, with the CPU spinning on a status register. That is fine for reading a filesystem and wrong for anything performance-sensitive, which is what DMA and virtio-blk are for later.

The driver IDENTIFYs the drive for its real capacity and model, distinguishes a floating bus and an ATAPI device from a disk, and reports `DeviceError` separately from `Timeout` — a drive that set ERR should not look like one that never answered.

**FAT32, not ext4.** `userspace/fs-service/src/ext4.rs` already claims to implement ext4, and is instructive about why not: `read_block` fills the buffer with zeroes, `write_block` returns success without writing, the superblock is fabricated in code, `mtime` is the literal `1234567890`, and `read_dir` returns only `.` and `..`. It was never connected to a disk, because there was no disk driver.

FAT32 is a few hundred lines to read correctly, and the image can be mounted on the development host — so every answer the kernel gives is checkable against what is actually on the disk. ext4 is a lot of surface area to get wrong silently.

## Details that matter

- **The BPB is validated before any arithmetic uses it.** A corrupt or hostile boot sector otherwise turns directly into out-of-range reads. `mount` checks sector size, cluster size (power of two), FAT count, region sizes, and rejects a root cluster past the end of the volume.
- **FAT32 is identified by `root_entry_count == 0` and `sectors_per_fat_16 == 0`**, not by the filesystem-type string, which is informational and routinely wrong.
- **The top four bits of a FAT entry are reserved and masked off.** A free (`0`) or out-of-range entry found *inside* a chain means the FAT is damaged — worth reporting rather than following into whatever sector it implies.
- **A zero-length file has no cluster allocated**, so the chain walk is skipped rather than started from cluster 0.
- Relative paths, `.` and `..` are resolved **in the console, not the filesystem.** FAT has no notion of a working directory and neither should a filesystem driver.
- `cat` prints a line at a time. Per character would be two lock acquisitions and a format call per byte, which is painful for anything but the smallest file.

## Two things that cost time

**The test disk was bootable, and that broke everything.** `mkfs.vfat` writes a `0xAA55` signature at offset 510, so SeaBIOS considered the FAT image bootable, tried it before the CD, and hung — producing *no serial output at all*. Every single boot marker failed at once, which looks exactly like a kernel that cannot start. `-boot order=d` fixes it, and it is now commented in `run.sh` so the next person does not spend the same twenty minutes.

**Long filenames were passing without being tested.** Every name on the first test image (`DOCS`, `README.TXT`, `HELLO.TXT`) is a valid 8.3 short name, so the ~80 lines of long-filename assembly never executed and the suite was green regardless. The image now contains `A Long File Name.txt`, and the self-test asserts both that it appears in a listing and that it opens by that name.

## Testing

`scripts/run.sh` builds a 64 MB FAT32 image with known contents, and `fs::selftest` asserts against them at boot rather than merely checking that no error came back — a filesystem that returned an empty root without complaining would otherwise look like a pass:

```
Filesystem self-test:
  root has 6 entries: ...
  PASS read /HELLO.TXT: 'hello from the filesystem'
  PASS read /BIG.TXT: 22000 bytes, 400 lines across the cluster chain
  PASS /docs contains NOTES.TXT (3 entries total)
  PASS long filename read back as 'A Long File Name.txt'
  PASS opened it by long name, 26 bytes
  PASS /NOPE.TXT reports NotFound
Filesystem: PASS — all checks against the known test image
```

`--check-cli` additionally drives `lsblk`, `df`, `ls`, `cat`, `cd` and `pwd` at the prompt through QEMU's monitor and asserts what comes back, including that `cat nope.txt` reports "no such file or directory". CI now installs `dosfstools` alongside `mtools`.

## Deliberately still missing

- **The filesystem is read-only.** Allocating clusters and keeping both FAT copies consistent is a separate problem, and a read-only filesystem that is correct beats a read-write one that is not.
- **No partition table support.** The BPB is read from LBA 0, so the image is a bare filesystem rather than a partitioned disk.
- **The VFS is still unwired.** `userspace/fs-service/src/vfs.rs` has a mount table; it has never had a real filesystem underneath it, and connecting the two is separate work from making FAT32 correct.
- **No `fork`/`exec`**, so `userspace/init` still cannot do its job, and the filesystem is not yet reachable from ring 3 — there are no `open`/`read` syscalls backed by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P1GdpYMiKP5Gj1Jmub59gw
