### PR TITLE
kernel: move the kernel into the higher half, out of PML4[0]

### DIFF
--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -15,11 +15,16 @@ Nothing in the kernel had ever executed. Everything below is what closed that ga
 ```
 BIOS
  └─> GRUB2  (reads the multiboot2 header in .multiboot2)
-      └─> _start32          kernel/src/boot32.rs   [32-bit protected mode]
-           └─> long_mode_start                     [64-bit long mode]
-                └─> _start   kernel/src/main.rs    [Rust]
-                     └─> boot::init_kernel         kernel/src/boot.rs
+      └─> _start32       kernel/src/boot32.rs  [32-bit, running at phys 1 MiB]
+           └─> long_mode_low                   [64-bit, running at phys 1 MiB]
+                └─> long_mode_start            [64-bit, 0xFFFFFFFF801.....]
+                     └─> _start   kernel/src/main.rs         [Rust]
+                          └─> boot::init_kernel    kernel/src/boot.rs
 ```
+
+The kernel is linked at `0xFFFF_FFFF_8010_0000` and loaded at physical 1 MiB.
+Which of those two a given line of `boot32.rs` is running at is the thing to
+track while reading it — see "The higher half" below.
 
 ### 1. `.multiboot2` header — `kernel/src/main.rs`
 
@@ -44,10 +49,14 @@ The ELF entry point (`ENTRY(_start32)` in `linker.ld`). In order:
 | Build PML4 / PDPT / PD / PT | Identity-maps the first 1 GiB (see the null guard note below) |
 | CR3, CR4.PAE, EFER.LME, CR0.PG | The actual mode switch |
 | `lgdt` + `ljmp $0x08` | Loads a 64-bit GDT and reloads CS — this is the moment we become 64-bit |
+| `movabsq` + `jmp *%rax` | ...and this is the moment we stop running at a physical address |
 
-The identity map covers the kernel at 1 MiB, the frame bitmap, the heap, VGA at
-`0xB8000` and QEMU's default RAM. It is deliberately a *bootstrap* map: the
-kernel replaces it with a proper higher-half address space in Phase 3.
+The trampoline maps physical 0..1 GiB **twice**: identity, because the code doing
+the mapping is executing at a low address and cannot pull the rug out from under
+itself, and again at `KERNEL_VMA` (PML4[511], PDPT[510]), because that is where
+the kernel is linked. Both windows point at the same PD, so the second costs one
+extra page table. `paging::init` later replaces both and keeps only the higher
+half.
 
 **Null guard page.** The first 2 MiB is mapped with 4 KiB pages rather than one
 2 MiB huge page, purely so that page 0 can be left *unmapped*. With a flat
@@ -87,20 +96,35 @@ Physical, at hand-off:
 the allocator would happily hand out the frames holding the running kernel — and
 the boot page tables with it.
 
+Those symbols are *virtual* (`0xFFFF_FFFF_8010_0000`), and the exclusion above is
+about *physical* frames, so `physical.rs` runs them through
+`paging::kernel_phys`. Before the higher-half migration the two were the same
+number and the conversion did not exist; forgetting it is not a subtle failure —
+the comparison never matches, and the allocator hands out the running kernel.
+
 Virtual, once `memory::paging` has installed the kernel's own tables:
 
 ```
-0x0000_0000_0000_0000   unmapped                    null guard
-0x0000_0000_0000_1000 ┬ identity window, 4 KiB pages, W^X
-                      │   .text            R-X
-                      │   .rodata          R--  NX
-                      │   .data/.bss       RW-  NX
-                      │   VGA, frame bitmap RW- NX
-0x0000_0000_0040_0000 ┘
+0x0000_0000_0000_0000 ┐
+        ...           │ the entire lower half belongs to userspace
+0x0000_7FFF_FFFF_FFFF ┘
         ...
-0xFFFF_8000_0000_0000   physmap: all of RAM, 2 MiB pages, RW+NX
-0xFFFF_9000_0000_0000   kernel heap window, 4 KiB pages, RW+NX
+0xFFFF_8000_0000_0000   physmap: all of RAM, 2 MiB pages, RW+NX      PML4[256]
+0xFFFF_9000_0000_0000   kernel heap window, 4 KiB pages, RW+NX       PML4[288]
+        ...
+0xFFFF_FFFF_8000_0000   unmapped                  null guard         PML4[511]
+0xFFFF_FFFF_8000_1000 ┬ kernel window, 4 KiB pages, W^X
+                      │   VGA, multiboot info, frame bitmap  RW- NX
+                      │   .text                              R-X
+                      │   .rodata                            R-- NX
+                      │   .data/.bss                         RW- NX
+0xFFFF_FFFF_8040_0000 ┘
 ```
+
+The kernel window maps `KERNEL_VMA + phys` for the low few MiB — the same frames
+the identity map used to cover, at addresses out of userspace's way. It exists
+because the frame bitmap and the VGA buffer are touched *before* `paging::init`
+builds the physmap, so they need a window that the boot trampoline can set up.
 
 ## Running it
 
@@ -860,6 +884,164 @@ running, and says so when it declines.
 `task::current_id()` now, so `getpid`, the log lines, and the task id `spawn`
 returns all agree.
 
