### PR TITLE
kernel: per-thread kernel stacks, and a shell that launches programs

### DIFF
--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -348,9 +348,9 @@ and is the first thing the stub does.
 Argument 4 travels in R10 rather than RCX precisely because `syscall` destroys
 RCX.
 
-`SFMASK` masks IF, so a syscall cannot be interrupted. That is what makes the
-single static kernel syscall stack safe for now; multiple user threads will need
-`swapgs` and a per-CPU block.
+`SFMASK` masks IF, so a syscall *starts* uninterruptible. Phase 10 replaced the
+single static kernel syscall stack this once justified — see
+"Several ring-3 threads" below.
 
 ### Trusting nothing from ring 3
 
@@ -689,6 +689,177 @@ the only practical way to test the pipe path: QEMU's `sendkey` cannot produce a
 null check and two TODOs; they delegate to `syscall::uaccess`, and take a
 `writable` flag so `read` and `write` are checked in the right direction.
 
+## Several ring-3 threads, and launching programs (Phase 10)
+
+Everything up to Phase 9 ran **one** ring-3 thread at a time, and the syscall
+path was built on that assumption: a single `static SYSCALL_STACK`, a single
+`SAVED_USER_RSP`, and a comment in three places saying so. Phase 10 removes the
+assumption, and then uses what that buys.
+
+### Per-thread kernel stacks
+
+`syscall` gives the kernel no stack. It leaves RSP pointing at the *user* stack,
+and no register is free — RCX and R11 carry the return state, everything else
+belongs to the caller. So the hop to a kernel stack has to go through memory
+without a register to address it with, which is what `gs:` addressing is for.
+
+`kernel/src/percpu.rs` holds the per-CPU block:
+
+```
+gs:0   syscall_rsp        kernel stack top for the running thread
+gs:8   user_rsp_scratch   where the stub parks the user RSP for two instructions
+gs:16  current_thread
+```
+
+The offsets are asserted with `offset_of!` at compile time, because the assembly
+addresses them numerically.
+
+The stub is now:
+
+```
+    movq    %rsp, %gs:8         /* park the user RSP                    */
+    movq    %gs:0, %rsp         /* this thread's own kernel stack        */
+    pushq   %gs:8               /* ...and onto the stack, where it is    */
+    ...                         /*    per-thread rather than per-CPU     */
+```
+
+`user_rsp` is a field of `SyscallFrame` now. That is the part that actually
+matters: the scratch slot at `gs:8` is only live while `SFMASK` has interrupts
+masked, and one instruction later the value is on a stack nobody else can touch.
+
+`task::schedule()` publishes the incoming thread's stack to two places on every
+switch — `TSS.RSP0`, used by the CPU when an interrupt arrives in ring 3, and
+`gs:0`, read by the syscall stub. `gdt.rs` stopped being a `lazy_static` for
+this: `set_kernel_stack` used to be `unimplemented!()` because a `lazy_static`
+hands out `&TSS` and no way to mutate it.
+
+**Why there is no `swapgs`.** The textbook mechanism swaps GS.base with
+`IA32_KERNEL_GS_BASE` on each kernel entry and exit. That invariant only holds if
+*every* transition swaps, and this kernel cannot honour it: its interrupt
+handlers are Rust functions using `x86-interrupt`, which offers no place to put a
+`swapgs` before the compiler's prologue. Once a timer tick can land inside a
+syscall — which `files::wait_for_key` makes reachable — the swap count stops
+being even, and a later `swapgs` leaves GS.base holding user data. So both MSRs
+point at the same block, and any `swapgs` is a no-op. Ring 3 cannot subvert this:
+`wrgsbase` needs CR4.FSGSBASE (clear) and `swapgs` itself is #GP in ring 3. The
+cost is that user-mode TLS through GS is unavailable until interrupt entry gets
+naked stubs.
+
+### Proving it needed doing
+
+A test that cannot fail proves nothing, so this one was checked against a
+deliberately broken kernel.
+
+`SYS_YIELD` (syscall 8) gives up the rest of a slice. It is the only way for
+userspace to force a context switch *from inside a system call* — which is
+exactly the situation per-thread stacks exist for. `kosh_user_pingpong_entry` in
+`user_program.rs` loops twelve times over "yield, then write one byte", and two
+threads run it concurrently with different tag bytes:
+
+```
+Two ring-3 threads, each yielding from inside a syscall:
+  ring 3 'A': entry 0x400000e7, user stack 0x58000000, kernel stack 0xffff900000054da0
+  ring 3 'B': entry 0x400000e7, user stack 0x57f00000, kernel stack 0xffff90000005cdd0
+ABABABABABABABABABABAB
+A: survived 12 yields inside a syscall
+B: survived 12 yields inside a syscall
+Concurrent ring 3: PASS — 52 syscalls across 39 context switches
+```
+
+With `publish_kernel_stack` patched to hand every thread the *same* stack — the
+Phase 9 behaviour — the same test produces:
+
+```
+BBBBBBBBBBBBB: survived 12 yields inside a syscall
+[#DB debug at 0x0000000000101216] — resuming
+...
+==================== PAGE FAULT ====================
+  cause : protection violation while fetching an instruction in kernel mode
+  rip   : 0x0000000000175df4
+```
+
+Thread A never finishes. B's syscall entry took the shared stack from the top and
+overwrote A's parked frame, so A's `sysretq` returned to a garbage RIP with
+garbage RFLAGS — TF among them, hence the single-step storm — and then tried to
+execute its own kernel stack.
+
+The completion line is assembled in one buffer and written with a single
+`write`, because two writes would let the other thread's byte land between the
+tag and the message.
+
+### spawn and wait
+
+With more than one ring-3 thread possible, a shell can launch a program:
+
+```
+ksh:/$ hello
+hello from a loaded ELF binary
+  my pid is 3
+  .bss was zeroed correctly
+  stack is writable and readable
+  exiting cleanly
+ksh:/$ ksh
+ksh: ksh: could not start (error -98)
+```
+
+`spawn(path, len)` (syscall 9) loads a named boot module and runs it on a new
+kernel thread in ring 3, returning the task id. `wait(task, status)` (syscall 4,
+which used to be a TODO and `Err(NotSupported)`) blocks until that task exits and
+writes its exit code.
+
+Three things are worth spelling out.
+
+**It is `spawn`, not `fork`+`exec`.** `fork` duplicates an address space; there
+is one address space. Calling it `spawn` keeps the name honest. `sys_fork` itself
+now returns `NotSupported` — it used to add a row to the process table, log "Fork
+successful", and return a PID for a child that did not exist, which userspace read
+as success.
+
+**Blocking is real blocking.** `State::Blocked { on }` is skipped by
+`next_runnable`, and `exit_current` wakes anyone waiting on the exiting thread.
+The alternative — a `yield_now` loop — would mean a shell waiting for a child
+consumed half the CPU. Getting the wake-up wrong is worse than a spin, though:
+the waiter is simply never Ready again and the machine deadlocks with a live
+thread the scheduler refuses to pick.
+
+**The ELF is loaded in the caller's thread, not the new one.** A load failure is
+then a synchronous error the shell can report, instead of a thread that starts
+and dies with the reason only in the kernel log.
+
+### Programs have to be unmapped
+
+The second `spawn` of the same binary used to be impossible: `map_user_pages`
+returns `PageAlreadyMapped`, after having already allocated a frame for that
+page, so every attempt also leaked one. `paging::unmap_user_pages` is the
+counterpart that was missing, and `usermode::RESIDENT` tracks what each program
+mapped so `task::exit_current` can hand it back:
+
+```
+  released 'hello': 19 page(s) returned, 1560 used system-wide
+  released 'hello': 19 page(s) returned, 1560 used system-wide
+```
+
+Two runs, identical used-page count. That number is printed for exactly this
+reason — it is the only way to see from the log alone that running a program
+twice does not cost twice the memory.
+
+The same table is what makes the overlap check possible. Every userspace program
+is linked at a fixed address, so `ksh` spawning `ksh` would overwrite the `.text`
+it is currently executing. `elf::extent_of` answers "where would this go" without
+mapping anything, which is the only moment a conflict can be refused cheaply.
+
+### Loose ends this exposed
+
+`sys_exit` called `files::close_all()`, which closes the *system's* descriptor
+table — there is only one, because there is no per-process state to hang one off.
+With two programs resident, a short-lived one exiting would close the shell's
+open files behind its back. It now does that only when it is the last program
+running, and says so when it declines.
+
+`kosh_syscall_handler` used a hardcoded `ProcessId::new(1)`. It uses
+`task::current_id()` now, so `getpid`, the log lines, and the task id `spawn`
+returns all agree.
+
 ## What is deliberately still missing
 - **The filesystem is read-only.** Allocating clusters and keeping both FAT
   copies consistent is a separate problem, and a read-only filesystem that is
@@ -698,14 +869,17 @@ null check and two TODOs; they delegate to `syscall::uaccess`, and take a
 - **The VFS is still unwired.** `userspace/fs-service/src/vfs.rs` has a mount
   table; it has never had a real filesystem underneath it, and connecting the
   two is separate work from making FAT32 correct.
-- **No `fork`/`exec`.** `userspace/init` cannot do its job until those exist, so
-  the ELF payload is `userspace/hello` rather than init.
+- **No `fork`/`exec`.** `spawn` loads a *second* program rather than duplicating
+  the caller, so there is still no way for a program to replace its own image or
+  to inherit one. `userspace/init` cannot do its job until `fork` exists.
 - **One address space.** Loaded programs share the kernel's page tables; they