+## The higher half (Phase 11)
+
+Until this, the kernel lived at physical 1 MiB and ran there, identity-mapped
+through PML4[0]. That is the same top-level entry a user process needs for its
+own image and stack, so "give each process its own address space" was blocked on
+"get the kernel out of the way first". This is that.
+
+The kernel is now linked at `0xFFFF_FFFF_8000_0000 + 1 MiB` and loaded at
+physical 1 MiB. `linker.ld` gives every section an explicit `AT()`, so the ELF
+program headers carry `p_vaddr` in the higher half and `p_paddr` at 1 MiB:
+
+```
+  Type   VirtAddr           PhysAddr           Flg
+  LOAD   0xffffffff80100000 0x0000000000100000 R
+  LOAD   0xffffffff80101000 0x0000000000101000 R E
+  ...
+```
+
+-2 GiB specifically, because that is what `-C code-model=kernel` assumes — a
+flag `.cargo/config.toml` had been setting since long before it was true.
+
+### The entry point is a virtual address
+
+The first attempt set `ENTRY()` to the *physical* address of the trampoline,
+reasoning that GRUB jumps there in 32-bit protected mode with paging off. GRUB
+disagreed, and said so:
+
+```
+error: entry point isn't in a segment.
+```
+
+GRUB looks `e_entry` up in `p_vaddr` space, finds the program header containing
+it, and rebases it into that header's `p_paddr` range itself. So `e_entry` is the
+higher-half address and GRUB arrives at physical 1 MiB on its own.
+
+Worth recording *how* that was found: the message goes to the VGA console, and
+`--check` only captures serial — so the symptom was a completely empty log,
+indistinguishable from a kernel that died on its first instruction. `run.sh` now
+writes a `grub.cfg` that puts GRUB's own output on COM1 for exactly this reason.
+
+### Two addresses for every symbol in the trampoline
+
+Steps 1-4 of `boot32.rs` execute at physical 1 MiB with paging off, but the file
+is linked with everything else. Every reference to a symbol in 32-bit code is
+therefore written `sym - KERNEL_VMA`:
+
+```asm
+    movl    %eax, (mb_magic - KERNEL_VMA)
+    movl    $(stack_top - KERNEL_VMA), %esp
+    movl    $(p4_table - KERNEL_VMA), %eax
+    movl    %eax, %cr3
+```
+
+Miss one and the failure is a triple fault with no output. The `%cr3` line is the
+one that bites hardest: a truncated CR3 faults on the very next instruction,
+before any of the serial output in that file can report anything.
+
+Three more places where 32 bits is not enough:
+
+- **`lgdt`.** A 32-bit LGDT consumes a 6-byte operand — 2-byte limit, 4-byte
+  base. Sharing one descriptor between the two modes silently loads a GDTR
+  pointing at the *low 32 bits* of a higher-half address, so there are now two:
+  `gdt64_ptr32` with the physical base and `gdt64_ptr` with the virtual one.
+- **The far jump.** `ljmp` takes a 32-bit offset and cannot reach the higher
+  half. It lands at the physical address of `long_mode_low`, two instructions
+  whose only job is `movabsq $long_mode_start, %rax; jmp *%rax`.
+- **`movq $stack_top, %rsp`.** `mov r64, imm32` sign-extends, which happens to
+  produce the right answer for a -2 GiB address — it worked by luck before and
+  is a `movabsq` now.
+
+### Virtual is not physical any more
+
+The migration's real cost is every place that used to get away with treating the
+two as the same number:
+
+| site | before | after |
+|---|---|---|
+| `physical::kernel_image_range` | linker symbols as physical | `paging::kernel_phys(sym)` |
+| the frame bitmap | placed and dereferenced at one address | placed physical, written through `kernel_virt` |
+| `vga_buffer` | `0xb8000 as *mut Buffer` | `kernel_virt(0xb8000)` |
+| the multiboot info pointer | dereferenced directly | `kernel_virt(phys)` |
+| `usermode`'s `.user` blob | `__user_start` passed as a frame address | `kernel_phys(__user_start)` |
+| `paging::identity_map_4k` | `PhysAddr::new(virt)` | `PhysAddr::new(kernel_phys(virt))` |
+
+`kernel_image_range` is the one that would have been worst. It feeds the check
+that keeps the allocator away from the running kernel's own frames; with virtual
+symbols the comparison simply never matches, and the failure is the allocator
+handing out the page tables it is executing on.
+
+The `.user` blob fails loudly instead, which is a mercy: `PhysAddr::new` panics
+on a value with bits above 52 set.
+
+### The bootstrap window
+
+There is an ordering problem underneath all of this. The frame bitmap is placed
+and zeroed, and the first `println!` reaches VGA, *before* `paging::init` builds
+the physmap. Neither can use `PHYSMAP_BASE`, and the identity map they used to
+rely on is what is being removed.
+
+The answer is that the trampoline's higher-half window covers a full 1 GiB, and
+`paging::init` deliberately keeps the low few MiB of it. `kernel_virt(phys)` is
+therefore valid from the first instruction of long mode through to shutdown, and
+neither the bitmap pointer nor the VGA pointer ever needs rebasing.
+
+Building the new tables has the same problem one level up: the mapper has to
+write page-table frames it just allocated, and the physmap it is constructing
+does not exist yet. So construction runs with the mapper offset set to
+`KERNEL_VMA` rather than `0`, and a `BootstrapFrameAllocator` refuses any frame
+above the 1 GiB window instead of returning a pointer that faults on first write.
+
+`phys_to_virt` was deleted rather than fixed. It answered "the kernel-virtual
+address of this frame" with either the identity or the physmap depending on a
+flag — and after the migration that question has two right answers depending on
+*when* you ask. Hiding that behind one function invites using the wrong one; the
+call sites pick `kernel_virt` or `PHYSMAP_BASE` deliberately now. It had no
+callers anyway.
+
+### Proving it
+
+`paging::self_test` gained a check, and `--check` gained a marker:
+
+```
+  kernel window   : 0xffffffff80000000 -> 0x0..0x400000 (4 KiB pages, W^X)
+  physmap         : 0xffff800000000000 -> 0x0..0x1ffe0000 (2 MiB pages, RW+NX)
+  PML4[0]         : empty — reserved for user address spaces
+  translate(0xffffffff80100000) -> 0x100000: OK
+  kernel out of PML4[0]: OK (0x100000 is unmapped, was the kernel image)
+```
+
+It checks that the kernel *image address* is gone from the lower half rather than
+that PML4[0] is empty, because PML4[0] is exactly where user mappings live — it
+is populated, just not by the kernel.
+
+Restoring the low mapping in `init` turns that line into:
+
+```
+  WARNING: 0x100000 still maps to 0x100000 — the low identity map survived
+```
+
+and the marker fails, which is the only evidence that it is checking anything.
+
+### One more thing this cleaned up
+
+`memory/vmm.rs` carried a `kernel_layout` module describing kernel code at
+`0xFFFFFFFF80000000`, data 16 MiB above it and a heap 16 MiB above that — three
+invented numbers for a layout nothing had ever built, printed in the boot log
+next to the real one. They are derived from `memory::paging` now, and the dump
+reports what the page tables actually contain:
+
+```
+  Kernel Window: 0xffffffff80000000 - 0xffffffff80400000 (4096 KB) [R-XK]
+  Physmap: 0xffff800000000000 - 0xffff80001ffe0000 (524160 KB) [RW-K]
+  Kernel Heap: 0xffff900000000000 - 0xffff900000400000 (4096 KB) [RW-K]
+```
+
+`KERNEL_CODE_START` finally being right is not a coincidence — the migration
+moved the kernel to the address that constant had been claiming all along.
+
 ## What is deliberately still missing
 - **The filesystem is read-only.** Allocating clusters and keeping both FAT
   copies consistent is a separate problem, and a read-only filesystem that is
@@ -872,11 +1054,12 @@ returns all agree.
 - **No `fork`/`exec`.** `spawn` loads a *second* program rather than duplicating
   the caller, so there is still no way for a program to replace its own image or
   to inherit one. `userspace/init` cannot do its job until `fork` exists.
-- **One address space.** Loaded programs share the kernel's page tables; they
-  are protected by page permissions, not by separation. That is why every
-  userspace program is linked at a distinct fixed address
-  (`userspace/*/user.ld`) and why `spawn` has to refuse an image that overlaps
-  one already resident.
+- **One address space, still.** The kernel is out of PML4[0], which is the
+  precondition for per-process address spaces — but nothing yet gives a process
+  its own PML4. Loaded programs share one set of tables and are protected by
+  page permissions, not separation, which is why every userspace program is
+  linked at a distinct fixed address (`userspace/*/user.ld`) and why `spawn`
+  refuses an image overlapping one already resident.
 - **No pipes or background jobs.** `ksh` parses them; running them needs two
   programs connected by a shared descriptor, which needs per-process descriptor
   tables. The table is currently global — see the note in `sys_exit`.

--- a/kernel/linker.ld
+++ b/kernel/linker.ld
@@ -2,23 +2,54 @@
  *
  * The ELF entry point is the 32-bit trampoline in src/boot32.rs, NOT the Rust
  * `_start` — Multiboot2 hands off in 32-bit protected mode.
+ *
+ * ## Two addresses for everything
+ *
+ * The kernel is *linked* at KERNEL_VMA + 1 MiB and *loaded* at 1 MiB physical.
+ * Every output section therefore carries an explicit LMA via `AT()`, so the ELF
+ * program headers end up with `p_vaddr` in the higher half and `p_paddr` at
+ * 1 MiB. GRUB loads by `p_paddr`, which is what puts the image where the 32-bit
+ * trampoline can reach it; everything after the jump to long mode runs at
+ * `p_vaddr`.
+ *
+ * ## Why the higher half at all
+ *
+ * Until now the kernel lived in PML4[0] — the same top-level entry every user
+ * program needs for its own image and stack. Giving a process its own address
+ * space means giving it its own PML4[0], which is impossible while the kernel
+ * is in there too. Moving the kernel to PML4[511] is what makes per-process
+ * address spaces possible.
+ *
+ * -2 GiB specifically, because that is what `-C code-model=kernel` assumes: it
+ * lets the compiler use 32-bit sign-extended displacements everywhere, which is
+ * why that flag was already in `.cargo/config.toml` long before it was true.
  */
 