-  are protected by page permissions, not by separation. Per-process address
-  spaces come with `fork`.
-- **One ring-3 thread at a time.** The syscall path uses a single static kernel
-  stack, which is only safe because `SFMASK` masks IF and nothing else is in
-  user mode. Several user threads need `swapgs` and per-CPU data.
+  are protected by page permissions, not by separation. That is why every
+  userspace program is linked at a distinct fixed address
+  (`userspace/*/user.ld`) and why `spawn` has to refuse an image that overlaps
+  one already resident.
+- **No pipes or background jobs.** `ksh` parses them; running them needs two
+  programs connected by a shared descriptor, which needs per-process descriptor
+  tables. The table is currently global — see the note in `sys_exit`.
 - **Swap and power management are disabled** in `init_kernel`. Both were
   simulated, and swap tried to allocate 8 MiB from a 1 MiB heap.
 - **Only IRQ0 and IRQ1 are unmasked.** Everything else on the PIC has a

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -20,7 +20,12 @@ pub fn init_kernel(boot_info: BootInformation) {
     
     // Set up GDT and TSS (now including ring-3 descriptors and RSP0)
     crate::gdt::init();
-    
+
+    // GS.base has to point at the per-CPU block before the syscall stub can run,
+    // and `gdt::init` reloads GS — so this comes after it, and long before
+    // `syscall::init_syscall_interface`.
+    crate::percpu::init();
+
     // Install the IDT before anything else can fault. From here on a bad
     // pointer produces a legible dump instead of a silent triple fault.
     crate::interrupts::init();
@@ -766,7 +771,52 @@ fn init_usermode() {
         serial_println!("Ring 3: FAIL — only {} syscalls serviced", serviced);
     }
 
-    // Demo 3: an ELF the kernel was not compiled with, loaded from a GRUB
+    // Demo 3: two ring-3 threads at once, each yielding from inside a syscall.
+    //
+    // Everything above ran one ring-3 thread at a time, which is what let the
+    // syscall path get away with a single static kernel stack. This is the test
+    // that stack could not pass.
+    serial_println!();
+    serial_println!("Two ring-3 threads, each yielding from inside a syscall:");
+    let before_pp = crate::syscall::entry::syscall_count();
+    let switches_before = crate::task::switch_count();
+
+    for which in 0..2 {
+        if let Err(e) = crate::task::spawn("pingpong", crate::usermode::run_pingpong, which) {
+            serial_println!("Concurrent ring 3: FAIL — could not spawn: {}", e);
+            return;
+        }
+    }
+    serial_println!("--- interleaved ring 3 output ---");
+    while crate::task::live_threads() > 0 {
+        x86_64::instructions::hlt();
+    }
+    serial_println!();
+    crate::task::reap_finished();
+
+    let pp_syscalls = crate::syscall::entry::syscall_count() - before_pp;
+    let pp_switches = crate::task::switch_count() - switches_before;
+
+    // 2 threads x 12 iterations x (yield + write) + 2 final writes + 2 exits.
+    // Anything less means a thread died partway, which is exactly the failure a
+    // shared syscall stack produces.
+    let expected = 2 * 12 * 2 + 4;
+    if pp_syscalls >= expected as u64 && pp_switches >= 24 {
+        serial_println!(
+            "Concurrent ring 3: PASS — {} syscalls across {} context switches, per-thread kernel stacks held",
+            pp_syscalls,
+            pp_switches
+        );
+    } else {
+        serial_println!(
+            "Concurrent ring 3: FAIL — {} syscalls (expected >= {}), {} switches (expected >= 24)",
+            pp_syscalls,
+            expected,
+            pp_switches
+        );
+    }
+
+    // Demo 4: an ELF the kernel was not compiled with, loaded from a GRUB
     // module. Reported separately, because it exercises the loader rather than
     // the ring-3 mechanics above.
     serial_println!();

--- a/kernel/src/console/commands.rs
+++ b/kernel/src/console/commands.rs
@@ -126,15 +126,27 @@ fn threads() {
     out!("  {:>3}  {:<12} {:<9} {:>8}", "id", "name", "state", "ticks");
 
     for slot in buf.iter().flatten() {
+        // `Blocked` carries the id it is waiting for, which is the only
+        // interesting thing about a thread that is not running.
+        let mut blocked = [0u8; 12];
+        let state = match slot.state {
+            crate::task::State::Running => "running",
+            crate::task::State::Ready => "ready",
+            crate::task::State::Finished => "finished",
+            crate::task::State::Blocked { on } => {
+                let text = alloc::format!("wait({})", on);
+                let bytes = text.as_bytes();
+                let take = core::cmp::min(bytes.len(), blocked.len());
+                blocked[..take].copy_from_slice(&bytes[..take]);
+                core::str::from_utf8(&blocked[..take]).unwrap_or("blocked")
+            }
+        };
+
         out!(
             "  {:>3}  {:<12} {:<9} {:>8}",
             slot.id,
             slot.name,
-            match slot.state {
-                crate::task::State::Running => "running",
-                crate::task::State::Ready => "ready",
-                crate::task::State::Finished => "finished",
-            },
+            state,
             slot.ticks
         );
     }

--- a/kernel/src/elf.rs
+++ b/kernel/src/elf.rs
@@ -53,6 +53,10 @@ pub enum ElfError {
     NotExecutable,
     WrongArchitecture,
     NoLoadableSegments,
+    /// More `PT_LOAD` segments than [`MAX_SEGMENTS`], so the range table this
+    /// loader hands back could not describe the whole image — and an image that
+    /// cannot be described cannot be unmapped.
+    TooManySegments,
     SegmentOutOfRange,
     /// A segment wants to live where the kernel already is.
     SegmentInKernelSpace,
@@ -91,11 +95,46 @@ struct Elf64ProgramHeader {
     align: u64,
 }
 
+/// The most `PT_LOAD` segments this loader will map. A `no_std` Rust binary
+/// linked with the scripts in `userspace/` produces three or four.
+pub const MAX_SEGMENTS: usize = 8;
+
+/// A page range this loader mapped, so it can be handed back later.
+#[derive(Debug, Clone, Copy)]
+pub struct MappedRange {
+    pub start: u64,
+    pub pages: usize,
+}
+
 /// A program that has been loaded and is ready to enter.
 pub struct LoadedImage {
     pub entry: u64,
     pub segments: usize,
     pub bytes_mapped: usize,
+    /// Exactly what was mapped, in the order it was mapped.
+    ///
+    /// Returned rather than discarded because a program that cannot be unmapped
+    /// can only be run once: the second `spawn` hits `PageAlreadyMapped`. The
+    /// caller records these and frees them when the program exits.
+    pub ranges: [Option<MappedRange>; MAX_SEGMENTS],
+}
+
+impl LoadedImage {
+    /// Lowest and highest virtual addresses this image occupies, for overlap
+    /// checks against programs that are already resident.
+    pub fn extent(&self) -> (u64, u64) {
+        let mut lo = u64::MAX;
+        let mut hi = 0;
+        for range in self.ranges.iter().flatten() {
+            lo = lo.min(range.start);
+            hi = hi.max(range.start + (range.pages * PAGE_SIZE) as u64);
+        }
+        if lo == u64::MAX {
+            (0, 0)
+        } else {
+            (lo, hi)
+        }
+    }
 }
 
 /// Everything at or above this is kernel territory; a user segment claiming to
@@ -107,7 +146,9 @@ const USER_ADDRESS_LIMIT: u64 = 0x0000_8000_0000_0000;
 ///
 /// # Safety
 /// The caller must ensure no existing user mapping overlaps the segments this
-/// image declares. Phase 6 runs one program at a time, so that holds trivially.
+/// image declares. There is one address space, so that is a real obligation, not
+/// a formality — `usermode::spawn_program` checks it against the table of
+/// resident programs before calling here.
 pub unsafe fn load(image: &[u8]) -> Result<LoadedImage, ElfError> {
     let header = parse_header(image)?;
 
@@ -121,6 +162,7 @@ pub unsafe fn load(image: &[u8]) -> Result<LoadedImage, ElfError> {
 
     let mut segments = 0usize;
     let mut bytes_mapped = 0usize;
+    let mut ranges: [Option<MappedRange>; MAX_SEGMENTS] = [None; MAX_SEGMENTS];
 
     for i in 0..header.phnum as usize {
         let offset = header.phoff as usize + i * header.phentsize as usize;
@@ -134,6 +176,14 @@ pub unsafe fn load(image: &[u8]) -> Result<LoadedImage, ElfError> {
         if ph.p_type != PT_LOAD || ph.memsz == 0 {
             continue;
         }
+
+        if segments >= MAX_SEGMENTS {
+            return Err(ElfError::TooManySegments);
+        }
+
+        // Record the range *before* mapping it, so a failure halfway through
+        // still tells the caller what to tear down.
+        ranges[segments] = Some(segment_range(&ph));
 
         load_segment(image, &ph)?;
 
@@ -149,7 +199,53 @@ pub unsafe fn load(image: &[u8]) -> Result<LoadedImage, ElfError> {
         entry: header.entry,
         segments,
         bytes_mapped,
+        ranges,
     })
+}
+
+/// Lowest and highest virtual address this image *would* occupy, without
+/// mapping anything.
+///
+/// Needed because there is one address space: the only moment at which a
+/// conflicting load can be refused cheaply is before the first page of it has
+/// been mapped. Afterwards the choice is between a half-loaded program and an
+/// unwind path.
+pub fn extent_of(image: &[u8]) -> Result<(u64, u64), ElfError> {
+    let header = parse_header(image)?;
+
+    let mut lo = u64::MAX;
+    let mut hi = 0u64;
+
+    for i in 0..header.phnum as usize {
+        let offset = header.phoff as usize + i * header.phentsize as usize;
+        if offset + core::mem::size_of::<Elf64ProgramHeader>() > image.len() {
+            return Err(ElfError::TooSmall);
+        }
+        let ph: Elf64ProgramHeader =
+            unsafe { core::ptr::read_unaligned(image.as_ptr().add(offset) as *const _) };
+        if ph.p_type != PT_LOAD || ph.memsz == 0 {
+            continue;
+        }
+        let range = segment_range(&ph);
+        lo = lo.min(range.start);
+        hi = hi.max(range.start + (range.pages * PAGE_SIZE) as u64);
+    }
+
+    if lo == u64::MAX {
+        return Err(ElfError::NoLoadableSegments);
+    }
+
+    Ok((lo, hi))
+}
+
+/// Page range a segment occupies, rounded out to page boundaries.
+fn segment_range(ph: &Elf64ProgramHeader) -> MappedRange {
+    let start = ph.vaddr & !(PAGE_SIZE as u64 - 1);
+    let end = (ph.vaddr + ph.memsz + PAGE_SIZE as u64 - 1) & !(PAGE_SIZE as u64 - 1);
+    MappedRange {
+        start,
+        pages: ((end - start) / PAGE_SIZE as u64) as usize,
+    }
 }
 
 fn parse_header(image: &[u8]) -> Result<Elf64Header, ElfError> {
@@ -193,9 +289,7 @@ unsafe fn load_segment(image: &[u8], ph: &Elf64ProgramHeader) -> Result<(), ElfE
         return Err(ElfError::SegmentOutOfRange);
     }
 
-    let start = ph.vaddr & !(PAGE_SIZE as u64 - 1);
-    let end = (ph.vaddr + ph.memsz + PAGE_SIZE as u64 - 1) & !(PAGE_SIZE as u64 - 1);
-    let pages = ((end - start) / PAGE_SIZE as u64) as usize;
+    let MappedRange { start, pages } = segment_range(ph);
 
     let mut flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
     if ph.flags & PF_W != 0 {

--- a/kernel/src/gdt.rs
+++ b/kernel/src/gdt.rs
@@ -1,9 +1,6 @@
 //! GDT and TSS.
 //!
-//! Split out of `boot.rs` in Phase 5, because the descriptor *order* stops
-//! being arbitrary the moment `syscall`/`sysret` exist.
-//!
-//! ## Why the order is forced
+//! ## Why the descriptor order is forced
 //!
 //! `syscall` loads CS from `STAR[47:32]` and SS from `STAR[47:32] + 8`.
 //! `sysretq` loads CS from `STAR[63:48] + 16` and SS from `STAR[63:48] + 8`.
@@ -23,11 +20,17 @@
 //! write out the `sysret` arithmetic; getting it the intuitive way round is a
 //! classic way to land in a #GP the first time a process returns to ring 3.
 //!
-//! Before Phase 5 this table had three entries — kernel code, kernel data,
-//! TSS — so the `cs: 0x1B / ss: 0x23` values in `process/context.rs` pointed at
-//! descriptors that did not exist.
+//! ## Why this is not a `lazy_static`
+//!
+//! `TSS.RSP0` — the stack the CPU switches to when an interrupt arrives in
+//! ring 3 — has to change on every context switch, because it has to name the
+//! *incoming* thread's kernel stack. A `lazy_static` gives out `&TSS` and no way
+//! to mutate it, which is why [`set_kernel_stack`] used to be
+//! `unimplemented!()`. The table and the TSS are now plain statics initialised
+//! imperatively, in a defined order.
 
-use lazy_static::lazy_static;
+use core::ptr::{addr_of, addr_of_mut};
+
 use x86_64::instructions::segmentation::{Segment, CS, DS, ES, FS, GS, SS};
 use x86_64::instructions::tables::load_tss;
 use x86_64::structures::gdt::{Descriptor, GlobalDescriptorTable, SegmentSelector};
@@ -43,35 +46,18 @@ use crate::serial_println;
 pub const DOUBLE_FAULT_IST_INDEX: u16 = 0;
 
 const DOUBLE_FAULT_STACK_SIZE: usize = 4096 * 5;
-const KERNEL_INTERRUPT_STACK_SIZE: usize = 4096 * 5;
+const BOOT_KERNEL_STACK_SIZE: usize = 4096 * 5;
 
 static mut DOUBLE_FAULT_STACK: [u8; DOUBLE_FAULT_STACK_SIZE] = [0; DOUBLE_FAULT_STACK_SIZE];
 
-/// The stack the CPU switches to when an interrupt arrives while running in
-/// ring 3. Without a valid RSP0, the first timer tick after entering user mode
-/// is a triple fault.
-static mut KERNEL_INTERRUPT_STACK: [u8; KERNEL_INTERRUPT_STACK_SIZE] =
-    [0; KERNEL_INTERRUPT_STACK_SIZE];
+/// RSP0 before any thread has claimed it. Only used between `gdt::init` and the
+/// first context switch, during which nothing runs in ring 3.
+static mut BOOT_KERNEL_STACK: [u8; BOOT_KERNEL_STACK_SIZE] = [0; BOOT_KERNEL_STACK_SIZE];
 
-lazy_static! {
-    static ref TSS: TaskStateSegment = {
-        let mut tss = TaskStateSegment::new();
+static mut TSS: TaskStateSegment = TaskStateSegment::new();
+static mut GDT: GlobalDescriptorTable = GlobalDescriptorTable::new();
 
-        tss.interrupt_stack_table[DOUBLE_FAULT_IST_INDEX as usize] = {
-            let start = VirtAddr::from_ptr(&raw const DOUBLE_FAULT_STACK);
-            start + DOUBLE_FAULT_STACK_SIZE
-        };
-
-        // RSP0: ring 3 -> ring 0 stack switch on interrupt.
-        tss.privilege_stack_table[0] = {
-            let start = VirtAddr::from_ptr(&raw const KERNEL_INTERRUPT_STACK);
-            start + KERNEL_INTERRUPT_STACK_SIZE
-        };
-
-        tss
-    };
-}
-
+#[derive(Debug, Clone, Copy)]
 pub struct Selectors {
     pub kernel_code: SegmentSelector,
     pub kernel_data: SegmentSelector,
@@ -80,77 +66,99 @@ pub struct Selectors {
     pub tss: SegmentSelector,
 }
 
-lazy_static! {
-    static ref GDT: (GlobalDescriptorTable, Selectors) = {
-        let mut gdt = GlobalDescriptorTable::new();
+static mut SELECTORS: Option<Selectors> = None;
+
+pub fn selectors() -> Selectors {
+    unsafe { (*addr_of!(SELECTORS)).expect("gdt::init has not run") }
+}
+
+/// Build the TSS and GDT, load them, and reload every segment register.
+pub fn init() {
+    serial_println!("Setting up GDT and TSS...");
+
+    unsafe {
+        let tss = &mut *addr_of_mut!(TSS);
+
+        tss.interrupt_stack_table[DOUBLE_FAULT_IST_INDEX as usize] = {
+            let start = VirtAddr::from_ptr(addr_of!(DOUBLE_FAULT_STACK));
+            start + DOUBLE_FAULT_STACK_SIZE
+        };
+
+        tss.privilege_stack_table[0] = {
+            let start = VirtAddr::from_ptr(addr_of!(BOOT_KERNEL_STACK));
+            start + BOOT_KERNEL_STACK_SIZE
+        };
+
+        let gdt = &mut *addr_of_mut!(GDT);
 
         // Order is load-bearing — see the module docs.
         let kernel_code = gdt.add_entry(Descriptor::kernel_code_segment());
         let kernel_data = gdt.add_entry(Descriptor::kernel_data_segment());
         let user_data = gdt.add_entry(Descriptor::user_data_segment());
         let user_code = gdt.add_entry(Descriptor::user_code_segment());
-        let tss = gdt.add_entry(Descriptor::tss_segment(&TSS));
+        let tss_sel = gdt.add_entry(Descriptor::tss_segment(&*addr_of!(TSS)));
 
-        (
-            gdt,
-            Selectors {
-                kernel_code,
-                kernel_data,
-                user_data,
-                user_code,
-                tss,
-            },
-        )
-    };
-}
+        let selectors = Selectors {
+            kernel_code,
+            kernel_data,
+            user_data,
+            user_code,
+            tss: tss_sel,
+        };
+        *addr_of_mut!(SELECTORS) = Some(selectors);
 
-pub fn selectors() -> &'static Selectors {
-    &GDT.1
-}
+        gdt.load();
 
-/// Load the GDT, reload every segment register, and install the TSS.
-pub fn init() {
-    serial_println!("Setting up GDT and TSS...");
+        CS::set_reg(kernel_code);
+        DS::set_reg(kernel_data);
+        ES::set_reg(kernel_data);
+        FS::set_reg(kernel_data);
+        GS::set_reg(kernel_data);
+        SS::set_reg(kernel_data);
 
-    GDT.0.load();
+        load_tss(tss_sel);
 
-    let sel = selectors();
-
-    unsafe {
-        CS::set_reg(sel.kernel_code);
-        DS::set_reg(sel.kernel_data);
-        ES::set_reg(sel.kernel_data);
-        FS::set_reg(sel.kernel_data);
-        GS::set_reg(sel.kernel_data);
-        SS::set_reg(sel.kernel_data);
-
-        load_tss(sel.tss);
+        serial_println!(
+            "  selectors: kcode 0x{:x}, kdata 0x{:x}, udata 0x{:x}, ucode 0x{:x}, tss 0x{:x}",
+            kernel_code.0,
+            kernel_data.0,
+            user_data.0,
+            user_code.0,
+            tss_sel.0
+        );
+        serial_println!(
+            "  TSS.RSP0 = 0x{:x} (boot stack; per-thread from the first switch)",
+            tss.privilege_stack_table[0].as_u64()
+        );
     }
-
-    serial_println!(
-        "  selectors: kcode 0x{:x}, kdata 0x{:x}, udata 0x{:x}, ucode 0x{:x}, tss 0x{:x}",
-        sel.kernel_code.0,
-        sel.kernel_data.0,
-        sel.user_data.0,
-        sel.user_code.0,
-        sel.tss.0
-    );
-    serial_println!(
-        "  TSS.RSP0 = 0x{:x} (ring 3 -> ring 0 interrupt stack)",
-        TSS.privilege_stack_table[0].as_u64()
-    );
 }
 
-/// Point RSP0 at a specific kernel stack.
+/// Point RSP0 at `top`.
 ///
-/// Phase 5 runs exactly one ring-3 thread, so the static stack above is enough.
-/// Once several threads can be in user mode, this must be called on every
-/// context switch with the incoming thread's kernel stack — otherwise two
-/// threads share one interrupt stack and corrupt each other's frames.
-#[allow(dead_code)]
-pub fn set_kernel_stack(_top: VirtAddr) {
-    // Deliberately not implemented yet rather than silently doing nothing:
-    // the TSS is behind a `lazy_static` and needs interior mutability to
-    // update. Phase 6 turns the TSS into a `static mut` per CPU.
-    unimplemented!("per-thread RSP0 arrives with multiple user threads");
+/// Called on every context switch with the incoming thread's kernel stack.
+/// Without this, two threads in ring 3 would share one interrupt stack and
+/// corrupt each other's exception frames the moment both were interrupted.
+///
+/// Note that the same stack serves a thread's syscalls and its ring-3
+/// interrupts. That is safe because RSP0 is only consumed when the CPU switches
+/// *from* ring 3: if the thread is already in the kernel, an interrupt stays on
+/// the stack it is already using, and the syscall frame is not at risk.
+pub fn set_kernel_stack(top: VirtAddr) {
+    unsafe {
+        (*addr_of_mut!(TSS)).privilege_stack_table[0] = top;
+    }
+}
+
+/// Current RSP0, for diagnostics.
+pub fn kernel_stack() -> VirtAddr {
+    unsafe { (*addr_of!(TSS)).privilege_stack_table[0] }
+}
+
+/// Top of the stack `init` installed as RSP0.
+///
+/// `task::init` adopts this as thread 0's kernel stack, so that the bootstrap
+/// context has a real answer for `gs:0` rather than a zero.
+pub fn boot_kernel_stack_top() -> VirtAddr {
+    let start = VirtAddr::from_ptr(unsafe { addr_of!(BOOT_KERNEL_STACK) });
+    (start + BOOT_KERNEL_STACK_SIZE).align_down(16u64)
 }

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -21,6 +21,8 @@ mod task;
 #[cfg(target_arch = "x86_64")]
 mod gdt;
 #[cfg(target_arch = "x86_64")]
+mod percpu;
+#[cfg(target_arch = "x86_64")]
 mod block;
 #[cfg(target_arch = "x86_64")]
 mod console;
@@ -316,14 +318,20 @@ fn supervisor(_arg: usize) {
         serial_println!("Kosh: starting the userspace shell");
 
         match task::spawn("ksh", usermode::run_shell, 0) {
-            Ok(_) => {
-                // Wait for it. `live_threads` counts everything except thread 0,
-                // and by this point the supervisor and ksh are the only two.
-                while task::live_threads() > 1 {
-                    x86_64::instructions::hlt();
-                }
+            Ok(shell) => {
+                // `wait_for` blocks in `State::Blocked` until ksh exits. This
+                // used to spin on `live_threads() > 1`, with a comment saying the
+                // supervisor and ksh were the only two threads — which stopped
+                // being true the moment ksh could spawn a program of its own.
+                let status = task::wait_for(shell);
                 serial_println!();
-                serial_println!("Kosh: ksh exited, falling back to the kernel console");
+                match status {
+                    Ok(code) => serial_println!(
+                        "Kosh: ksh exited with code {}, falling back to the kernel console",
+                        code
+                    ),
+                    Err(e) => serial_println!("Kosh: ksh wait failed ({}), taking the console", e),
+                }
                 task::reap_finished();
             }
             Err(e) => serial_println!("Kosh: could not start ksh: {}", e),

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -384,6 +384,46 @@ pub fn map_user_pages(
     Ok(())
 }
 
+/// Unmap `pages` user pages at `virt` and return their frames to the allocator.
+///
+/// The counterpart to [`map_user_pages`], and the reason a program can be run
+/// twice. Without it, the second `spawn` of the same binary failed in
+/// `map_to_with_table_flags` with `PageAlreadyMapped` — after the loader had
+/// already allocated a frame for that page, so each attempt also leaked one.
+///
+/// Returns how many pages were actually unmapped; a page that was not mapped is
+/// skipped rather than treated as an error, so tearing down a partially-loaded
+/// image is safe.
+///
+/// # Safety
+/// Nothing may still be using these addresses. In particular the caller must not
+/// be running *on* them — which is why teardown happens from the reaping thread,
+/// not from the exiting one.
+pub unsafe fn unmap_user_pages(virt: u64, pages: usize) -> usize {
+    let mut mapper = active_mapper();
+    let mut freed = 0;
+
+    for i in 0..pages {
+        let page: Page<Size4KiB> =
+            Page::containing_address(VirtAddr::new(virt + (i * PAGE_SIZE) as u64));
+
+        match mapper.unmap(page) {
+            Ok((frame, flush)) => {
+                flush.flush();
+                crate::memory::physical::deallocate_frame(PageFrame::from_address(
+                    frame.start_address().as_u64() as usize,
+                ));
+                freed += 1;
+            }
+            Err(_) => {
+                // Already absent. Nothing to free, nothing to complain about.
+            }
+        }
+    }
+
+    freed
+}
+
 /// Borrow the live page tables through the physmap.
 ///
 /// # Safety

--- a/kernel/src/percpu.rs
+++ b/kernel/src/percpu.rs
@@ -1,0 +1,160 @@
+//! Per-CPU state, reached through GS.
+//!
+//! ## Why this exists
+//!
+//! `syscall` gives the kernel no stack. It loads CS, SS and RIP from MSRs and
+//! leaves RSP pointing at the *user* stack, so the first thing the entry stub
+//! must do is find a kernel stack — without touching any register the caller
+//! cares about, and with no stack to spill to.
+//!
+//! Until now the stub read a single global, `SYSCALL_KERNEL_RSP`. That worked
+//! exactly as long as only one thread could ever be in ring 3: a second thread
+//! entering a syscall while the first was parked inside one would take the same
+//! stack from the top and overwrite its frame. Half a dozen comments in this
+//! kernel said so, and `files::wait_for_key` — which enables interrupts inside a
+//! syscall so a blocking `read` can be woken by the keyboard IRQ — is precisely
+//! the code path that makes "parked inside one" reachable.
+//!
+//! The fix is two-part: the stack pointer the stub loads becomes per-thread
+//! (here), and the stub parks the user's RSP on that stack instead of in a
+//! global (`syscall/entry.rs`).
+//!
+//! ## Why GS.base, and why no `swapgs`
+//!
+//! The textbook mechanism is `swapgs`: user mode keeps its own GS.base, the
+//! kernel's lives in `IA32_KERNEL_GS_BASE`, and each kernel entry and exit
+//! exchanges them. That invariant only holds if *every* transition swaps, and
+//! this kernel cannot honour that. Its interrupt handlers are Rust functions
+//! using `x86-interrupt`, which gives no place to put a `swapgs` before the
+//! compiler-generated prologue — so an interrupt taken from ring 3 enters the
+//! kernel without swapping. As soon as a timer tick can land inside a syscall
+//! (see `wait_for_key` above) the swap count stops being even, and a later
+//! `swapgs` leaves GS.base holding user data. `movq %gs:0, %rsp` would then load
+//! garbage as the kernel stack pointer — with no fault to point at the cause.
+//!
+//! So both MSRs point at the same block: GS.base for the accesses, and
+//! `IA32_KERNEL_GS_BASE` so that a `swapgs` from anywhere — including one added
+//! later — is a no-op rather than a bug. `gs:0` reads per-CPU data in every ring
+//! and after any number of swaps.
+//!
+//! Ring 3 cannot subvert this. Writing GS.base needs `wrgsbase` (CR4.FSGSBASE is
+//! clear) or `wrmsr` (ring 0), and the `swapgs` instruction itself is #GP in
+//! ring 3. The real cost is that user-mode TLS via GS is off the table until
+//! entry becomes swap-based, which needs naked interrupt stubs first.
+//!
+//! ## Field offsets are part of the ABI
+//!
+//! `syscall/entry.rs` addresses these fields as `%gs:0` and `%gs:8`. Reordering
+//! them silently breaks the syscall path, so the layout is `repr(C)` and the
+//! offsets are asserted at compile time.
+
+use core::ptr::{addr_of, addr_of_mut};
+
+use x86_64::registers::model_specific::{GsBase, KernelGsBase};
+use x86_64::VirtAddr;
+
+use crate::serial_println;
+
+#[repr(C)]
+pub struct PerCpu {
+    /// Kernel stack top for the currently-running thread's system calls.
+    /// Offset 0 — read by the syscall stub as `gs:0`.
+    pub syscall_rsp: u64,
+    /// Scratch slot where the stub parks the user's RSP for the two
+    /// instructions it takes to get onto the kernel stack. Offset 8 — `gs:8`.
+    ///
+    /// Per-CPU rather than per-thread, which is only sound because the window it
+    /// is live for runs with interrupts masked by `SFMASK`. The stub immediately
+    /// pushes the value onto the kernel stack, where it *is* per-thread, and
+    /// never reads this slot again.
+    pub user_rsp_scratch: u64,
+    /// Which thread the two fields above belong to. Diagnostics only — but it is
+    /// what makes a mismatch visible. Offset 16.
+    pub current_thread: u64,
+}
+
+impl PerCpu {
+    const fn new() -> Self {
+        Self {
+            syscall_rsp: 0,
+            user_rsp_scratch: 0,
+            current_thread: 0,
+        }
+    }
+}
+
+/// The one and only CPU's block. Becomes an array indexed by APIC id if SMP
+/// ever arrives — at which point `swapgs` and naked interrupt stubs become
+/// mandatory, not optional.
+static mut PER_CPU: PerCpu = PerCpu::new();
+
+// The assembly addresses these by offset, so a reordering has to be a build
+// error rather than a mystery at run time.
+const _: () = {
+    assert!(core::mem::offset_of!(PerCpu, syscall_rsp) == 0);
+    assert!(core::mem::offset_of!(PerCpu, user_rsp_scratch) == 8);
+    assert!(core::mem::offset_of!(PerCpu, current_thread) == 16);
+};
+
+/// Point GS.base — and `IA32_KERNEL_GS_BASE` — at the per-CPU block.
+///
+/// Must run before `syscall::init`, because the stub it installs dereferences
+/// `gs:0` on the very first system call.
+pub fn init() {
+    let addr = unsafe { addr_of!(PER_CPU) as u64 };
+    let va = VirtAddr::new(addr);
+
+    unsafe {
+        GsBase::write(va);
+        KernelGsBase::write(va);
+    }
+
+    // Seeded, not left at zero. `task::init` overwrites this with thread 0's
+    // stack — but it runs *after* `syscall::init`, and a `gs:0` of zero would
+    // turn any syscall issued in between into a page fault at address 0 with no
+    // frame to read. Same stack, published early.
+    set_syscall_stack(crate::gdt::boot_kernel_stack_top().as_u64());
+
+    serial_println!(
+        "Per-CPU block at 0x{:x} (GS.base and IA32_KERNEL_GS_BASE, so swapgs is a no-op)",
+        addr
+    );
+    serial_println!("  gs:0 = 0x{:x} (boot kernel stack)", syscall_stack());
+}
+
+/// Set the kernel stack the syscall stub will switch to.
+///
+/// Called on every context switch with the incoming thread's stack. That is the
+/// whole point of the exercise: the value is per-thread, not per-kernel.
+pub fn set_syscall_stack(top: u64) {
+    unsafe {
+        (*addr_of_mut!(PER_CPU)).syscall_rsp = top;
+    }
+}
+
+pub fn set_current_thread(id: u64) {
+    unsafe {
+        (*addr_of_mut!(PER_CPU)).current_thread = id;
+    }
+}
+
+pub fn syscall_stack() -> u64 {
+    unsafe { (*addr_of!(PER_CPU)).syscall_rsp }
+}
+
+pub fn current_thread() -> u64 {
+    unsafe { (*addr_of!(PER_CPU)).current_thread }
+}
+
+/// Read `gs:0` the way the syscall stub does, and compare it with the static.
+///
+/// A self-test rather than a getter: if the GS base were wrong, every syscall
+/// would take a page fault on its first instruction with nothing but a stack
+/// pointer of `0` to explain it. Cheaper to find out here.
+pub fn check_gs_addressing() -> bool {
+    let via_gs: u64;
+    unsafe {
+        core::arch::asm!("mov {}, gs:[0]", out(reg) via_gs, options(nostack, readonly));
+    }
+    via_gs == syscall_stack()
+}

--- a/kernel/src/syscall/dispatcher.rs
+++ b/kernel/src/syscall/dispatcher.rs
@@ -62,6 +62,8 @@ pub fn dispatch_syscall(
         SYS_GETPID => sys_getpid(process_id, args),
         SYS_GETPPID => sys_getppid(process_id, args),
         SYS_KILL => sys_kill(process_id, args),
+        SYS_YIELD => sys_yield(process_id, args),
+        SYS_SPAWN => sys_spawn(process_id, args),
         
         // Memory management
         SYS_MMAP => sys_mmap(process_id, args),
@@ -157,13 +159,34 @@ fn sys_exit(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
         exit_code
     );
 
-    // Nothing else will do it: there is no process teardown path yet.
-    crate::syscall::files::close_all();
+    // The descriptor table is global — one table for the whole system, because
+    // there is no per-process state to hang one off. So closing everything is
+    // only safe when this is the last program running; otherwise a short-lived
+    // program exiting would close the shell's open files behind its back.
+    #[cfg(target_arch = "x86_64")]
+    let last_program = crate::usermode::resident_count() <= 1;
+    #[cfg(not(target_arch = "x86_64"))]
+    let last_program = true;
+
+    if last_program {
+        crate::syscall::files::close_all();
+    } else {
+        serial_println!(
+            "  (leaving {} open file(s) alone: another program is still resident)",
+            crate::syscall::files::open_count()
+        );
+    }
 
     // Actually terminate. The ring-3 program runs on a kernel thread, so
     // retiring that thread is the exit: `exit_current` marks it finished and
     // schedules away, and never returns. Previously this logged and returned
     // Ok(0), leaving the caller running as if nothing had happened.
+    //
+    // The code is recorded first, because `exit_current` does not return and
+    // whoever is in `wait` needs something to collect.
+    #[cfg(target_arch = "x86_64")]
+    crate::task::set_exit_code(exit_code);
+
     #[cfg(target_arch = "x86_64")]
     crate::task::exit_current();
 
@@ -171,24 +194,37 @@ fn sys_exit(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
     Ok(0)
 }
 
+/// Not implemented, and now says so.
+///
+/// This used to add a row to the process table, log "Fork successful", and
+/// return the new PID — without duplicating an address space, copying a stack,
+/// or creating anything that could run. Userspace saw a positive return value,
+/// concluded it was the parent, and carried on; the "child" never existed. A
+/// syscall that reports success for work it did not do is worse than one that
+/// refuses, because the caller has no way to find out.
+///
+/// Honest `fork` needs per-process page tables, which needs the kernel out of
+/// the low identity mapping first. Until then, `Err`.
 fn sys_fork(process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
-    serial_println!("Process {} attempting to fork", process_id.0);
-    
-    // Create a new child process
-    match crate::process::create_process(
-        Some(process_id),
-        format!("child_of_{}", process_id.0),
-        crate::process::ProcessPriority::Normal,
-    ) {
-        Ok(child_pid) => {
-            serial_println!("Fork successful: parent={}, child={}", process_id.0, child_pid.0);
-            // Return child PID to parent process
-            // Note: In a real implementation, the child would receive 0
-            // This requires more complex context switching implementation
-            Ok(child_pid.0 as u64)
-        }
-        Err(_) => Err(SyscallError::OutOfMemory)
-    }
+    serial_println!(
+        "Process {} called fork, which needs per-process address spaces (not implemented)",
+        process_id.0
+    );
+    Err(SyscallError::NotSupported)
+}
+
+/// Give up the rest of the current time slice.
+///
+/// The interesting part is where this runs: inside a system call, on the calling
+/// thread's own kernel stack, with a live `SyscallFrame` on it. `yield_now` ends
+/// in `kosh_switch_context`, so another thread can enter a syscall of its own
+/// while this frame is parked — which is precisely what a single shared syscall
+/// stack could not survive.
+fn sys_yield(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
+    #[cfg(target_arch = "x86_64")]
+    crate::task::yield_now();
+
+    Ok(0)
 }
 
 fn sys_exec(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
@@ -208,16 +244,87 @@ fn sys_exec(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
     Err(SyscallError::NotSupported)
 }
 
+/// `spawn(path, path_len)` -> task id
+///
+/// Deliberately not called `exec`: `exec` replaces the calling image, and
+/// `fork`+`exec` needs two address spaces. This loads a *second* program into
+/// the one address space that exists and runs it on its own thread — which is
+/// enough for a shell to launch a program, and honest about what it is.
+///
+/// `path` names a boot module (`module2 /boot/hello hello` in grub.cfg), not a
+/// file on the FAT32 volume. Loading from disk needs the loader to read through
+/// the VFS, which is a separate job from this one.
+#[cfg(target_arch = "x86_64")]
+fn sys_spawn(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
+    use crate::usermode::SpawnError;
+
+    let name = crate::syscall::files::path_from_user(args[0], args[1])?;
+    let name = name.trim_start_matches('/');
+
+    serial_println!("Process {} spawning '{}'", process_id.0, name);
+
+    match crate::usermode::spawn_program(name) {
+        Ok(thread) => Ok(thread as u64),
+        // A shell turns this one into "command not found", so it must not be
+        // lumped in with the others.
+        Err(SpawnError::NotFound) => Err(SyscallError::NotFound),
+        Err(SpawnError::AddressConflict) => Err(SyscallError::AddressInUse),
+        Err(SpawnError::TooManyPrograms) | Err(SpawnError::NoThread(_)) => {
+            Err(SyscallError::ResourceExhausted)
+        }
+        Err(SpawnError::Map(e)) => {
+            serial_println!("  spawn mapping failed: {}", e);
+            Err(SyscallError::OutOfMemory)
+        }
+        Err(SpawnError::Load(e)) => {
+            serial_println!("  spawn load failed: {:?}", e);
+            Err(SyscallError::InvalidArgument)
+        }
+    }
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn sys_spawn(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
+    Err(SyscallError::NotSupported)
+}
+
+/// `wait(task_id, status_ptr)` -> task id
+///
+/// Blocks — really blocks, in `State::Blocked`, not in a yield loop — until that
+/// task finishes, then writes its exit code to `status_ptr` if that is non-null.
+///
+/// This used to be a `serial_println!` and `Err(NotSupported)` under a three-line
+/// TODO. It takes a task id rather than "any child" because there is no process
+/// hierarchy to define a child with; `spawn` returns the id it expects back.
+#[cfg(target_arch = "x86_64")]
 fn sys_wait(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
-    let status_ptr = args[0];
-    
-    serial_println!("Process {} waiting for child process", process_id.0);
-    
-    // TODO: Implement process waiting
-    // This would involve:
-    // 1. Blocking until a child process exits
-    // 2. Returning the child's PID and exit status
-    
+    let task_id = args[0] as usize;
+    let status_ptr = args[1];
+
+    // Validate the destination *before* blocking. Failing afterwards would mean
+    // the child has already been reaped and its exit code thrown away, with
+    // nothing to return it to.
+    if status_ptr != 0 {
+        crate::syscall::uaccess::validate_user_range(status_ptr, 4, true)
+            .map_err(|_| SyscallError::InvalidArgument)?;
+    }
+
+    let code = crate::task::wait_for(task_id).map_err(|e| {
+        serial_println!("Process {} wait({}) failed: {}", process_id.0, task_id, e);
+        SyscallError::InvalidArgument
+    })?;
+
+    if status_ptr != 0 {
+        let bytes = code.to_le_bytes();
+        crate::syscall::uaccess::copy_to_user(status_ptr, &bytes)
+            .map_err(|_| SyscallError::InvalidArgument)?;
+    }
+
+    Ok(task_id as u64)
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn sys_wait(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
     Err(SyscallError::NotSupported)
 }
 

--- a/kernel/src/syscall/entry.rs
+++ b/kernel/src/syscall/entry.rs
@@ -37,32 +37,6 @@ use x86_64::VirtAddr;
 use crate::process::ProcessId;
 use crate::serial_println;
 
-/// Kernel stack used while servicing a syscall.
-///
-/// One static stack is correct only because exactly one thread can be in ring 3
-/// in Phase 5, and `SFMASK` masks IF so a syscall cannot be interrupted into a
-/// second syscall. Multiple user threads need this to become per-thread, reached
-/// through `swapgs` and a per-CPU block — see the note on `SAVED_USER_RSP`.
-const SYSCALL_STACK_SIZE: usize = 32 * 1024;
-
-#[repr(align(16))]
-struct SyscallStack([u8; SYSCALL_STACK_SIZE]);
-
-static mut SYSCALL_STACK: SyscallStack = SyscallStack([0; SYSCALL_STACK_SIZE]);
-
-/// Top of the syscall stack, read by the assembly stub.
-#[no_mangle]
-static mut SYSCALL_KERNEL_RSP: u64 = 0;
-
-/// Where the stub parks the user's RSP for the duration of the call.
-///
-/// A plain static rather than `swapgs` + per-CPU data: single CPU, single
-/// ring-3 thread, and interrupts masked during the call, so nothing can
-/// re-enter. The moment any of those three stops being true this must become
-/// `swapgs`-based, or two concurrent syscalls will trample each other's stacks.
-#[no_mangle]
-static mut SAVED_USER_RSP: u64 = 0;
-
 /// Registers the stub pushes, in push order (so the first field is at the
 /// lowest address — the layout the stub builds by pushing RAX last).
 #[repr(C)]
@@ -78,6 +52,15 @@ pub struct SyscallFrame {
     pub rip: u64,
     /// User RFLAGS, delivered in R11. `sysretq` needs it back there.
     pub rflags: u64,
+    /// The caller's RSP, saved *on this thread's kernel stack* rather than in a
+    /// global. Pushed first, so it sits at the highest address in the frame.
+    ///
+    /// This is what makes a preempted syscall safe. It used to live in a static
+    /// `SAVED_USER_RSP`, which meant a second thread entering a syscall while
+    /// the first was blocked inside one would overwrite the first thread's user
+    /// stack pointer — and `sysretq` would then return it to ring 3 with
+    /// somebody else's RSP.
+    pub user_rsp: u64,
 }
 
 extern "C" {
@@ -93,14 +76,21 @@ core::arch::global_asm!(
 kosh_syscall_entry:
     /* On entry: RSP is still the *user* stack, RCX = user RIP,
        R11 = user RFLAGS, RAX = syscall number. Interrupts are already masked
-       by SFMASK. */
+       by SFMASK, which is what makes the scratch slot below safe.
 
-    movq    %rsp, SAVED_USER_RSP(%rip)
-    movq    SYSCALL_KERNEL_RSP(%rip), %rsp
+       No register is free — RCX and R11 carry the return state, everything
+       else is the caller's — so the hop from the user stack to the kernel one
+       has to go through memory. gs: addressing needs no register at all. */
 
-    /* Build SyscallFrame. Pushed high field first so RAX lands lowest. */
-    pushq   %r11                /* rflags */
-    pushq   %rcx                /* rip    */
+    movq    %rsp, %gs:8         /* park the user RSP in the per-CPU scratch */
+    movq    %gs:0, %rsp         /* this thread's own kernel stack           */
+
+    /* Build SyscallFrame. Pushed high field first so RAX lands lowest.
+       The scratch value moves onto the kernel stack immediately: from here on
+       it is per-thread, so a preemption cannot lose it. */
+    pushq   %gs:8               /* user_rsp */
+    pushq   %r11                /* rflags   */
+    pushq   %rcx                /* rip      */
     pushq   %r9
     pushq   %r8
     pushq   %r10
@@ -111,11 +101,10 @@ kosh_syscall_entry:
 
     movq    %rsp, %rdi          /* &mut SyscallFrame */
 
-    /* SysV wants RSP 16-byte aligned at the call. Nine pushes from a
-       16-aligned top leaves it 8 past, so nudge it. */
-    subq    $8, %rsp
+    /* SysV wants RSP 16-byte aligned at the call. Ten pushes from a 16-aligned
+       top land back on 16, so there is nothing to correct — unlike the nine
+       pushes this had before user_rsp joined the frame. */
     call    kosh_syscall_handler
-    addq    $8, %rsp
 
     movq    %rax, (%rsp)        /* return value into frame.rax */
 
@@ -129,7 +118,7 @@ kosh_syscall_entry:
     popq    %rcx                /* sysretq takes the target RIP here    */
     popq    %r11                /* ...and the target RFLAGS here        */
 
-    movq    SAVED_USER_RSP(%rip), %rsp
+    movq    (%rsp), %rsp        /* frame.user_rsp — the last word we own */
     sysretq
 "#,
     options(att_syntax)
@@ -143,9 +132,11 @@ pub extern "C" fn kosh_syscall_handler(frame: &mut SyscallFrame) -> u64 {
 
     SYSCALL_COUNT.fetch_add(1, Ordering::Relaxed);
 
-    // Phase 5 runs a single ring-3 thread; a real current-process lookup lands
-    // with the process table in Phase 6.
-    let pid = ProcessId::new(1);
+    // The calling thread's id, which is now a real answer rather than the
+    // hardcoded `1` this used while only one thread could be in ring 3. It is
+    // also what `spawn` returns and what `wait` takes, so a log line naming a
+    // process can be matched against one naming a task.
+    let pid = ProcessId::new(crate::task::current_id() as u32);
 
     match crate::syscall::dispatcher::dispatch_syscall(pid, number, args) {
         Ok(value) => value,
@@ -181,13 +172,6 @@ pub fn init() {
     let sel = crate::gdt::selectors();
 
     unsafe {
-        SYSCALL_KERNEL_RSP = {
-            let base = &raw const SYSCALL_STACK as u64;
-            (base + SYSCALL_STACK_SIZE as u64) & !0xF
-        };
-    }
-
-    unsafe {
         // Without SCE, `syscall` is an invalid opcode.
         Efer::update(|flags| flags.insert(EferFlags::SYSTEM_CALL_EXTENSIONS));
 
@@ -198,10 +182,11 @@ pub fn init() {
 
         LStar::write(VirtAddr::new(kosh_syscall_entry as usize as u64));
 
-        // Bits cleared in RFLAGS on entry. Masking IF means a syscall cannot be
-        // interrupted — which is what makes the single static kernel stack
-        // above safe. DF is masked so string instructions behave; TF so a
-        // single-stepping debugger in userspace does not trap in the kernel.
+        // Bits cleared in RFLAGS on entry. Masking IF means a syscall starts
+        // uninterruptible, which is what makes the per-CPU scratch slot in the
+        // stub safe; a handler that wants to block re-enables it deliberately.
+        // DF is masked so string instructions behave; TF so a single-stepping
+        // debugger in userspace does not trap into the kernel.
         SFMask::write(
             RFlags::INTERRUPT_FLAG | RFlags::DIRECTION_FLAG | RFlags::TRAP_FLAG,
         );
@@ -216,10 +201,15 @@ pub fn init() {
         sel.user_code.0 | 3,
         sel.user_data.0 | 3
     );
+    serial_println!("  LSTAR -> 0x{:x}", kosh_syscall_entry as usize as u64);
     serial_println!(
-        "  LSTAR -> 0x{:x}, kernel stack 0x{:x}",
-        kosh_syscall_entry as usize as u64,
-        unsafe { SYSCALL_KERNEL_RSP }
+        "  kernel stack from gs:0 = 0x{:x} (per-thread), gs addressing {}",
+        crate::percpu::syscall_stack(),
+        if crate::percpu::check_gs_addressing() {
+            "OK"
+        } else {
+            "BROKEN"
+        }
     );
     serial_println!("  SFMASK masks IF, DF, TF");
 }

--- a/kernel/src/syscall/files.rs
+++ b/kernel/src/syscall/files.rs
@@ -53,7 +53,7 @@ fn fs_error_to_syscall(e: FsError) -> SyscallError {
 }
 
 /// Read a path out of user memory and validate it.
-fn path_from_user(ptr: u64, len: u64) -> Result<String, SyscallError> {
+pub fn path_from_user(ptr: u64, len: u64) -> Result<String, SyscallError> {
     let len = len as usize;
     if len == 0 || len > MAX_PATH {
         return Err(SyscallError::InvalidArgument);

--- a/kernel/src/syscall/numbers.rs
+++ b/kernel/src/syscall/numbers.rs
@@ -9,6 +9,15 @@ pub const SYS_WAIT: u64 = 4;
 pub const SYS_GETPID: u64 = 5;
 pub const SYS_GETPPID: u64 = 6;
 pub const SYS_KILL: u64 = 7;
+/// Give up the rest of this thread's time slice.
+///
+/// Cheap to implement and unusually useful as a test: it is the only way for
+/// userspace to force a context switch *from inside a system call*, which is
+/// exactly the situation per-thread kernel stacks exist for.
+pub const SYS_YIELD: u64 = 8;
+/// Load a named program and run it. Not `fork`+`exec`: there is one address
+/// space, so there is nothing to duplicate. `spawn(path, len) -> task id`.
+pub const SYS_SPAWN: u64 = 9;
 
 /// Memory management system calls
 pub const SYS_MMAP: u64 = 10;
@@ -92,7 +101,9 @@ pub fn syscall_name(syscall_number: u64) -> &'static str {
         SYS_GETPID => "getpid",
         SYS_GETPPID => "getppid",
         SYS_KILL => "kill",
-        
+        SYS_YIELD => "yield",
+        SYS_SPAWN => "spawn",
+
         SYS_MMAP => "mmap",
         SYS_MUNMAP => "munmap",
         SYS_MPROTECT => "mprotect",

--- a/kernel/src/syscall/validation.rs
+++ b/kernel/src/syscall/validation.rs
@@ -21,7 +21,8 @@ pub fn validate_syscall_args(
         SYS_FORK => validate_fork_args(args),
         SYS_EXEC => validate_exec_args(process_id, args),
         SYS_WAIT => validate_wait_args(args),
-        SYS_GETPID | SYS_GETPPID => validate_no_args(args),
+        SYS_SPAWN => validate_spawn_args(process_id, args),
+        SYS_GETPID | SYS_GETPPID | SYS_YIELD => validate_no_args(args),
         SYS_KILL => validate_kill_args(args),
         
         SYS_MMAP => validate_mmap_args(args),
@@ -144,9 +145,24 @@ fn validate_exec_args(process_id: ProcessId, args: &[u64; 6]) -> Result<(), Sysc
     Ok(())
 }
 
-fn validate_wait_args(args: &[u64; 6]) -> Result<(), SyscallError> {
-    // Wait can take a status pointer (optional)
+/// `wait(task_id, status_ptr)`.
+///
+/// The status pointer is optional and checked in the handler rather than here,
+/// because the handler has to check it *before* blocking — validating a
+/// destination after the child has been reaped leaves nowhere to put the answer.
+fn validate_wait_args(_args: &[u64; 6]) -> Result<(), SyscallError> {
     Ok(())
+}
+
+/// `spawn(path_ptr, path_len)`.
+fn validate_spawn_args(process_id: ProcessId, args: &[u64; 6]) -> Result<(), SyscallError> {
+    let path_ptr = args[0];
+    let path_len = args[1];
+
+    if path_len == 0 || path_len > 255 {
+        return Err(SyscallError::InvalidArgument);
+    }
+    validate_user_pointer(process_id, path_ptr, path_len as usize, false)
 }
 
 fn validate_no_args(args: &[u64; 6]) -> Result<(), SyscallError> {

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -43,8 +43,12 @@ use switch::kosh_switch_context;
 /// leave that pointer dangling.
 const MAX_THREADS: usize = 16;
 
-/// Per-thread kernel stack. Generous — these are debug-friendly, not tight.
-const STACK_SIZE: usize = 16 * 1024;
+/// Per-thread kernel stack.
+///
+/// This is also the stack a thread's *system calls* run on once it is in ring 3,
+/// which is why it is no longer 16 KiB: the FAT32 and ATA paths buffer whole
+/// sectors, and the old dedicated syscall stack was 32 KiB.
+const STACK_SIZE: usize = 32 * 1024;
 
 /// Timer ticks a thread runs before being preempted. 100 Hz tick, so 2 ticks is
 /// a 20 ms slice.
@@ -54,6 +58,11 @@ const TIME_SLICE_TICKS: u32 = 2;
 pub enum State {
     Ready,
     Running,
+    /// Waiting for the thread with this id to finish. Skipped by the scheduler,
+    /// so a `wait` costs nothing while it blocks — as opposed to spinning on
+    /// `yield_now`, which is what the first version of this did and which meant
+    /// a shell waiting for a child consumed half the CPU.
+    Blocked { on: usize },
     Finished,
 }
 
@@ -65,10 +74,23 @@ pub struct Thread {
     /// Owning handle to the stack. `None` for the bootstrap thread, which runs
     /// on the stack the boot trampoline set up.
     _stack: Option<Box<[u8]>>,
+    /// Top of this thread's kernel stack, 16-aligned.
+    ///
+    /// Published to `TSS.RSP0` and to `gs:0` on every switch to this thread, so
+    /// that an interrupt taken in ring 3 and a `syscall` from ring 3 both land
+    /// on *this* thread's stack. Safe to reuse from the top because entering
+    /// ring 3 is `-> !`: `enter_ring3` never returns, so nothing below is live
+    /// while the thread is in user mode.
+    kernel_stack_top: u64,
     state: State,
     entry: Option<(fn(usize), usize)>,
     /// Ticks this thread has been scheduled for — a cheap fairness check.
     ticks: u64,
+    /// Set by `sys_exit` before the thread retires, collected by `wait_for`.
+    exit_code: i32,
+    /// Another thread is in `wait_for` on this one, so `reap_finished` must
+    /// leave the slot alone until that waiter has collected the exit code.
+    awaited: bool,
 }
 
 impl Thread {
@@ -81,7 +103,10 @@ impl Thread {
     /// The trailing dummy word exists for ABI alignment: after `ret` pops the
     /// return address, RSP must be congruent to 8 mod 16, which is the state a
     /// function sees immediately after a real `call`.
-    fn prepare_stack(stack: &mut [u8]) -> u64 {
+    ///
+    /// Returns `(top, rsp)`: the 16-aligned top of the stack, and the synthetic
+    /// resume point below the frame.
+    fn prepare_stack(stack: &mut [u8]) -> (u64, u64) {
         let top = (stack.as_mut_ptr() as u64 + stack.len() as u64) & !0xF;
 
         unsafe {
@@ -105,7 +130,7 @@ impl Thread {
             put(72, 0x0000_0002);
         }
 
-        top - 72
+        (top, top - 72)
     }
 }
 
@@ -145,6 +170,12 @@ static ENABLED: AtomicBool = AtomicBool::new(false);
 
 /// Register the currently-executing context as thread 0 and start scheduling.
 pub fn init() {
+    // kmain runs on the stack `gdt::init` published as RSP0, so thread 0 adopts
+    // that rather than pretending it has no kernel stack. It never enters ring 3,
+    // but leaving `gs:0` at zero would turn any mistake about that into a
+    // page fault at address 0 with no frame to read.
+    let boot_top = crate::gdt::boot_kernel_stack_top().as_u64();
+
     without_interrupts(|| {
         let mut sched = SCHEDULER.lock();
         sched.threads[0] = Some(Thread {
@@ -152,12 +183,17 @@ pub fn init() {
             name: "kmain",
             rsp: 0, // filled in by the first switch away from here
             _stack: None,
+            kernel_stack_top: boot_top,
             state: State::Running,
             entry: None,
             ticks: 0,
+            exit_code: 0,
+            awaited: false,
         });
         sched.current = 0;
     });
+
+    publish_kernel_stack(0, boot_top);
 
     serial_println!(
         "Scheduler: round-robin over up to {} kernel threads, {} ms slice",
@@ -169,7 +205,7 @@ pub fn init() {
 /// Create a runnable kernel thread. It starts the next time the scheduler runs.
 pub fn spawn(name: &'static str, entry: fn(usize), arg: usize) -> Result<usize, &'static str> {
     let mut stack = alloc::vec![0u8; STACK_SIZE].into_boxed_slice();
-    let rsp = Thread::prepare_stack(&mut stack);
+    let (kernel_stack_top, rsp) = Thread::prepare_stack(&mut stack);
 
     without_interrupts(|| {
         let mut sched = SCHEDULER.lock();
@@ -185,12 +221,21 @@ pub fn spawn(name: &'static str, entry: fn(usize), arg: usize) -> Result<usize, 
             name,
             rsp,
             _stack: Some(stack),
+            kernel_stack_top,
             state: State::Ready,
             entry: Some((entry, arg)),
             ticks: 0,
+            exit_code: 0,
+            awaited: false,
         });
 
-        serial_println!("  spawned thread {} '{}' (stack top 0x{:x})", slot, name, rsp);
+        serial_println!(
+            "  spawned thread {} '{}' (kernel stack 0x{:x}, resume 0x{:x})",
+            slot,
+            name,
+            kernel_stack_top,
+            rsp
+        );
         Ok(slot)
     })
 }
@@ -264,16 +309,23 @@ pub fn schedule() {
                     sched.switches += 1;
 
                     let next_rsp = sched.threads[next].as_ref().unwrap().rsp;
+                    let next_top = sched.threads[next].as_ref().unwrap().kernel_stack_top;
                     let prev_rsp = sched.threads[current].as_mut().unwrap().rsp_ptr();
 
-                    Some((prev_rsp, next_rsp))
+                    Some((prev_rsp, next_rsp, next, next_top))
                 }
             }
         }
         // lock dropped here, before the switch
     };
 
-    if let Some((prev_rsp, next_rsp)) = plan {
+    if let Some((prev_rsp, next_rsp, next, next_top)) = plan {
+        // Before the switch, not after: the incoming thread may resume straight
+        // into `sysretq` and be in ring 3 — able to fault or syscall — before
+        // any instruction after `kosh_switch_context` in *this* frame runs.
+        // Interrupts are off, so publishing early is not visible to anyone else.
+        publish_kernel_stack(next as u64, next_top);
+
         unsafe { kosh_switch_context(prev_rsp, next_rsp) };
     }
 
@@ -286,6 +338,30 @@ impl Thread {
     fn rsp_ptr(&mut self) -> *mut u64 {
         &mut self.rsp as *mut u64
     }
+}
+
+/// Tell the CPU and the syscall stub which kernel stack is current.
+///
+/// Two consumers, one value:
+///
+/// * `TSS.RSP0` — used by the CPU when an interrupt arrives while the thread is
+///   in ring 3. Without this, two ring-3 threads would push exception frames
+///   onto the same stack.
+/// * `gs:0` — read by the `syscall` stub, which the CPU gives no stack at all.
+///
+/// Must be called with interrupts disabled, from `schedule()`, for every switch.
+/// Skipping it is not a subtle bug: the next syscall or ring-3 interrupt lands on
+/// the *previous* thread's stack and quietly overwrites whatever it had parked
+/// there.
+fn publish_kernel_stack(id: u64, top: u64) {
+    crate::gdt::set_kernel_stack(x86_64::VirtAddr::new(top));
+    crate::percpu::set_syscall_stack(top);
+    crate::percpu::set_current_thread(id);
+}
+
+/// Kernel stack top of the running thread, for diagnostics.
+pub fn current_kernel_stack_top() -> u64 {
+    crate::percpu::syscall_stack()
 }
 
 /// First thing a new thread executes.
@@ -311,14 +387,42 @@ extern "C" fn thread_bootstrap() -> ! {
     exit_current()
 }
 
+/// Record the value `wait_for` will hand to whoever is waiting.
+pub fn set_exit_code(code: i32) {
+    without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+        let current = sched.current;
+        if let Some(t) = sched.threads[current].as_mut() {
+            t.exit_code = code;
+        }
+    });
+}
+
+/// Id of the running thread.
+pub fn current_id() -> usize {
+    without_interrupts(|| SCHEDULER.lock().current)
+}
+
 /// Retire the running thread and never come back.
 pub fn exit_current() -> ! {
+    // Release this thread's address-space reservations before it becomes
+    // unschedulable. Done here, while the thread is still current, because the
+    // table keyed on thread ids is about to stop having an entry for it.
+    let id = current_id();
+    crate::usermode::on_thread_exit(id);
+
     without_interrupts(|| {
         let mut sched = SCHEDULER.lock();
         let current = sched.current;
         if let Some(t) = sched.threads[current].as_mut() {
             t.state = State::Finished;
         }
+
+        // Wake anyone blocked on us. If this is skipped the waiter is never
+        // Ready again and the machine deadlocks with a live thread that the
+        // scheduler will not pick — the failure mode that makes `Blocked` more
+        // dangerous than a yield loop, and worth the two lines to get right.
+        wake_waiters_locked(&mut sched, current);
     });
 
     loop {
@@ -327,6 +431,82 @@ pub fn exit_current() -> ! {
         // makes something else ready.
         x86_64::instructions::hlt();
     }
+}
+
+fn wake_waiters_locked(sched: &mut Scheduler, finished: usize) {
+    for slot in sched.threads.iter_mut() {
+        if let Some(t) = slot {
+            if t.state == (State::Blocked { on: finished }) {
+                t.state = State::Ready;
+            }
+        }
+    }
+}
+
+/// Block until thread `id` finishes, then return its exit code.
+///
+/// The kernel half of `sys_wait`. Returns `Err` if `id` is not a live thread or
+/// is the caller itself — waiting on yourself is a deadlock, and it is better
+/// caught here than discovered as a hang.
+pub fn wait_for(id: usize) -> Result<i32, &'static str> {
+    if id >= MAX_THREADS {
+        return Err("no such thread");
+    }
+
+    // Claim the slot first. Without this, `reap_finished` running between the
+    // child's exit and this thread waking up would free the TCB and take the
+    // exit code with it.
+    let already_finished = without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+        let current = sched.current;
+        if id == current {
+            return Err("a thread cannot wait for itself");
+        }
+        match sched.threads[id].as_mut() {
+            None => Err("no such thread"),
+            Some(t) => {
+                t.awaited = true;
+                Ok(t.state == State::Finished)
+            }
+        }
+    })?;
+
+    if !already_finished {
+        // Mark, then switch. `schedule()` will not pick a Blocked thread, so
+        // this returns only once the child's `exit_current` has woken us.
+        loop {
+            let done = without_interrupts(|| {
+                let mut sched = SCHEDULER.lock();
+                let current = sched.current;
+                let finished = matches!(
+                    sched.threads[id].as_ref().map(|t| t.state),
+                    Some(State::Finished) | None
+                );
+                if !finished {
+                    if let Some(t) = sched.threads[current].as_mut() {
+                        t.state = State::Blocked { on: id };
+                    }
+                }
+                finished
+            });
+
+            if done {
+                break;
+            }
+
+            schedule();
+        }
+    }
+
+    // Collect and release. The child is Finished, so nothing is running on the
+    // stack this drops.
+    without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+        match sched.threads[id].take() {
+            Some(t) => Ok(t.exit_code),
+            None => Ok(0),
+        }
+    })
 }
 
 /// Yield the rest of this thread's slice.
@@ -361,7 +541,9 @@ pub fn reap_finished() {
             if i == current {
                 continue;
             }
-            if matches!(slot, Some(t) if t.state == State::Finished) {
+            // `awaited` threads belong to whoever is in `wait_for` on them; that
+            // caller frees the slot after reading the exit code.
+            if matches!(slot, Some(t) if t.state == State::Finished && !t.awaited) {
                 *slot = None;
             }
         }

--- a/kernel/src/user_program.rs
+++ b/kernel/src/user_program.rs
@@ -6,14 +6,17 @@
 //! `-C code-model=kernel` would happily emit an absolute reference to a static
 //! and fault the moment it ran at the wrong address.
 //!
-//! It exercises three things:
+//! It exercises four things:
 //!
 //! 1. A syscall that works — `write(1, ...)`.
 //! 2. A syscall that returns a value — `getpid()`.
 //! 3. A syscall the kernel must *refuse* — `write(1, <kernel address>, 16)`.
-//!    That last one is the interesting case: it proves the user-pointer
-//!    validation in `syscall::uaccess` actually rejects a hostile pointer,
-//!    tested from the user side rather than by the kernel checking itself.
+//!    That one is the interesting case: it proves the user-pointer validation in
+//!    `syscall::uaccess` actually rejects a hostile pointer, tested from the user
+//!    side rather than by the kernel checking itself.
+//! 4. Two ring-3 threads yielding from inside a system call
+//!    (`kosh_user_pingpong_entry`), which is what per-thread kernel stacks are
+//!    for and what a single shared syscall stack cannot survive.
 
 core::arch::global_asm!(
     r#"
@@ -95,6 +98,87 @@ kosh_user_fault_entry:
     syscall
 .Lfault_hang:
     jmp     .Lfault_hang
+
+/* A third payload, run as two concurrent ring-3 threads.
+   It exists to make per-thread kernel stacks *observably* necessary: each
+   iteration calls SYS_YIELD, which context-switches while this thread's
+   SyscallFrame is still live on its kernel stack, and then writes one byte. If
+   both threads shared one syscall stack, the second thread's entry would take
+   that stack from the top and overwrite the first thread's parked frame,
+   including its return RIP and user RSP.
+
+   The tag byte arrives in RDI — the kernel sets it before iretq — and is copied
+   onto the user stack, because `write` needs an address it can read and this
+   payload has no writable data section of its own. */
+.global kosh_user_pingpong_entry
+.type kosh_user_pingpong_entry, @function
+kosh_user_pingpong_entry:
+    andq    $-16, %rsp
+    subq    $64, %rsp
+    movq    %rsp, %r13                  /* callee-saved: survives syscalls */
+    movb    %dil, (%r13)                /* tag byte, now in user memory */
+
+    /* Assemble "<tag>: survived ...\n" in one buffer, so the completion line
+       goes out as a single write. Two writes would let the other thread's byte
+       land between the tag and the message. */
+    leaq    1(%r13), %rdi
+    leaq    msg_pp_done(%rip), %rsi
+    movq    $msg_pp_done_len, %rcx
+    rep     movsb
+    movq    $msg_pp_done_len + 1, %r15
+
+    movq    $12, %r14                   /* iterations */
+
+.Lpp_loop:
+    movq    $8, %rax                    /* SYS_YIELD, from inside a syscall */
+    syscall
+    testq   %rax, %rax
+    js      .Lpp_fail
+
+    movq    $1, %rdi                    /* write(1, &tag, 1) */
+    movq    %r13, %rsi
+    movq    $1, %rdx
+    movq    $23, %rax
+    syscall
+    testq   %rax, %rax
+    js      .Lpp_fail
+
+    decq    %r14
+    jnz     .Lpp_loop
+
+    /* Reaching here at all is the result: 12 round trips through a syscall that
+       gave up the CPU with its frame still on this thread's kernel stack. */
+    movq    $1, %rdi
+    movq    %r13, %rsi
+    movq    %r15, %rdx
+    movq    $23, %rax
+    syscall
+
+    xorq    %rdi, %rdi
+    movq    $1, %rax                    /* SYS_EXIT */
+    syscall
+
+.Lpp_fail:
+    movq    $1, %rdi
+    leaq    msg_pp_fail(%rip), %rsi
+    movq    $msg_pp_fail_len, %rdx
+    movq    $23, %rax
+    syscall
+
+    movq    $1, %rdi
+    movq    $1, %rax                    /* exit(1) */
+    syscall
+
+.Lpp_hang:
+    jmp     .Lpp_hang
+
+msg_pp_done:
+    .ascii  ": survived 12 yields inside a syscall\n"
+    .set    msg_pp_done_len, . - msg_pp_done
+
+msg_pp_fail:
+    .ascii  "FAIL: a syscall failed across a yield\n"
+    .set    msg_pp_fail_len, . - msg_pp_fail
 
 msg_faulting:
     .ascii  "about to dereference a kernel address directly\n"

--- a/kernel/src/usermode.rs
+++ b/kernel/src/usermode.rs
@@ -136,6 +136,7 @@ extern "C" {
     static __user_end: u8;
     fn kosh_user_entry();
     fn kosh_user_fault_entry();
+    fn kosh_user_pingpong_entry();
 }
 
 /// Which payload to run.
@@ -220,6 +221,336 @@ pub fn run_user_demo(which: usize) {
     unsafe { enter_ring3(user_entry, stack_top) }
 }
 
+// ---------------------------------------------------------------------------
+// Resident programs
+// ---------------------------------------------------------------------------
+
+/// How many loaded programs can be resident at once. Bounded by the thread
+/// table, and small because they all share one address space.
+const MAX_PROGRAMS: usize = 8;
+
+/// Marker for a reservation whose thread has not claimed it yet.
+const NO_THREAD: usize = usize::MAX;
+
+/// Top of the stack region handed to spawned programs. Each slot gets 1 MiB of
+/// address space, well clear of the fixed stacks the boot demos use.
+const SPAWN_STACK_REGION_TOP: u64 = 0x0000_0000_3000_0000;
+
+/// A program currently occupying part of the address space.
+///
+/// This table is what makes `spawn` safe in a single address space. Every
+/// userspace program here is linked at a fixed `p_vaddr` (`userspace/*/user.ld`),
+/// so two programs whose images overlap cannot both be resident — and `ksh`
+/// spawning `ksh` would overwrite its own `.text` while executing it. The table
+/// is also what lets a program's pages be freed when it exits, which is what
+/// makes running one twice possible.
+#[derive(Clone, Copy)]
+struct Resident {
+    /// Thread that owns this program, or [`NO_THREAD`] until it claims it.
+    thread: usize,
+    name: [u8; 32],
+    lo: u64,
+    hi: u64,
+    entry: u64,
+    stack_top: u64,
+    ranges: [Option<crate::elf::MappedRange>; crate::elf::MAX_SEGMENTS],
+    stack: crate::elf::MappedRange,
+}
+
+impl Resident {
+    fn name(&self) -> &str {
+        let end = self.name.iter().position(|&b| b == 0).unwrap_or(self.name.len());
+        core::str::from_utf8(&self.name[..end]).unwrap_or("")
+    }
+}
+
+static RESIDENT: Mutex<[Option<Resident>; MAX_PROGRAMS]> = Mutex::new([None; MAX_PROGRAMS]);
+
+/// Why a `spawn` could not happen.
+#[derive(Debug)]
+pub enum SpawnError {
+    /// No boot module by that name. This is what a shell turns into
+    /// "command not found", so it must be distinguishable from the rest.
+    NotFound,
+    /// The image overlaps a program that is already resident.
+    AddressConflict,
+    TooManyPrograms,
+    Load(crate::elf::ElfError),
+    Map(&'static str),
+    NoThread(&'static str),
+}
+
+/// Load a boot module and run it on a new kernel thread in ring 3.
+///
+/// Returns the thread id, which is what `wait` takes.
+///
+/// The ELF is loaded here, in the *caller's* thread, rather than in the new one.
+/// That is deliberate: a load failure is then a synchronous error the caller can
+/// act on, instead of a thread that starts and immediately dies with the reason
+/// only in the kernel log.
+pub fn spawn_program(name: &str) -> Result<usize, SpawnError> {
+    let module = boot_module_named(name).ok_or(SpawnError::NotFound)?;
+    let image = unsafe { module.bytes() };
+
+    let (lo, hi) = crate::elf::extent_of(image).map_err(SpawnError::Load)?;
+
+    // Reserve a slot and check for conflicts under one lock, so two concurrent
+    // spawns cannot both pass the check and then both load.
+    let slot = {
+        let mut table = RESIDENT.lock();
+
+        for existing in table.iter().flatten() {
+            if lo < existing.hi && existing.lo < hi {
+                serial_println!(
+                    "spawn '{}' refused: 0x{:x}..0x{:x} overlaps resident '{}' at 0x{:x}..0x{:x}",
+                    name,
+                    lo,
+                    hi,
+                    existing.name(),
+                    existing.lo,
+                    existing.hi
+                );
+                return Err(SpawnError::AddressConflict);
+            }
+        }
+
+        let slot = table
+            .iter()
+            .position(|s| s.is_none())
+            .ok_or(SpawnError::TooManyPrograms)?;
+
+        let mut name_buf = [0u8; 32];
+        let bytes = name.as_bytes();
+        let take = core::cmp::min(bytes.len(), name_buf.len() - 1);
+        name_buf[..take].copy_from_slice(&bytes[..take]);
+
+        // Placeholder, so the range is claimed against other spawns while this
+        // one loads. Filled in properly below.
+        table[slot] = Some(Resident {
+            thread: NO_THREAD,
+            name: name_buf,
+            lo,
+            hi,
+            entry: 0,
+            stack_top: 0,
+            ranges: [None; crate::elf::MAX_SEGMENTS],
+            stack: crate::elf::MappedRange { start: 0, pages: 0 },
+        });
+
+        slot
+    };
+
+    match load_into_slot(slot, image) {
+        Ok(()) => {}
+        Err(e) => {
+            release_slot(slot);
+            return Err(e);
+        }
+    }
+
+    match crate::task::spawn("spawned", enter_spawned, slot) {
+        Ok(thread) => {
+            serial_println!(
+                "spawn '{}': thread {}, entry 0x{:x}, image 0x{:x}..0x{:x}",
+                name,
+                thread,
+                RESIDENT.lock()[slot].as_ref().map(|r| r.entry).unwrap_or(0),
+                lo,
+                hi
+            );
+            Ok(thread)
+        }
+        Err(e) => {
+            release_slot(slot);
+            Err(SpawnError::NoThread(e))
+        }
+    }
+}
+
+fn load_into_slot(slot: usize, image: &[u8]) -> Result<(), SpawnError> {
+    let loaded = unsafe { crate::elf::load(image) }.map_err(SpawnError::Load)?;
+
+    let stack_top = SPAWN_STACK_REGION_TOP - (slot as u64 * 0x10_0000);
+    let stack_bottom = stack_top - (SHELL_STACK_PAGES * PAGE_SIZE) as u64;
+    let stack_flags = PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE;
+
+    paging::map_user_pages(stack_bottom, SHELL_STACK_PAGES, stack_flags)
+        .map_err(SpawnError::Map)?;
+
+    let mut table = RESIDENT.lock();
+    if let Some(r) = table[slot].as_mut() {
+        r.entry = loaded.entry;
+        r.stack_top = stack_top;
+        r.ranges = loaded.ranges;
+        r.stack = crate::elf::MappedRange {
+            start: stack_bottom,
+            pages: SHELL_STACK_PAGES,
+        };
+    }
+
+    Ok(())
+}
+
+/// Entry point of a spawned thread: claim the slot, then drop to ring 3.
+fn enter_spawned(slot: usize) {
+    let target = {
+        let mut table = RESIDENT.lock();
+        match table.get_mut(slot).and_then(|s| s.as_mut()) {
+            None => None,
+            Some(r) => {
+                // Claimed by the thread itself, as its first action. Doing it in
+                // the parent would race: the child can be scheduled — and can
+                // exit — between `task::spawn` returning and the parent writing
+                // the id, and then nothing would free its pages.
+                r.thread = crate::task::current_id();
+                Some((r.entry, r.stack_top))
+            }
+        }
+    };
+
+    match target {
+        Some((entry, stack_top)) => unsafe { enter_ring3(entry, stack_top) },
+        None => serial_println!("spawned thread has no program slot {}", slot),
+    }
+}
+
+/// Record an image loaded by the running thread, so its pages are freed when it
+/// exits. Used by the boot-time demos, which load in their own thread.
+fn adopt_resident(name: &str, loaded: &crate::elf::LoadedImage, stack: crate::elf::MappedRange) {
+    let (lo, hi) = loaded.extent();
+    let mut table = RESIDENT.lock();
+
+    let Some(slot) = table.iter().position(|s| s.is_none()) else {
+        serial_println!("  (no resident slot for '{}'; its pages will not be freed)", name);
+        return;
+    };
+
+    let mut name_buf = [0u8; 32];
+    let bytes = name.as_bytes();
+    let take = core::cmp::min(bytes.len(), name_buf.len() - 1);
+    name_buf[..take].copy_from_slice(&bytes[..take]);
+
+    table[slot] = Some(Resident {
+        thread: crate::task::current_id(),
+        name: name_buf,
+        lo,
+        hi,
+        entry: loaded.entry,
+        stack_top: stack.start + (stack.pages * PAGE_SIZE) as u64,
+        ranges: loaded.ranges,
+        stack,
+    });
+}
+
+fn release_slot(slot: usize) {
+    let entry = RESIDENT.lock().get_mut(slot).and_then(|s| s.take());
+    if let Some(r) = entry {
+        unmap_resident(&r);
+    }
+}
+
+fn unmap_resident(r: &Resident) {
+    let mut freed = 0;
+    for range in r.ranges.iter().flatten() {
+        freed += unsafe { paging::unmap_user_pages(range.start, range.pages) };
+    }
+    if r.stack.pages > 0 {
+        freed += unsafe { paging::unmap_user_pages(r.stack.start, r.stack.pages) };
+    }
+
+    // The used-page count is printed on purpose: it is the only way to see, from
+    // the log alone, that running a program twice does not cost twice the memory.
+    // Two `hello` runs should report the same number here.
+    let used = crate::memory::physical::memory_stats()
+        .map(|s| s.used_pages)
+        .unwrap_or(0);
+
+    serial_println!(
+        "  released '{}': {} page(s) returned, {} used system-wide",
+        r.name(),
+        freed,
+        used
+    );
+}
+
+/// Free the address space a finished thread was using.
+///
+/// Called from `task::exit_current`, while the exiting thread is still current
+/// and still on its *kernel* stack — so unmapping its user pages cannot pull the
+/// ground out from under it. A thread with no program registered is a plain
+/// kernel thread and this does nothing.
+pub fn on_thread_exit(thread: usize) {
+    let entry = {
+        let mut table = RESIDENT.lock();
+        let found = table.iter().position(|s| matches!(s, Some(r) if r.thread == thread));
+        found.and_then(|i| table[i].take())
+    };
+
+    if let Some(r) = entry {
+        unmap_resident(&r);
+    }
+}
+
+/// Names of resident programs, for diagnostics.
+pub fn resident_count() -> usize {
+    RESIDENT.lock().iter().flatten().count()
+}
+
+/// Top of the ping-pong payload's stacks. Each thread gets its own 1 MiB below
+/// this, so neither can blame the other for a corrupted stack.
+const PINGPONG_STACK_TOP: u64 = 0x0000_0000_5800_0000;
+
+/// Ring-3 half of the per-thread-kernel-stack test. Runs as a kernel thread;
+/// `which` is 0 or 1 and picks both the tag byte and the stack.
+///
+/// Two of these run concurrently. Each iteration calls `SYS_YIELD`, so the
+/// thread is sitting *inside* a system call — with a `SyscallFrame` live on its
+/// kernel stack — at the moment the scheduler hands the CPU to the other one.
+/// Under the old single static syscall stack, the second thread's entry stub
+/// would reset RSP to the same top and overwrite the first thread's frame; the
+/// first would then `sysretq` to whatever landed where its return RIP had been.
+pub fn run_pingpong(which: usize) {
+    use core::sync::atomic::Ordering;
+
+    let blob_start = sym(unsafe { &__user_start });
+    let blob_end = sym(unsafe { &__user_end });
+    let blob_pages = ((blob_end - blob_start) as usize).div_ceil(PAGE_SIZE).max(1);
+    let entry = USER_CODE_BASE + (kosh_user_pingpong_entry as usize as u64 - blob_start);
+
+    let code_flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+    if !CODE_MAPPED.swap(true, Ordering::SeqCst) {
+        if let Err(e) = paging::map_user_range(USER_CODE_BASE, blob_start, blob_pages, code_flags) {
+            serial_println!("  failed to map user code: {}", e);
+            return;
+        }
+    }
+
+    let stack_top = PINGPONG_STACK_TOP - (which as u64 * 0x10_0000);
+    let stack_bottom = stack_top - (USER_STACK_PAGES * PAGE_SIZE) as u64;
+    let stack_flags = PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE;
+    if let Err(e) = paging::map_user_pages(stack_bottom, USER_STACK_PAGES, stack_flags) {
+        serial_println!("  failed to map ping-pong stack: {}", e);
+        return;
+    }
+
+    let tag = if which == 0 { b'A' } else { b'B' };
+    serial_println!(
+        "  ring 3 '{}': entry 0x{:x}, user stack 0x{:x}, kernel stack 0x{:x}",
+        tag as char,
+        entry,
+        stack_top,
+        crate::task::current_kernel_stack_top()
+    );
+
+    unsafe { enter_ring3_with_arg(entry, stack_top, tag as u64) }
+}
+
 /// Load boot module 0 as an ELF and run it in ring 3.
 ///
 /// This is the real path: a program the kernel was not compiled with, parsed
@@ -280,6 +611,19 @@ fn run_module(name: &str, stack_top: u64) {
         stack_top
     );
 
+    // Register before entering ring 3, so `task::exit_current` frees these pages
+    // when the program exits. Without this the boot-time load of `hello` stayed
+    // mapped forever, and `ksh` spawning `hello` later failed with
+    // `PageAlreadyMapped` — leaking a frame per attempt.
+    adopt_resident(
+        name,
+        &loaded,
+        crate::elf::MappedRange {
+            start: stack_bottom,
+            pages: SHELL_STACK_PAGES,
+        },
+    );
+
     serial_println!("Entering loaded ELF in ring 3...");
     serial_println!("--- loaded program output ---");
 
@@ -307,6 +651,20 @@ const SHELL_STACK_PAGES: usize = 16;
 /// `entry` and `stack_top` must be mapped `USER_ACCESSIBLE`, and the GDT must
 /// carry ring-3 code and data descriptors.
 unsafe fn enter_ring3(entry: u64, stack_top: u64) -> ! {
+    enter_ring3_with_arg(entry, stack_top, 0)
+}
+
+/// As [`enter_ring3`], but with `arg` in RDI at entry.
+///
+/// `iretq` only replaces SS, RSP, RFLAGS, CS and RIP, so every other register
+/// crosses the ring boundary untouched — which makes RDI a perfectly good place
+/// to hand a starting value to a payload. That is how `argc`/`argv` will
+/// eventually arrive; for now it is how the ping-pong payload learns which of the
+/// two threads it is.
+///
+/// # Safety
+/// As [`enter_ring3`].
+unsafe fn enter_ring3_with_arg(entry: u64, stack_top: u64, arg: u64) -> ! {
     let sel = crate::gdt::selectors();
     let user_cs = (sel.user_code.0 | 3) as u64;
     let user_ss = (sel.user_data.0 | 3) as u64;
@@ -328,6 +686,7 @@ unsafe fn enter_ring3(entry: u64, stack_top: u64) -> ! {
         rflags = in(reg) rflags,
         cs = in(reg) user_cs,
         rip = in(reg) entry,
+        in("rdi") arg,
         options(noreturn)
     )
 }

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -234,6 +234,9 @@ check)
         "ring 3 fault — terminating the process" \
         "Ring 3: PASS" \
         "kernel survived a ring 3 fault" \
+        "A: survived 12 yields inside a syscall" \
+        "B: survived 12 yields inside a syscall" \
+        "Concurrent ring 3: PASS" \
         "hello from a loaded ELF binary" \
         ".bss was zeroed correctly" \
         "stack is writable and readable" \
@@ -326,7 +329,19 @@ check-cli)
         type_line "echo hello from ring 3 shell"
         type_line "stat big.txt"
         type_line "cat nope.txt"
+        # An unknown command is now a spawn attempt, so this also proves ENOENT
+        # from spawn still reads as "command not found" and nothing else does.
         type_line "nosuchcommand"
+        # The real thing: the shell launches a separate program, blocks in the
+        # kernel's wait, and gets its prompt back when the child exits. Twice,
+        # because running a program a second time is what exercises the teardown
+        # of the first one's mappings.
+        type_line "hello"
+        type_line "hello"
+        # One address space, so a program cannot be loaded on top of one that is
+        # already resident. Spawning ksh from ksh has to be refused, not
+        # attempted — it would overwrite the .text currently executing.
+        type_line "ksh"
         # The shell must refuse redirection rather than silently dropping it.
         type_line "echo a > out.txt"
         # QEMU's sendkey cannot produce a '|' through this keyboard layout, so
@@ -368,12 +383,17 @@ check-cli)
         "type  file" \
         "cat: /nope.txt: no such file" \
         "nosuchcommand: command not found" \
+        "spawn 'hello': thread" \
+        "hello from a loaded ELF binary" \
+        "released 'hello'" \
+        "overlaps resident 'ksh'" \
+        "ksh: could not start (error -98)" \
         "redirection needs a writable filesystem" \
         "pipe yes" \
         "redirect out" \
         "background" \
         "ksh: exiting" \
-        "falling back to the kernel console" \
+        "ksh exited with code 0, falling back to the kernel console" \
         "Kosh console" \
         "Kosh 0.1.0 x86_64" \
         "physical memory:" \

--- a/userspace/shell/src/main.rs
+++ b/userspace/shell/src/main.rs
@@ -71,6 +71,15 @@ fn print_u64(mut value: u64) {
 }
 
 /// Right-align a number in `width` columns.
+fn print_i64(value: i64) {
+    if value < 0 {
+        print("-");
+        print_u64(value.unsigned_abs());
+    } else {
+        print_u64(value as u64);
+    }
+}
+
 fn print_u64_padded(value: u64, width: usize) {
     let mut digits = 1;
     let mut v = value;
@@ -251,8 +260,13 @@ fn cmd_help() {
     println("  getpid                this process's id");
     println("  exit                  leave the shell");
     println("");
+    println("Anything else is treated as a program name: the kernel loads it,");
+    println("runs it on its own task, and this shell blocks until it exits.");
+    println("Try 'hello'.");
+    println("");
     println("Pipes, redirection and background jobs parse but do not run:");
-    println("they need fork and exec, which the kernel does not have yet.");
+    println("they need per-process address spaces, which the kernel does not");
+    println("have yet — spawn puts a second program in the same one.");
 }
 
 fn cmd_ls(cwd: &str, args: &[String]) {
@@ -462,6 +476,52 @@ fn report_unsupported(parsed: &ParsedCommand) -> bool {
     false
 }
 
+/// Run an external program: spawn it, wait for it, report a non-zero exit.
+///
+/// The shell blocks in the kernel's `wait` — `State::Blocked`, not a yield loop —
+/// so while the child runs, the shell costs nothing.
+///
+/// Only `ENOENT` becomes "command not found". Any other failure is a real error
+/// and gets said out loud, because "command not found" for what is actually
+/// "out of memory" or "that program's address range is already occupied" sends
+/// you looking in the wrong place.
+fn cmd_run(name: &str) {
+    let task = sys::spawn(name);
+
+    if task == sys::ENOENT {
+        print("ksh: ");
+        print(name);
+        println(": command not found");
+        return;
+    }
+
+    if task < 0 {
+        print("ksh: ");
+        print(name);
+        print(": could not start (error ");
+        print_i64(task);
+        println(")");
+        return;
+    }
+
+    let mut status: i32 = 0;
+    let waited = sys::wait(task, &mut status);
+    if waited < 0 {
+        print("ksh: ");
+        print(name);
+        println(": wait failed");
+        return;
+    }
+
+    if status != 0 {
+        print("ksh: ");
+        print(name);
+        print(": exited ");
+        print_i64(status as i64);
+        println("");
+    }
+}
+
 // --- entry -----------------------------------------------------------------
 
 // System V says RSP is 16-byte aligned at process entry, but a Rust
@@ -545,11 +605,10 @@ pub extern "C" fn ksh_main() -> ! {
                 println("ksh: exiting");
                 sys::exit(0);
             }
-            other => {
-                print("ksh: ");
-                print(other);
-                println(": command not found");
-            }
+            // Not a builtin: ask the kernel to run a program by that name. This
+            // is the one thing a shell exists for, and until `spawn` landed it
+            // was the one thing this shell could not do.
+            other => cmd_run(other),
         }
     }
 }

--- a/userspace/shell/src/syscall.rs
+++ b/userspace/shell/src/syscall.rs
@@ -11,7 +11,10 @@
 #![allow(dead_code)]
 
 pub const SYS_EXIT: u64 = 1;
+pub const SYS_WAIT: u64 = 4;
 pub const SYS_GETPID: u64 = 5;
+pub const SYS_YIELD: u64 = 8;
+pub const SYS_SPAWN: u64 = 9;
 pub const SYS_OPEN: u64 = 20;
 pub const SYS_CLOSE: u64 = 21;
 pub const SYS_READ: u64 = 22;
@@ -117,6 +120,36 @@ pub fn stat(path: &str, out: &mut RawDirEntry) -> i64 {
 
 pub fn getpid() -> i64 {
     unsafe { syscall(SYS_GETPID, 0, 0, 0, 0) }
+}
+
+pub fn yield_now() -> i64 {
+    unsafe { syscall(SYS_YIELD, 0, 0, 0, 0) }
+}
+
+/// ENOENT, as `SyscallError::NotFound` encodes it. The one error `spawn` returns
+/// that means "no such program" rather than "something went wrong", so it is the
+/// only one a shell should turn into "command not found".
+pub const ENOENT: i64 = -2;
+
+/// Load a program by name and run it on its own task. Returns the task id.
+///
+/// Not `fork`/`exec` — the kernel has one address space, so there is nothing to
+/// duplicate. The name is a boot-module name, not a filesystem path.
+pub fn spawn(name: &str) -> i64 {
+    unsafe { syscall(SYS_SPAWN, name.as_ptr() as u64, name.len() as u64, 0, 0) }
+}
+
+/// Block until `task` finishes; returns its exit code through `status`.
+pub fn wait(task: i64, status: &mut i32) -> i64 {
+    unsafe {
+        syscall(
+            SYS_WAIT,
+            task as u64,
+            status as *mut i32 as u64,
+            0,
+            0,
+        )
+    }
 }
 
 pub fn exit(code: u64) -> ! {


### PR DESCRIPTION
Everything up to now ran one ring-3 thread at a time. The syscall path was built on it: one `static SYSCALL_STACK`, one `SAVED_USER_RSP`, and three comments saying so. This removes the assumption and then spends it.

Per-thread kernel stacks. `percpu.rs` holds a block reached through `gs:`, because the syscall stub has no free register and no stack to spill to. `user_rsp` becomes a field of `SyscallFrame`, so a preempted syscall keeps its return state on a stack nobody else can touch. `task::schedule()` publishes the incoming thread's stack to `TSS.RSP0` and `gs:0`; `gdt.rs` stopped being a `lazy_static` so `set_kernel_stack` could stop being `unimplemented!()`.

No `swapgs`: the interrupt handlers use `x86-interrupt`, which gives nowhere to put one, so once a tick can land inside a syscall the swap count stops being even. Both MSRs point at the same block instead.

SYS_YIELD (8) exists mainly to make the failure reachable — it is the only way userspace can force a context switch from inside a syscall. Two ring-3 threads yielding inside syscalls now interleave (`ABABABAB...`) and both survive; with the Phase 9 shared stack the same test kills one of them and page-faults on a garbage RIP.

SYS_SPAWN (9) loads a named boot module onto its own thread; SYS_WAIT (4), previously a TODO and `Err(NotSupported)`, blocks in `State::Blocked` and returns the exit code. `ksh` treats an unknown command as a program name, so `hello` runs and the prompt comes back. `sys_fork` now returns NotSupported instead of logging "Fork successful" and returning a PID for a child that never existed.

Running a program twice needed teardown: `paging::unmap_user_pages` was missing, so the second `map_user_pages` failed with PageAlreadyMapped after leaking a frame. `usermode::RESIDENT` records what each program mapped and frees it on exit — two `hello` runs end on the same used-page count — and is also what lets `spawn` refuse an image overlapping a resident one, since there is one address space and `ksh` spawning `ksh` would overwrite its own `.text`.

Also: `sys_exit` no longer closes the global descriptor table while another program is resident, and `kosh_syscall_handler` uses `task::current_id()` instead of a hardcoded pid of 1.

32 boot markers and 28 console markers pass from a clean build.


Claude-Session: https://claude.ai/code/session_01P1GdpYMiKP5Gj1Jmub59gw