+KERNEL_VMA = 0xFFFFFFFF80000000;
+
+/* `e_entry` is a *virtual* address, even though GRUB jumps to it in 32-bit
+ * protected mode with paging off. GRUB finds the program header whose
+ * `p_vaddr` range contains the entry and rebases it into that header's
+ * `p_paddr` range, so it arrives at physical 1 MiB on its own.
+ *
+ * Naming the physical address here instead gets `error: entry point isn't in a
+ * segment` and no boot at all — GRUB looks it up in `p_vaddr` space, where a
+ * bare 0x101000 is nowhere. */
 ENTRY(_start32)
 
 SECTIONS
 {
-    . = 1M;
+    . = 1M + KERNEL_VMA;
 
     __kernel_start = .;
 
-    .multiboot2 ALIGN(8) :
+    .multiboot2 ALIGN(8) : AT(ADDR(.multiboot2) - KERNEL_VMA)
     {
         KEEP(*(.multiboot2))
     }
 
     __text_start = .;
-    .text ALIGN(4K) :
+    .text ALIGN(4K) : AT(ADDR(.text) - KERNEL_VMA)
     {
         KEEP(*(.text.boot32))
         *(.text .text.*)
@@ -27,7 +58,7 @@ SECTIONS
     __text_end = .;
 
     __rodata_start = .;
-    .rodata ALIGN(4K) :
+    .rodata ALIGN(4K) : AT(ADDR(.rodata) - KERNEL_VMA)
     {
         KEEP(*(.rodata.boot32))
         *(.rodata .rodata.*)
@@ -39,20 +70,20 @@ SECTIONS
        user space independently of anything the kernel keeps to itself. */
     . = ALIGN(4K);
     __user_start = .;
-    .user ALIGN(4K) :
+    .user ALIGN(4K) : AT(ADDR(.user) - KERNEL_VMA)
     {
         KEEP(*(.user))
     }
     . = ALIGN(4K);
     __user_end = .;
 
-    .data ALIGN(4K) :
+    .data ALIGN(4K) : AT(ADDR(.data) - KERNEL_VMA)
     {
         *(.data .data.*)
         *(.got .got.plt)
     }
 
-    .bss ALIGN(4K) :
+    .bss ALIGN(4K) : AT(ADDR(.bss) - KERNEL_VMA)
     {
         *(COMMON)
         *(.bss .bss.*)

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -683,13 +683,34 @@ fn test_virtual_memory() {
     // Print virtual memory layout
     memory::vmm::print_virtual_memory_stats();
     
-    // Test virtual address translation
-    let test_virt_addr = memory::vmm::VirtualAddress::new(0xFFFFFFFF80000000);
-    if let Some(phys_addr) = memory::vmm::translate_virtual_address(test_virt_addr) {
-        serial_println!("Virtual address 0x{:x} maps to physical address 0x{:x}", 
-                       test_virt_addr.as_usize(), phys_addr);
-    } else {
-        serial_println!("Virtual address 0x{:x} is not mapped", test_virt_addr.as_usize());
+    // KERNEL_VMA itself is the first page of the kernel window, and it maps
+    // physical page 0 — which `paging::init` deliberately leaves out, so the
+    // null guard survives the move to the higher half. Unmapped is the pass.
+    let guard_page =
+        memory::vmm::VirtualAddress::new(memory::paging::KERNEL_VMA as usize);
+    match memory::vmm::translate_virtual_address(guard_page) {
+        Some(phys) => serial_println!(
+            "  WARNING: the kernel window's guard page 0x{:x} maps to 0x{:x}",
+            guard_page.as_usize(),
+            phys
+        ),
+        None => serial_println!(
+            "  kernel window guard page 0x{:x}: unmapped, as it should be",
+            guard_page.as_usize()
+        ),
+    }
+
+    // And the kernel image itself, one page in, must resolve.
+    let image = memory::vmm::VirtualAddress::new(
+        (memory::paging::KERNEL_VMA + 0x10_0000) as usize,
+    );
+    match memory::vmm::translate_virtual_address(image) {
+        Some(phys) => serial_println!(
+            "  kernel image 0x{:x} -> physical 0x{:x}",
+            image.as_usize(),
+            phys
+        ),
+        None => serial_println!("  WARNING: the kernel image is not mapped"),
     }
     
     serial_println!("Virtual memory management test complete");

--- a/kernel/src/boot32.rs
+++ b/kernel/src/boot32.rs
@@ -1,20 +1,43 @@
 //! 32-bit Multiboot2 entry trampoline.
 //!
 //! Multiboot2 hands control to the kernel in **32-bit protected mode with
-//! paging disabled**. The rest of the kernel is compiled as 64-bit code, so
-//! something has to bridge the gap. That is this file.
+//! paging disabled**. The rest of the kernel is compiled as 64-bit code linked
+//! in the higher half, so something has to bridge both gaps. That is this file.
 //!
 //! Sequence:
 //!   1. `_start32` — stash the multiboot magic/info pointer, set up a stack,
 //!      bring COM1 up so we can talk even if everything else fails.
 //!   2. Validate the multiboot2 magic and check the CPU actually has long mode.
-//!   3. Build a bootstrap identity map of the first 1 GiB using 2 MiB pages.
+//!   3. Build a bootstrap map of the first 1 GiB, present at *two* virtual
+//!      addresses: identity, and again at `KERNEL_VMA`.
 //!   4. CR3 <- PML4, CR4.PAE, EFER.LME, CR0.PG, load a 64-bit GDT, far jump.
-//!   5. `long_mode_start` — reload segments, enable SSE (rustc emits SSE for
+//!   5. `long_mode_low` — an absolute 64-bit jump up to the higher half.
+//!   6. `long_mode_start` — reload segments, enable SSE (rustc emits SSE for
 //!      x86-64 by default), then call the Rust `_start(mb_info_addr)`.
 //!
 //! Registers at Multiboot2 hand-off: EAX = 0x36D76289, EBX = &boot_info.
 //! The System V AMD64 ABI wants the first argument in RDI, so we marshal it.
+//!
+//! ## Every symbol here has two addresses
+//!
+//! This file is linked with the rest of the kernel at `KERNEL_VMA + 1 MiB`, but
+//! steps 1-4 execute at *physical* 1 MiB with paging off. So every reference to
+//! a symbol in 32-bit code is written `sym - KERNEL_VMA`, which the linker
+//! resolves to a value that fits in the 32-bit operand. Miss one and the failure
+//! is a triple fault with no output — the exact class of bug that cost this
+//! project 27 commits the first time round.
+//!
+//! The one that bites hardest is `movl $p4_table, %eax` before `mov %cr3`:
+//! a truncated CR3 faults on the very next instruction, before any of the serial
+//! output below can report anything.
+//!
+//! ## Two maps, briefly
+//!
+//! The identity map still exists here because the code doing the switch is
+//! *running* at a low address; it cannot be removed until execution has moved to
+//! the higher half. `paging::init` builds the real tables later and drops it.
+//! Both windows point at the same PD, so they cost one extra page table between
+//! them.
 
 core::arch::global_asm!(
     r#"
@@ -23,25 +46,30 @@ core::arch::global_asm!(
 .global _start32
 .type _start32, @function
 
+/* Link-time constant, so `sym - KERNEL_VMA` is resolved by the linker into
+   something that fits a 32-bit operand. The linker script defines the same
+   value; it is repeated here because the assembler needs it too. */
+.set KERNEL_VMA, 0xFFFFFFFF80000000
+
 _start32:
     cli
     cld
 
     /* Stash the Multiboot2 hand-off registers before anything can clobber
        them (CPUID clobbers EBX, and we need EBX free for serial output). */
-    movl    %eax, mb_magic
-    movl    %ebx, mb_info
+    movl    %eax, (mb_magic - KERNEL_VMA)
+    movl    %ebx, (mb_info - KERNEL_VMA)
 
-    movl    $stack_top, %esp
+    movl    $(stack_top - KERNEL_VMA), %esp
     xorl    %ebp, %ebp
 
     call    serial_init32
 
-    movl    $msg_boot32, %esi
+    movl    $(msg_boot32 - KERNEL_VMA), %esi
     call    puts32
 
     /* Verify we were actually loaded by a Multiboot2-compliant loader. */
-    movl    mb_magic, %eax
+    movl    (mb_magic - KERNEL_VMA), %eax
     cmpl    $0x36D76289, %eax
     jne     bad_magic
 
@@ -49,18 +77,26 @@ _start32:
     call    setup_page_tables
     call    enable_paging
 
-    lgdt    gdt64_ptr
-    ljmp    $0x08, $long_mode_start
+    /* A 32-bit LGDT takes a 6-byte operand: 2-byte limit, 4-byte *linear* base.
+       Paging is on by now and only the identity window is usable from here, so
+       the base recorded in the descriptor is physical. This GDT is replaced by
+       `gdt::init` long before the identity map goes away. */
+    lgdt    (gdt64_ptr32 - KERNEL_VMA)
+
+    /* The far jump takes a 32-bit offset, so it cannot reach the higher half.
+       Land at the physical address of a two-instruction stub and jump the rest
+       of the way with a full 64-bit immediate. */
+    ljmp    $0x08, $(long_mode_low - KERNEL_VMA)
 
 /* --- error paths ------------------------------------------------------- */
 
 bad_magic:
-    movl    $msg_badmagic, %esi
+    movl    $(msg_badmagic - KERNEL_VMA), %esi
     call    puts32
     jmp     halt32
 
 no_long_mode:
-    movl    $msg_nolm, %esi
+    movl    $(msg_nolm - KERNEL_VMA), %esi
     call    puts32
     jmp     halt32
 
@@ -84,8 +120,16 @@ check_long_mode:
     ret
 
 /* --- bootstrap page tables --------------------------------------------- */
-/* Identity-maps 0..1GiB. That covers the kernel image at 1 MiB, the frame
-   bitmap, the heap, VGA at 0xB8000 and QEMU's default RAM.
+/* Maps physical 0..1 GiB twice: identity, and again at KERNEL_VMA.
+ *
+ * Both windows share one PD, so the second costs a single extra PDPT. The
+ * identity half is what the code below is executing from and cannot be dropped
+ * here; the higher half is where the kernel is linked and where it runs from
+ * `long_mode_start` onwards. `paging::init` replaces both with real tables.
+ *
+ * KERNEL_VMA = 0xFFFFFFFF80000000 decomposes as PML4[511], PDPT[510] — the last
+ * 2 GiB of the address space, which is exactly the window `-C code-model=kernel`
+ * assumes.
  *
  * The first 2 MiB uses 4 KiB pages rather than one huge page, purely so that
  * page 0 can be left unmapped as a null guard. With a flat huge-page map, a
@@ -94,26 +138,37 @@ check_long_mode:
  * from 2 MiB up uses 2 MiB pages. */
 
 setup_page_tables:
-    /* Zero PML4, PDPT, PD and the first-2MiB PT (4 * 4096 = 4096 dwords). */
-    movl    $p4_table, %edi
+    /* Zero PML4, PDPT-low, PDPT-high, PD and the first-2MiB PT
+       (5 * 4096 bytes = 5120 dwords). */
+    movl    $(p4_table - KERNEL_VMA), %edi
     xorl    %eax, %eax
-    movl    $4096, %ecx
+    movl    $5120, %ecx
     rep stosl
 
-    /* PML4[0] -> PDPT, present + writable */
-    movl    $p3_table, %eax
+    /* PML4[0] -> low PDPT, present + writable */
+    movl    $(p3_table - KERNEL_VMA), %eax
     orl     $0x03, %eax
-    movl    %eax, p4_table
+    movl    %eax, (p4_table - KERNEL_VMA)
+
+    /* PML4[511] -> high PDPT, present + writable. Entry 511 is byte 4088. */
+    movl    $(p3_high_table - KERNEL_VMA), %eax
+    orl     $0x03, %eax
+    movl    %eax, (p4_table - KERNEL_VMA + 4088)
 
     /* PDPT[0] -> PD, present + writable */
-    movl    $p2_table, %eax
+    movl    $(p2_table - KERNEL_VMA), %eax
     orl     $0x03, %eax
-    movl    %eax, p3_table
+    movl    %eax, (p3_table - KERNEL_VMA)
+
+    /* high PDPT[510] -> the *same* PD. Entry 510 is byte 4080. */
+    movl    $(p2_table - KERNEL_VMA), %eax
+    orl     $0x03, %eax
+    movl    %eax, (p3_high_table - KERNEL_VMA + 4080)
 
     /* PD[0] -> PT (4 KiB pages), present + writable, NOT huge */
-    movl    $p1_table, %eax
+    movl    $(p1_table - KERNEL_VMA), %eax
     orl     $0x03, %eax
-    movl    %eax, p2_table
+    movl    %eax, (p2_table - KERNEL_VMA)
 
     /* PT[i] = (i * 4KiB) | present | writable, for i = 1..511.
        PT[0] is deliberately left zero: unmapped null guard page. */
@@ -122,7 +177,7 @@ setup_page_tables:
     movl    %ecx, %eax
     shll    $12, %eax
     orl     $0x03, %eax
-    movl    $p1_table, %edi
+    movl    $(p1_table - KERNEL_VMA), %edi
     movl    %eax, (%edi, %ecx, 8)
     movl    $0, 4(%edi, %ecx, 8)
     incl    %ecx
@@ -135,7 +190,7 @@ setup_page_tables:
     movl    $0x200000, %eax
     mull    %ecx                    /* EDX:EAX = 2MiB * i */
     orl     $0x83, %eax
-    movl    $p2_table, %edi
+    movl    $(p2_table - KERNEL_VMA), %edi
     movl    %eax, (%edi, %ecx, 8)
     movl    %edx, 4(%edi, %ecx, 8)
     incl    %ecx
@@ -146,7 +201,7 @@ setup_page_tables:
 /* --- switch the CPU into long mode ------------------------------------- */
 
 enable_paging:
-    movl    $p4_table, %eax
+    movl    $(p4_table - KERNEL_VMA), %eax
     movl    %eax, %cr3
 
     movl    %cr4, %eax
@@ -223,6 +278,14 @@ puts32:                             /* NUL-terminated string in ESI */
 /* --- 64-bit land -------------------------------------------------------- */
 
 .code64
+
+/* Reached by the far jump, still executing at a physical address. The only job
+   here is to get RIP into the higher half; `movabsq` is the only form that can
+   name a 64-bit target. */
+long_mode_low:
+    movabsq $long_mode_start, %rax
+    jmp     *%rax
+
 long_mode_start:
     movw    $0x10, %ax
     movw    %ax, %ss
@@ -231,7 +294,7 @@ long_mode_start:
     movw    %ax, %fs
     movw    %ax, %gs
 
-    movq    $stack_top, %rsp
+    movabsq $stack_top, %rsp
     xorq    %rbp, %rbp
 
     /* rustc emits SSE instructions for x86-64 unconditionally, so the FPU/SSE
@@ -289,8 +352,19 @@ gdt64:
     .quad   0
     .quad   0x00AF9A000000FFFF      /* 0x08: 64-bit code, ring 0 */
     .quad   0x00CF92000000FFFF      /* 0x10: data, ring 0 */
+gdt64_end:
+
+/* Two descriptors for one table. The 32-bit LGDT above consumes 6 bytes and
+   needs the physical base; the 64-bit form consumes 10 and takes the higher-half
+   one. Sharing a single descriptor between the two modes is a silent way to load
+   a GDTR pointing at the low 32 bits of a higher-half address. */
+gdt64_ptr32:
+    .word   gdt64_end - gdt64 - 1
+    .long   gdt64 - KERNEL_VMA
+
+.balign 8
 gdt64_ptr:
-    .word   gdt64_ptr - gdt64 - 1
+    .word   gdt64_end - gdt64 - 1
     .quad   gdt64
 
 msg_boot32:
@@ -309,6 +383,8 @@ p4_table:
 p3_table:
     .skip   4096
 p2_table:
+    .skip   4096
+p3_high_table:
     .skip   4096
 p1_table:
     .skip   4096

--- a/kernel/src/main.rs
+++ b/kernel/src/main.rs
@@ -250,8 +250,21 @@ pub extern "C" fn _start(multiboot_info_addr: usize) -> ! {
     serial_println!("Kosh Kernel Starting...");
     println!("Kosh Kernel Starting...");
 
-    // Parse multiboot2 information
-    let boot_info = unsafe { BootInformation::load(multiboot_info_addr as *const _) };
+    // GRUB passes a *physical* address, and this is one of the places where the
+    // difference started to matter: with the kernel in the higher half there is
+    // no identity map to make it dereferenceable. The low 1 GiB is reachable
+    // through the kernel window, which is where GRUB puts the structure.
+    //
+    // Everything that reads `boot_info` runs before `paging::init`; nothing may
+    // hold on to it past that point, because the tables it builds only keep the
+    // window up to the end of the frame bitmap.
+    let mb_virt = crate::memory::paging::kernel_virt(multiboot_info_addr as u64);
+    serial_println!(
+        "Multiboot2 info at phys 0x{:x} (mapped at 0x{:x})",
+        multiboot_info_addr,
+        mb_virt
+    );
+    let boot_info = unsafe { BootInformation::load(mb_virt as *const _) };
     
     match boot_info {
         Ok(boot_info) => {

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -41,6 +41,39 @@ pub const PHYSMAP_BASE: u64 = 0xFFFF_8000_0000_0000;
 /// Virtual base of the kernel heap window. PML4 entry 288.
 pub const KERNEL_HEAP_BASE: u64 = 0xFFFF_9000_0000_0000;
 
+/// Where the kernel image is linked. PML4 entry 511, PDPT entry 510 — the last
+/// 2 GiB, which is the window `-C code-model=kernel` assumes.
+///
+/// The kernel is *loaded* at 1 MiB physical and *runs* at `KERNEL_VMA + 1 MiB`.
+/// Anything that turns a linker symbol into a physical address goes through
+/// [`kernel_phys`]; getting that wrong used to be impossible, because the two
+/// were the same number.
+pub const KERNEL_VMA: u64 = 0xFFFF_FFFF_8000_0000;
+
+/// How much physical memory is reachable through the `KERNEL_VMA` window.
+///
+/// The trampoline maps a full 1 GiB there and [`init`] keeps a smaller slice, so
+/// this is the bound during construction — before the physmap exists and while
+/// `KERNEL_VMA + phys` is the only way to reach a fresh page-table frame.
+pub const KERNEL_WINDOW_SIZE: u64 = 1024 * 1024 * 1024;
+
+/// Physical address of a kernel-image virtual address.
+///
+/// Only valid for addresses inside the kernel window — linker symbols, the frame
+/// bitmap, VGA. Use [`translate`] for anything else.
+pub const fn kernel_phys(virt: u64) -> u64 {
+    virt - KERNEL_VMA
+}
+
+/// Kernel-virtual address of a physical address in the low window.
+///
+/// The inverse of [`kernel_phys`], and usable *before* the physmap exists —
+/// which is what makes it the right tool for the frame bitmap and for the VGA
+/// buffer, both of which are touched before `paging::init` runs.
+pub const fn kernel_virt(phys: u64) -> u64 {
+    phys + KERNEL_VMA
+}
+
 extern "C" {
     static __kernel_start: u8;
     static __text_start: u8;
@@ -66,20 +99,31 @@ unsafe impl FrameAllocator<Size4KiB> for KoshFrameAllocator {
     }
 }
 
-/// Set once `init` has switched CR3. Before that, physical addresses must be
-/// reached through the bootstrap identity map instead.
+/// True once `init` has switched CR3 and the physmap covers all of RAM.
+///
+/// There used to be a `phys_to_virt` here that consulted this and returned
+/// either the physical address unchanged (identity map) or `PHYSMAP_BASE + phys`.
+/// It had no callers, and the higher-half migration is what made it a trap
+/// rather than a convenience: "the kernel-virtual address of this frame" now has
+/// two right answers depending on *when* you ask, and hiding that behind one
+/// function invites using the wrong one. Call [`kernel_virt`] before `init` and
+/// add [`PHYSMAP_BASE`] after it, deliberately.
 static PHYSMAP_ACTIVE: Mutex<bool> = Mutex::new(false);
 
-/// Translate a physical address to a kernel-virtual one.
+/// Whether the physmap covers all of physical memory yet.
+pub fn physmap_active() -> bool {
+    *PHYSMAP_ACTIVE.lock()
+}
+
+/// How much physical memory `init` actually mapped into the kernel window.
 ///
-/// Before [`init`] this is the identity map (offset 0); afterwards it is the
-/// physmap. Callers do not need to care which.
-pub fn phys_to_virt(phys: u64) -> u64 {
-    if *PHYSMAP_ACTIVE.lock() {
-        PHYSMAP_BASE + phys
-    } else {
-        phys
-    }
+/// The trampoline maps a full 1 GiB there; the real tables map only as far as
+/// the frame bitmap needs, so reporting `KERNEL_WINDOW_SIZE` as the window would
+/// overstate it by two orders of magnitude.
+static KERNEL_WINDOW_END: Mutex<u64> = Mutex::new(0);
+
+pub fn kernel_window_end() -> u64 {
+    *KERNEL_WINDOW_END.lock()
 }
 
 /// Build the kernel's own page tables and install them.
@@ -106,27 +150,36 @@ pub fn init(phys_mem_end: u64) -> Result<(), &'static str> {
     }
     serial_println!("  CR0.WP enabled (read-only pages enforced in ring 0)");
 
-    // We are still running on the bootstrap identity map, so a physical
-    // address is also a valid virtual address. That is what makes it possible
-    // to build a fresh table hierarchy at all.
+    // The physmap does not exist yet, so a freshly-allocated table frame has to
+    // be reached through the window the trampoline set up: `KERNEL_VMA + phys`,
+    // valid for the low 1 GiB. `BootstrapFrameAllocator` refuses anything above
+    // that rather than handing back a pointer that faults on first write.
     let pml4_frame = allocate_frame().ok_or("no frame for PML4")?;
     let pml4_phys = pml4_frame.address() as u64;
+    check_bootstrap_reachable(pml4_phys)?;
     let pml4: &mut PageTable = unsafe {
-        let ptr = pml4_phys as *mut PageTable;
+        let ptr = kernel_virt(pml4_phys) as *mut PageTable;
         ptr.write(PageTable::new());
         &mut *ptr
     };
 
-    // Offset 0: during construction, physical == virtual.
-    let mut mapper = unsafe { OffsetPageTable::new(pml4, VirtAddr::new(0)) };
-    let mut frames = KoshFrameAllocator;
+    // The offset the mapper uses to reach the tables it is editing. During
+    // construction that is the kernel window, not the physmap — the physmap is
+    // one of the things being built.
+    let mut mapper = unsafe { OffsetPageTable::new(pml4, VirtAddr::new(KERNEL_VMA)) };
+    let mut frames = BootstrapFrameAllocator;
 
     map_kernel_image(&mut mapper, &mut frames)?;
-    let identity_end = map_low_identity(&mut mapper, &mut frames)?;
+    let window_end = map_kernel_window(&mut mapper, &mut frames)?;
     map_physical_memory(&mut mapper, &mut frames, phys_mem_end)?;
 
     // Install. From the next instruction onwards the kernel is running on
     // tables it built, with W^X enforced and a real physmap.
+    //
+    // Nothing about this instruction is delicate any more: RIP, RSP and every
+    // static are higher-half addresses that the new tables map, so the switch is
+    // invisible. Before the migration it worked only because the new tables
+    // reproduced the bootstrap identity map exactly.
     unsafe {
         Cr3::write(
             PhysFrame::containing_address(PhysAddr::new(pml4_phys)),
@@ -135,12 +188,13 @@ pub fn init(phys_mem_end: u64) -> Result<(), &'static str> {
     }
 
     *PHYSMAP_ACTIVE.lock() = true;
+    *KERNEL_WINDOW_END.lock() = window_end;
 
     serial_println!("  CR3 -> 0x{:x} (kernel page tables active)", pml4_phys);
     serial_println!(
-        "  identity window : 0x{:x}..0x{:x} (4 KiB pages, W^X)",
-        PAGE_SIZE,
-        identity_end
+        "  kernel window   : 0x{:x} -> 0x0..0x{:x} (4 KiB pages, W^X)",
+        KERNEL_VMA,
+        window_end
     );
     serial_println!(
         "  physmap         : 0x{:x} -> 0x0..0x{:x} (2 MiB pages, RW+NX)",
@@ -148,18 +202,50 @@ pub fn init(phys_mem_end: u64) -> Result<(), &'static str> {
         phys_mem_end
     );
     serial_println!("  page 0          : unmapped (null guard)");
+    serial_println!("  PML4[0]         : empty — reserved for user address spaces");
 
     Ok(())
 }
 
-/// Map the kernel image with per-section permissions.
+/// Frame allocator for the window between "no page tables of our own" and "a
+/// physmap". Every frame it hands out is about to be written through
+/// `KERNEL_VMA + phys`, so a frame outside that window is not a subtle problem.
+struct BootstrapFrameAllocator;
+
+unsafe impl FrameAllocator<Size4KiB> for BootstrapFrameAllocator {
+    fn allocate_frame(&mut self) -> Option<PhysFrame<Size4KiB>> {
+        let frame = allocate_frame()?;
+        let phys = frame.address() as u64;
+        if phys >= KERNEL_WINDOW_SIZE {
+            // Returning None would surface as a vague "failed to map" further
+            // up, so say what actually happened.
+            serial_println!(
+                "  FATAL: page-table frame at 0x{:x} is outside the 0x{:x} bootstrap window",
+                phys,
+                KERNEL_WINDOW_SIZE
+            );
+            return None;
+        }
+        Some(PhysFrame::containing_address(PhysAddr::new(phys)))
+    }
+}
+
+fn check_bootstrap_reachable(phys: u64) -> Result<(), &'static str> {
+    if phys >= KERNEL_WINDOW_SIZE {
+        return Err("PML4 frame is outside the bootstrap kernel window");
+    }
+    Ok(())
+}
+
+/// Map the kernel image at [`KERNEL_VMA`] with per-section permissions.
 ///
-/// The identity mapping is kept — the kernel is linked at 1 MiB and is
-/// executing there, so it cannot move without a jump trampoline. What changes
-/// is the permissions: `.text` loses write, everything else loses execute.
+/// `.text` loses write, `.rodata` loses execute and write, everything else
+/// loses execute. The addresses here are already higher-half — they are the
+/// linker symbols — and [`kernel_phys`] turns each one back into the frame GRUB
+/// actually loaded it into.
 fn map_kernel_image(
     mapper: &mut OffsetPageTable,
-    frames: &mut KoshFrameAllocator,
+    frames: &mut BootstrapFrameAllocator,
 ) -> Result<(), &'static str> {
     let text_start = align_down_page(sym(unsafe { &__text_start }));
     let text_end = align_up_page(sym(unsafe { &__text_end }));
@@ -182,7 +268,7 @@ fn map_kernel_image(
         } else {
             rw
         };
-        identity_map_4k(mapper, frames, addr, flags)?;
+        map_window_4k(mapper, frames, addr, flags)?;
         addr += PAGE_SIZE as u64;
     }
 
@@ -197,13 +283,20 @@ fn map_kernel_image(
     Ok(())
 }
 
-/// Identity-map the low region the kernel still touches by physical address:
-/// VGA at 0xB8000, and the physical frame bitmap.
+/// Map the low physical region the kernel reaches by `KERNEL_VMA + phys`:
+/// VGA at 0xB8000, the multiboot info GRUB left below 1 MiB, and the physical
+/// frame bitmap.
 ///
-/// Page 0 is skipped so a null dereference still faults.
-fn map_low_identity(
+/// This used to be `map_low_identity`, and it mapped the same frames at the same
+/// numeric addresses in PML4[0]. The frames are identical; the virtual addresses
+/// moved out of the half that belongs to userspace. That move is the whole
+/// point of the migration — everything else here is unchanged.
+///
+/// Physical page 0 is skipped so that `KERNEL_VMA` itself is unmapped, the same
+/// null guard the identity map had at address 0.
+fn map_kernel_window(
     mapper: &mut OffsetPageTable,
-    frames: &mut KoshFrameAllocator,
+    frames: &mut BootstrapFrameAllocator,
 ) -> Result<u64, &'static str> {
     let (_bitmap_start, bitmap_end) = bitmap_extent();
     let kernel_start = align_down_page(sym(unsafe { &__kernel_start }));
@@ -212,18 +305,22 @@ fn map_low_identity(
     // One 2 MiB of slack past the bitmap covers early page-table frames, which
     // the allocator hands out from just above it.
     let end = align_up_2mib(bitmap_end as u64 + 2 * 1024 * 1024);
+    if end > KERNEL_WINDOW_SIZE {
+        return Err("kernel window is not big enough for the frame bitmap");
+    }
 
     let rw = PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::NO_EXECUTE;
 
-    let mut addr = PAGE_SIZE as u64; // skip page 0: null guard
-    while addr < end {
+    let mut phys = PAGE_SIZE as u64; // skip physical page 0: null guard
+    while phys < end {
+        let virt = kernel_virt(phys);
         // The kernel image was already mapped with tighter permissions.
-        if addr >= kernel_start && addr < kernel_end {
-            addr += PAGE_SIZE as u64;
+        if virt >= kernel_start && virt < kernel_end {
+            phys += PAGE_SIZE as u64;
             continue;
         }
-        identity_map_4k(mapper, frames, addr, rw)?;
-        addr += PAGE_SIZE as u64;
+        map_window_4k(mapper, frames, virt, rw)?;
+        phys += PAGE_SIZE as u64;
     }
 
     Ok(end)
@@ -232,7 +329,7 @@ fn map_low_identity(
 /// Map all of physical memory at [`PHYSMAP_BASE`] using 2 MiB pages.
 fn map_physical_memory(
     mapper: &mut OffsetPageTable,
-    frames: &mut KoshFrameAllocator,
+    frames: &mut BootstrapFrameAllocator,
     phys_mem_end: u64,
 ) -> Result<(), &'static str> {
     const HUGE: u64 = 2 * 1024 * 1024;
@@ -260,19 +357,25 @@ fn map_physical_memory(
     Ok(())
 }
 
-fn identity_map_4k(
+/// Map one page of the `KERNEL_VMA` window to the frame it corresponds to.
+///
+/// `virt` is a higher-half address; the frame is `virt - KERNEL_VMA`. Before the
+/// migration this function was `identity_map_4k` and the frame was `virt`
+/// itself, which is the single line that made the kernel unmovable.
+fn map_window_4k(
     mapper: &mut OffsetPageTable,
-    frames: &mut KoshFrameAllocator,
-    addr: u64,
+    frames: &mut BootstrapFrameAllocator,
+    virt: u64,
     flags: PageTableFlags,
 ) -> Result<(), &'static str> {
-    let page: Page<Size4KiB> = Page::containing_address(VirtAddr::new(addr));
-    let frame: PhysFrame<Size4KiB> = PhysFrame::containing_address(PhysAddr::new(addr));
+    let page: Page<Size4KiB> = Page::containing_address(VirtAddr::new(virt));
+    let frame: PhysFrame<Size4KiB> =
+        PhysFrame::containing_address(PhysAddr::new(kernel_phys(virt)));
 
     unsafe {
         mapper
             .map_to(page, frame, flags, frames)
-            .map_err(|_| "failed to identity-map page")?
+            .map_err(|_| "failed to map a kernel window page")?
             .ignore();
     }
     Ok(())
@@ -460,28 +563,36 @@ fn align_up_2mib(addr: u64) -> u64 {
 pub fn self_test() {
     serial_println!("Verifying kernel page tables...");
 
-    // The physmap must alias the identity region. Reading the kernel's first
-    // bytes through both windows must give the same value.
+    // The physmap must alias the kernel window. Reading the kernel's first bytes
+    // through both must give the same value.
     let kernel_start = align_down_page(sym(unsafe { &__kernel_start }));
-    let via_identity = unsafe { core::ptr::read_volatile(kernel_start as *const u64) };
-    let via_physmap =
-        unsafe { core::ptr::read_volatile((PHYSMAP_BASE + kernel_start) as *const u64) };
+    let kernel_phys_start = kernel_phys(kernel_start);
 
-    if via_identity == via_physmap {
-        serial_println!("  physmap aliases identity map: OK (0x{:016x})", via_identity);
+    let via_window = unsafe { core::ptr::read_volatile(kernel_start as *const u64) };
+    let via_physmap =
+        unsafe { core::ptr::read_volatile((PHYSMAP_BASE + kernel_phys_start) as *const u64) };
+
+    if via_window == via_physmap {
+        serial_println!("  physmap aliases identity map: OK (0x{:016x})", via_window);
     } else {
         serial_println!(
-            "  physmap MISMATCH: identity 0x{:x} vs physmap 0x{:x}",
-            via_identity,
+            "  physmap MISMATCH: window 0x{:x} vs physmap 0x{:x}",
+            via_window,
             via_physmap
         );
     }
 
     match translate(kernel_start) {
-        Some(phys) if phys == kernel_start => {
-            serial_println!("  translate(0x{:x}) -> 0x{:x}: OK", kernel_start, phys)
-        }
-        Some(phys) => serial_println!("  translate mismatch: 0x{:x}", phys),
+        Some(phys) if phys == kernel_phys_start => serial_println!(
+            "  translate(0x{:x}) -> 0x{:x}: OK",
+            kernel_start,
+            phys
+        ),
+        Some(phys) => serial_println!(
+            "  translate mismatch: 0x{:x}, expected 0x{:x}",
+            phys,
+            kernel_phys_start
+        ),
         None => serial_println!("  translate FAILED: kernel not mapped?"),
     }
 
@@ -489,5 +600,25 @@ pub fn self_test() {
         serial_println!("  page 0 unmapped: OK (null dereferences will fault)");
     } else {
         serial_println!("  WARNING: page 0 is mapped, null dereferences will NOT fault");
+    }
+
+    // The point of the whole migration: the kernel is no longer anywhere in the
+    // half of the address space a user process needs.
+    //
+    // Checking the *image* address specifically, rather than PML4[0] being
+    // empty, because PML4[0] is exactly where user mappings live — it is
+    // populated, just not by us.
+    let low_kernel = translate(kernel_phys_start);
+    if low_kernel.is_none() {
+        serial_println!(
+            "  kernel out of PML4[0]: OK (0x{:x} is unmapped, was the kernel image)",
+            kernel_phys_start
+        );
+    } else {
+        serial_println!(
+            "  WARNING: 0x{:x} still maps to 0x{:x} — the low identity map survived",
+            kernel_phys_start,
+            low_kernel.unwrap()
+        );
     }
 }

--- a/kernel/src/memory/physical.rs
+++ b/kernel/src/memory/physical.rs
@@ -13,11 +13,19 @@ extern "C" {
 /// Physical extent of the kernel image as actually loaded by the bootloader.
 /// These frames must never be handed out by the allocator — the boot page
 /// tables and the boot stack live in .bss, inside this range.
+///
+/// The linker symbols are higher-half addresses (the kernel is linked at
+/// `KERNEL_VMA + 1 MiB` and loaded at 1 MiB), so each one is converted. Before
+/// the migration this function returned the symbols unchanged and was correct
+/// only because the two numbers were the same. Getting it wrong now means the
+/// comparison at the bottom of `mark_available_frames` never matches and the
+/// allocator hands out the running kernel's own frames.
 fn kernel_image_range() -> (usize, usize) {
+    use crate::memory::paging::kernel_phys;
     unsafe {
         (
-            &__kernel_start as *const u8 as usize,
-            &__kernel_end as *const u8 as usize,
+            kernel_phys(&__kernel_start as *const u8 as u64) as usize,
+            kernel_phys(&__kernel_end as *const u8 as u64) as usize,
         )
     }
 }
@@ -140,9 +148,17 @@ impl PhysicalMemoryManager {
             }
         }
         
-        // Initialize bitmap memory
+        // The bitmap lives at a physical address, but it has to be *written*
+        // through a virtual one — and this runs before `paging::init`, so the
+        // physmap does not exist yet. `KERNEL_VMA + phys` is the window the boot
+        // trampoline set up, and `paging::init` deliberately keeps it, so this
+        // pointer stays valid for the life of the kernel and needs no rebasing
+        // when the low identity map goes away.
         let bitmap = unsafe {
-            core::slice::from_raw_parts_mut(bitmap_start as *mut u8, bitmap_size)
+            core::slice::from_raw_parts_mut(
+                crate::memory::paging::kernel_virt(bitmap_start as u64) as *mut u8,
+                bitmap_size,
+            )
         };
         
         // Clear the bitmap (all pages initially marked as used)

--- a/kernel/src/memory/vmm.rs
+++ b/kernel/src/memory/vmm.rs
@@ -282,27 +282,36 @@ impl VirtualAddressSpace {
     }
 }
 
-/// Kernel virtual memory layout constants
+/// Kernel virtual memory layout constants.
+///
+/// These used to be three invented numbers — code at `KERNEL_VMA`, data 16 MiB
+/// above it, heap 16 MiB above that — describing a layout nothing had ever
+/// built. They were printed in the boot log next to the real one, which is
+/// worse than not printing them at all.
+///
+/// They are derived from `memory::paging` now, so the layout this module reports
+/// is the layout the page tables actually have. `KERNEL_CODE_START` finally
+/// being correct is not a coincidence: the higher-half migration moved the
+/// kernel to the address this constant had been claiming all along.
 pub mod kernel_layout {
     use super::VirtualAddress;
-    
-    /// Kernel code start address (higher half)
-    pub const KERNEL_CODE_START: VirtualAddress = VirtualAddress(0xFFFFFFFF80000000);
-    
-    /// Kernel code size (16MB)
-    pub const KERNEL_CODE_SIZE: usize = 16 * 1024 * 1024;
-    
-    /// Kernel data start address
-    pub const KERNEL_DATA_START: VirtualAddress = VirtualAddress(0xFFFFFFFF81000000);
-    
-    /// Kernel data size (16MB)
-    pub const KERNEL_DATA_SIZE: usize = 16 * 1024 * 1024;
-    
-    /// Kernel heap start address
-    pub const KERNEL_HEAP_START: VirtualAddress = VirtualAddress(0xFFFFFFFF82000000);
-    
-    /// Kernel heap size (64MB)
-    pub const KERNEL_HEAP_SIZE: usize = 64 * 1024 * 1024;
+
+    /// Base of the kernel image window. The image itself starts 1 MiB in;
+    /// the first page is left unmapped as the null guard.
+    pub const KERNEL_CODE_START: VirtualAddress =
+        VirtualAddress(crate::memory::paging::KERNEL_VMA as usize);
+
+    /// Upper bound on the kernel window. The amount `paging::init` actually
+    /// maps is smaller and only known at run time — see
+    /// `paging::kernel_window_end`, which is what the layout dump reports.
+    pub const KERNEL_CODE_SIZE: usize = crate::memory::paging::KERNEL_WINDOW_SIZE as usize;
+
+    /// Kernel heap start address — the window `memory::heap` actually maps.
+    pub const KERNEL_HEAP_START: VirtualAddress =
+        VirtualAddress(crate::memory::paging::KERNEL_HEAP_BASE as usize);
+
+    /// Kernel heap size. Matches `boot::HEAP_SIZE_PAGES` worth of 4 KiB pages.
+    pub const KERNEL_HEAP_SIZE: usize = 1024 * 4096;
     
     /// Physical memory mapping start (for higher half kernel)
     /// Offset at which all of physical memory is visible in the virtual
@@ -357,24 +366,27 @@ unsafe fn get_level_4_page_table() -> &'static mut PageTable {
 fn setup_kernel_memory_layout(vas: &mut VirtualAddressSpace) -> Result<(), &'static str> {
     serial_println!("Setting up kernel virtual memory layout...");
     
-    // Add kernel code region
+    // The kernel image window. One region rather than separate code and data
+    // ones: the image is a single contiguous span whose per-section permissions
+    // live in the page tables, not in a table of constants.
     let kernel_code_region = VirtualMemoryRegion::new(
         kernel_layout::KERNEL_CODE_START,
-        kernel_layout::KERNEL_CODE_SIZE,
+        crate::memory::paging::kernel_window_end() as usize,
         MemoryProtection::read_execute(),
-        "Kernel Code"
+        "Kernel Window"
     );
     vas.add_region(kernel_code_region);
-    
-    // Add kernel data region
-    let kernel_data_region = VirtualMemoryRegion::new(
-        kernel_layout::KERNEL_DATA_START,
-        kernel_layout::KERNEL_DATA_SIZE,
+
+    // The physmap, which was missing from this table entirely even though it is
+    // the largest mapping the kernel has.
+    let physmap_region = VirtualMemoryRegion::new(
+        kernel_layout::PHYSICAL_MEMORY_OFFSET,
+        crate::memory::physical::physical_memory_end() as usize,
         MemoryProtection::read_write(),
-        "Kernel Data"
+        "Physmap"
     );
-    vas.add_region(kernel_data_region);
-    
+    vas.add_region(physmap_region);
+
     // Add kernel heap region
     let kernel_heap_region = VirtualMemoryRegion::new(
         kernel_layout::KERNEL_HEAP_START,
@@ -548,13 +560,23 @@ mod tests {
     
     #[test_case]
     fn test_kernel_layout_constants() {
-        // Verify kernel layout constants are properly defined
-        assert_eq!(kernel_layout::KERNEL_CODE_START.as_usize(), 0xFFFFFFFF80000000);
-        assert_eq!(kernel_layout::KERNEL_CODE_SIZE, 16 * 1024 * 1024);
-        assert_eq!(kernel_layout::KERNEL_DATA_START.as_usize(), 0xFFFFFFFF81000000);
-        assert_eq!(kernel_layout::KERNEL_DATA_SIZE, 16 * 1024 * 1024);
-        assert_eq!(kernel_layout::KERNEL_HEAP_START.as_usize(), 0xFFFFFFFF82000000);
-        assert_eq!(kernel_layout::KERNEL_HEAP_SIZE, 64 * 1024 * 1024);
-        assert_eq!(kernel_layout::PHYSICAL_MEMORY_OFFSET.as_usize(), 0xFFFF800000000000);
+        // These now assert against `memory::paging`, so the test fails if the two
+        // modules ever disagree about where the kernel lives — which is the only
+        // thing worth asserting about a constant.
+        assert_eq!(
+            kernel_layout::KERNEL_CODE_START.as_usize(),
+            crate::memory::paging::KERNEL_VMA as usize
+        );
+        assert_eq!(
+            kernel_layout::KERNEL_HEAP_START.as_usize(),
+            crate::memory::paging::KERNEL_HEAP_BASE as usize
+        );
+        assert_eq!(
+            kernel_layout::PHYSICAL_MEMORY_OFFSET.as_usize(),
+            crate::memory::paging::PHYSMAP_BASE as usize
+        );
+        // The kernel window has to start below the heap window, or the two
+        // descriptions overlap and the layout dump is nonsense.
+        assert!(kernel_layout::KERNEL_HEAP_START.as_usize() < kernel_layout::KERNEL_CODE_START.as_usize());
     }
 }

--- a/kernel/src/usermode.rs
+++ b/kernel/src/usermode.rs
@@ -121,8 +121,11 @@ pub fn boot_module_named(name: &str) -> Option<BootModule> {
         .copied()
 }
 
-/// Where the user blob is mapped. 1 GiB — clear of the kernel's low identity
-/// window and nowhere near the higher half.
+/// Where the user blob is mapped. 1 GiB into the lower half.
+///
+/// It used to have to dodge the kernel's low identity window; there isn't one
+/// any more, so the whole lower half belongs to userspace and this is just a
+/// round number that keeps the payload clear of the loaded ELFs at 4 and 8 MiB.
 pub const USER_CODE_BASE: u64 = 0x0000_0000_4000_0000;
 
 /// Top of the user stack, growing down.
@@ -155,6 +158,17 @@ fn sym(s: &u8) -> u64 {
     s as *const u8 as u64
 }
 
+/// Physical frame the `.user` section starts at.
+///
+/// The section is part of the kernel image, so its link-time address is
+/// higher-half; `map_user_range` needs the frame GRUB actually loaded it into.
+/// Passing the virtual address here used to work because they were the same
+/// number — now it would hand `PhysAddr::new` a value with bits above 52 set,
+/// which panics rather than silently mapping the wrong thing.
+fn user_blob_phys() -> u64 {
+    crate::memory::paging::kernel_phys(sym(unsafe { &__user_start }))
+}
+
 /// Map the user blob and its stack, then drop to ring 3.
 ///
 /// Runs as a kernel thread, so `sys_exit` can retire it through
@@ -184,12 +198,15 @@ pub fn run_user_demo(which: usize) {
     let code_flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
     if !CODE_MAPPED.swap(true, Ordering::SeqCst) {
         serial_println!(
-            "  .user section  : 0x{:x}..0x{:x} ({} page(s))",
+            "  .user section  : 0x{:x}..0x{:x} ({} page(s), phys 0x{:x})",
             blob_start,
             blob_end,
-            blob_pages
+            blob_pages,
+            user_blob_phys()
         );
-        if let Err(e) = paging::map_user_range(USER_CODE_BASE, blob_start, blob_pages, code_flags) {
+        if let Err(e) =
+            paging::map_user_range(USER_CODE_BASE, user_blob_phys(), blob_pages, code_flags)
+        {
             serial_println!("  failed to map user code: {}", e);
             return;
         }
@@ -522,7 +539,9 @@ pub fn run_pingpong(which: usize) {
 
     let code_flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
     if !CODE_MAPPED.swap(true, Ordering::SeqCst) {
-        if let Err(e) = paging::map_user_range(USER_CODE_BASE, blob_start, blob_pages, code_flags) {
+        if let Err(e) =
+            paging::map_user_range(USER_CODE_BASE, user_blob_phys(), blob_pages, code_flags)
+        {
             serial_println!("  failed to map user code: {}", e);
             return;
         }

--- a/kernel/src/vga_buffer.rs
+++ b/kernel/src/vga_buffer.rs
@@ -3,11 +3,23 @@ use core::fmt;
 use spin::Mutex;
 use lazy_static::lazy_static;
 
+/// Physical address of the VGA text buffer.
+const VGA_PHYS: u64 = 0xb8000;
+
 lazy_static! {
     pub static ref WRITER: Mutex<Writer> = Mutex::new(Writer {
         column_position: 0,
         color_code: ColorCode::new(Color::Yellow, Color::Black),
-        buffer: unsafe { &mut *(0xb8000 as *mut Buffer) },
+        // Reached through the kernel window rather than by physical address.
+        //
+        // This is materialised by the first `println!`, which happens long
+        // before `paging::init` — so the physmap is not an option here, and the
+        // low identity map that used to make `0xb8000` work directly is gone.
+        // The trampoline maps `KERNEL_VMA + phys` for the low 1 GiB from the
+        // very first instruction of long mode, and `paging::init` keeps it.
+        buffer: unsafe {
+            &mut *(crate::memory::paging::kernel_virt(VGA_PHYS) as *mut Buffer)
+        },
     });
 }
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -105,6 +105,15 @@ cp "$HELLO" "$ISO_DIR/boot/hello"
 cp "$KSH"   "$ISO_DIR/boot/ksh"
 
 cat > "$ISO_DIR/boot/grub/grub.cfg" <<'EOF'
+# Put GRUB's own output on COM1 as well as the screen. A kernel that GRUB
+# refuses to load produces no serial output at all, which looks exactly like a
+# kernel that hung on its first instruction — and the message that tells the two
+# apart ("error: entry point isn't in a segment") only ever went to the VGA
+# console, which --check does not capture.
+serial --unit=0 --speed=38400 --word=8 --parity=no --stop=1
+terminal_output serial console
+terminal_input serial console
+
 set timeout=0
 set default=0
 
@@ -227,6 +236,7 @@ check)
         "kernel page tables active" \
         "physmap aliases identity map: OK" \
         "page 0 unmapped: OK" \
+        "kernel out of PML4[0]: OK" \
         "PASS: heap fully reclaimed" \
         "Scheduler: PASS" \
         "hello from ring 3" \


### PR DESCRIPTION
The kernel was linked and loaded at physical 1 MiB and ran there, identity mapped through PML4[0] — the same top-level entry a user process needs for its own image and stack. Per-process address spaces were blocked on getting it out of the way. It is now linked at KERNEL_VMA + 1 MiB (-2 GiB, which is what `-C code-model=kernel` has been assuming all along) and loaded at 1 MiB, with `AT()` on every section so GRUB still puts it where the trampoline can reach it.

GRUB looks `e_entry` up in p_vaddr space and rebases it into p_paddr itself, so the ELF entry stays virtual. Naming the physical address gets "entry point isn't in a segment" and an empty log — that message goes to VGA, which --check does not capture, so run.sh now puts GRUB's own output on COM1.

boot32.rs maps physical 0..1 GiB twice, identity and at KERNEL_VMA, because the code doing the mapping is executing at a low address. Every 32-bit reference to a symbol is now `sym - KERNEL_VMA`; `lgdt` gets a second 6-byte descriptor with a physical base; the far jump lands on a two-instruction stub that `movabsq`es the rest of the way.

Then the real work: everything that got away with treating a virtual address as a physical one. `physical::kernel_image_range` is the dangerous one — it feeds the check that keeps the allocator off the running kernel's frames, and with virtual symbols the comparison never matches. Also the frame bitmap, VGA, the multiboot info pointer, the `.user` blob and `identity_map_4k`.

The bitmap and VGA are touched before the physmap exists, so they use `kernel_virt(phys)` — the trampoline's window, which paging::init keeps, so neither pointer ever needs rebasing. Table construction has the same problem one level up and runs with the mapper offset at KERNEL_VMA, with a BootstrapFrameAllocator that refuses frames above the window rather than returning a pointer that faults on first write.

`phys_to_virt` is deleted rather than fixed: after this, "the kernel-virtual address of this frame" has two right answers depending on when you ask.

`self_test` checks the kernel image address is gone from the lower half — not that PML4[0] is empty, since that is exactly where user mappings live. Restoring the low mapping turns the new marker into a FAIL, which is the only evidence it checks anything.

Also: vmm's `kernel_layout` described three invented addresses for a layout nothing had built, printed next to the real one. It is derived from memory::paging now.

33 boot markers and 28 console markers pass from a clean build.


Claude-Session: https://claude.ai/code/session_01P1GdpYMiKP5Gj1Jmub59gw