### PR TITLE
kernel: give every process its own address space

### DIFF
--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -1042,6 +1042,128 @@ reports what the page tables actually contain:
 `KERNEL_CODE_START` finally being right is not a coincidence — the migration
 moved the kernel to the address that constant had been claiming all along.
 
+## Per-process address spaces (Phase 12)
+
+Phase 11 got the kernel out of PML4[0]. This puts a process in it.
+
+An address space is a PML4 of its own: entries 0..256 — the whole lower half —
+are the process's alone, and 256..512 are copied from the kernel's table at
+creation. It copies the *entries*, not the tables under them, so every process
+walks the same PDPTs for the physmap, the heap window and the kernel image. That
+is what makes it safe for a syscall to allocate: a page added to the kernel heap
+after a process was created is already visible to it.
+
+```
+  0x10000000 -> frame 0x5a4000 in one space, 0x5a8000 in the other
+  same address 0x10000000: 0xaaaaaaaaaaaaaaaa in one space, 0xbbbbbbbbbbbbbbbb in the other
+  Address spaces: PASS — 3 kernel PML4 entries shared, lower half private
+```
+
+Three entries: 256 (physmap), 288 (heap), 511 (kernel image). The copy happens
+once, at creation, so a *new* top-level kernel entry appearing later would be
+invisible to processes that already exist — a syscall would fault on a valid
+kernel address, intermittently, depending on which process was running. Nothing
+creates one; `check_kernel_half` says so rather than assuming it.
+
+### Switching
+
+`task::schedule` reloads CR3 when the incoming thread lives somewhere else. It
+can do that in the middle of the scheduler only because everything it touches
+from that instruction until the incoming thread is running — RIP, RSP, the
+scheduler's statics, the GDT, the IDT, the per-CPU block — is in the shared upper
+half. That was not true one phase ago, which is why this could not be written
+until now.
+
+CR3 is compared before being written, because writing it flushes the TLB and
+most switches here are between kernel threads.
+
+### Teardown, and the order that matters
+
+`exit_current` returns CR3 to the kernel's tables **first**, then frees the
+space. The other order hands the frame holding the live top-level table to the
+allocator, and the next allocation overwrites the address space out from under
+the CPU walking it.
+
+Freeing walks the lower half and returns every page table it visits — but a leaf
+frame only if the entry carries `OWNED_BY_ADDRESS_SPACE`. `map_user_pages_in`
+allocates fresh frames and sets that bit; `map_user_range_in` maps frames the
+space does not own and does not. The distinction is not theoretical: the built-in
+ring-3 payload lives inside the kernel image and is mapped straight into user
+space, so an untagged teardown would hand the kernel's own `.user` section to the
+frame allocator.
+
+```
+  address space of thread 3 released: 98 frame(s)
+```
+
+### What this deletes
+
+The interesting part of the diff is the removals.
+
+| gone | why it existed |
+|---|---|
+| the `Resident` address-range table | to refuse a `spawn` whose image overlapped a resident one |
+| `elf::extent_of` | to answer "where would this go" before mapping it |
+| `LoadedImage::ranges`, `MappedRange`, `MAX_SEGMENTS`, `TooManySegments` | so somebody could unmap exactly what the loader had mapped |
+| `SpawnError::AddressConflict` | there is nothing left to conflict with |
+| `paging::unmap_user_pages` (whole-process form) | teardown walks the tables instead |
+| `SPAWN_STACK_REGION_TOP`, `ELF_USER_STACK_TOP`, `SHELL_USER_STACK_TOP`, the per-slot 1 MiB stack stride | to keep programs' stacks from colliding |
+
+All of it was bookkeeping around a shared lower half. Every program now loads at
+its own `p_vaddr` and gets a stack at one `USER_STACK_TOP`.
+
+### Two programs at one address
+
+`userspace/hello/user.ld` is now `. = 0x800000` — the same address as `ksh`. That
+is deliberate, and it is the test: `ksh` executing at 0x800000 spawns `hello`,
+which is also linked at 0x800000, twice in the scripted session.
+
+`ksh` can also spawn `ksh`:
+
+```
+ksh:/$ ksh
+Loading 'ksh' into a new address space:
+  segment: vaddr 0x800000 filesz 39813 memsz 39813 [r-x] -> 10 page(s)
+spawn 'ksh': thread 3, entry 0x800000
+
+ksh: the Kosh shell, in ring 3. Type 'help'.
+ksh:/$ getpid
+pid 3
+ksh:/$ exit
+  address space of thread 3 released: 98 frame(s)
+ksh:/$ getpid
+pid 2
+```
+
+Two shells, both executing at 0x800000, one nested inside the other. The previous
+phase refused this with `error -98` because a second copy would have overwritten
+the `.text` the first one was running.
+
+### Proving it can fail
+
+`address_space::self_test` maps one page at the same user virtual address in two
+spaces, writes a different value into each through the physmap, then activates
+each in turn and reads that address.
+
+Pointing both maps at the *same* space — which is what the kernel did until now —
+produces:
+
+```
+  Address spaces: FAIL — could not map the probe page: failed to map user page
+```
+
+`PageAlreadyMapped`, which is exactly the error `spawn` used to pre-empt with its
+overlap check.
+
+### One inconsistency this surfaced
+
+`run_user_demo` — the built-in payload — mapped its code and stack into the
+*kernel's* PML4[0] and left them there. That quietly contradicted the previous
+phase's "PML4[0] is empty, reserved for user address spaces": it was empty right
+up until the first ring-3 demo ran. It gets its own address space now, like
+everything else, and the two demos share a stack address instead of being handed
+regions a megabyte apart.
+
 ## What is deliberately still missing
 - **The filesystem is read-only.** Allocating clusters and keeping both FAT
   copies consistent is a separate problem, and a read-only filesystem that is
@@ -1054,12 +1176,15 @@ moved the kernel to the address that constant had been claiming all along.
 - **No `fork`/`exec`.** `spawn` loads a *second* program rather than duplicating
   the caller, so there is still no way for a program to replace its own image or
   to inherit one. `userspace/init` cannot do its job until `fork` exists.
-- **One address space, still.** The kernel is out of PML4[0], which is the
-  precondition for per-process address spaces — but nothing yet gives a process
-  its own PML4. Loaded programs share one set of tables and are protected by
-  page permissions, not separation, which is why every userspace program is
-  linked at a distinct fixed address (`userspace/*/user.ld`) and why `spawn`
-  refuses an image overlapping one already resident.
+- **No `fork`.** Every process starts from an ELF. Duplicating a *running*
+  address space needs the page tables copied and every writable page marked
+  copy-on-write, plus a `#PF` handler that does the copying — none of which
+  exists. The address space is now the right shape for it.
+- **No demand paging.** Every page of a program is allocated and populated at
+  load time, so a 256 KiB `.bss` costs 65 frames whether or not it is touched.
+- **The descriptor table is still global.** One table for the system, because
+  `Program` has nowhere to hang a per-process one yet. `sys_exit` works around
+  it by only closing everything when it is the last program running.
 - **No pipes or background jobs.** `ksh` parses them; running them needs two
   programs connected by a shared descriptor, which needs per-process descriptor
   tables. The table is currently global — see the note in `sys_exit`.

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -758,6 +758,8 @@ fn init_storage_selftest() {
 #[cfg(target_arch = "x86_64")]
 fn init_usermode() {
     crate::syscall::uaccess::self_test();
+    crate::memory::address_space::self_test();
+    serial_println!();
 
     let before = crate::syscall::entry::syscall_count();
 

--- a/kernel/src/elf.rs
+++ b/kernel/src/elf.rs
@@ -53,10 +53,6 @@ pub enum ElfError {
     NotExecutable,
     WrongArchitecture,
     NoLoadableSegments,
-    /// More `PT_LOAD` segments than [`MAX_SEGMENTS`], so the range table this
-    /// loader hands back could not describe the whole image — and an image that
-    /// cannot be described cannot be unmapped.
-    TooManySegments,
     SegmentOutOfRange,
     /// A segment wants to live where the kernel already is.
     SegmentInKernelSpace,
@@ -95,11 +91,7 @@ struct Elf64ProgramHeader {
     align: u64,
 }
 
-/// The most `PT_LOAD` segments this loader will map. A `no_std` Rust binary
-/// linked with the scripts in `userspace/` produces three or four.
-pub const MAX_SEGMENTS: usize = 8;
-
-/// A page range this loader mapped, so it can be handed back later.
+/// A page range this loader mapped.
 #[derive(Debug, Clone, Copy)]
 pub struct MappedRange {
     pub start: u64,
@@ -111,45 +103,22 @@ pub struct LoadedImage {
     pub entry: u64,
     pub segments: usize,
     pub bytes_mapped: usize,
-    /// Exactly what was mapped, in the order it was mapped.
-    ///
-    /// Returned rather than discarded because a program that cannot be unmapped
-    /// can only be run once: the second `spawn` hits `PageAlreadyMapped`. The
-    /// caller records these and frees them when the program exits.
-    pub ranges: [Option<MappedRange>; MAX_SEGMENTS],
-}
-
-impl LoadedImage {
-    /// Lowest and highest virtual addresses this image occupies, for overlap
-    /// checks against programs that are already resident.
-    pub fn extent(&self) -> (u64, u64) {
-        let mut lo = u64::MAX;
-        let mut hi = 0;
-        for range in self.ranges.iter().flatten() {
-            lo = lo.min(range.start);
-            hi = hi.max(range.start + (range.pages * PAGE_SIZE) as u64);
-        }
-        if lo == u64::MAX {
-            (0, 0)
-        } else {
-            (lo, hi)
-        }
-    }
 }
 
 /// Everything at or above this is kernel territory; a user segment claiming to
 /// live here is rejected rather than mapped.
 const USER_ADDRESS_LIMIT: u64 = 0x0000_8000_0000_0000;
 
-/// Load a static ELF64 executable from a byte slice into the current address
-/// space, mapped for ring 3.
+/// Load a static ELF64 executable into a named address space.
+///
+/// Separate from [`load`] because `sys_spawn` runs in the *parent* process and
+/// has to populate the child's tables. That works at all because the physmap is
+/// in the shared higher half: every address space can reach every physical
+/// frame, including another space's page tables and the frames being filled in.
 ///
 /// # Safety
-/// The caller must ensure no existing user mapping overlaps the segments this
-/// image declares. There is one address space, so that is a real obligation, not
-/// a formality — `usermode::spawn_program` checks it against the table of
-/// resident programs before calling here.
-pub unsafe fn load(image: &[u8]) -> Result<LoadedImage, ElfError> {
+/// As [`load`], and `pml4_phys` must be a live PML4.
+pub unsafe fn load_into(pml4_phys: u64, image: &[u8]) -> Result<LoadedImage, ElfError> {
     let header = parse_header(image)?;
 
     serial_println!(
@@ -162,7 +131,6 @@ pub unsafe fn load(image: &[u8]) -> Result<LoadedImage, ElfError> {
 
     let mut segments = 0usize;
     let mut bytes_mapped = 0usize;
-    let mut ranges: [Option<MappedRange>; MAX_SEGMENTS] = [None; MAX_SEGMENTS];
 
     for i in 0..header.phnum as usize {
         let offset = header.phoff as usize + i * header.phentsize as usize;
@@ -177,15 +145,11 @@ pub unsafe fn load(image: &[u8]) -> Result<LoadedImage, ElfError> {
             continue;
         }
 
-        if segments >= MAX_SEGMENTS {
-            return Err(ElfError::TooManySegments);
-        }
-
-        // Record the range *before* mapping it, so a failure halfway through
-        // still tells the caller what to tear down.
-        ranges[segments] = Some(segment_range(&ph));
-
-        load_segment(image, &ph)?;
+        // A failure part-way through leaves a half-populated address space, and
+        // that is fine now: the caller frees the whole thing. Before per-process
+        // page tables the loader had to hand back a list of ranges so somebody
+        // could unmap exactly what it had mapped.
+        load_segment(pml4_phys, image, &ph)?;
 
         segments += 1;
         bytes_mapped += ph.memsz as usize;
@@ -199,43 +163,7 @@ pub unsafe fn load(image: &[u8]) -> Result<LoadedImage, ElfError> {
         entry: header.entry,
         segments,
         bytes_mapped,
-        ranges,
     })
-}
-
-/// Lowest and highest virtual address this image *would* occupy, without
-/// mapping anything.
-///
-/// Needed because there is one address space: the only moment at which a
-/// conflicting load can be refused cheaply is before the first page of it has
-/// been mapped. Afterwards the choice is between a half-loaded program and an
-/// unwind path.
-pub fn extent_of(image: &[u8]) -> Result<(u64, u64), ElfError> {
-    let header = parse_header(image)?;
-
-    let mut lo = u64::MAX;
-    let mut hi = 0u64;
-
-    for i in 0..header.phnum as usize {
-        let offset = header.phoff as usize + i * header.phentsize as usize;
-        if offset + core::mem::size_of::<Elf64ProgramHeader>() > image.len() {
-            return Err(ElfError::TooSmall);
-        }
-        let ph: Elf64ProgramHeader =
-            unsafe { core::ptr::read_unaligned(image.as_ptr().add(offset) as *const _) };
-        if ph.p_type != PT_LOAD || ph.memsz == 0 {
-            continue;
-        }
-        let range = segment_range(&ph);
-        lo = lo.min(range.start);
-        hi = hi.max(range.start + (range.pages * PAGE_SIZE) as u64);
-    }
-
-    if lo == u64::MAX {
-        return Err(ElfError::NoLoadableSegments);
-    }
-
-    Ok((lo, hi))
 }
 
 /// Page range a segment occupies, rounded out to page boundaries.
@@ -281,7 +209,11 @@ fn parse_header(image: &[u8]) -> Result<Elf64Header, ElfError> {
 /// created. That keeps the final page permissions honest — a read-only or
 /// non-writable segment never has to be temporarily writable just so the loader
 /// can fill it in.
-unsafe fn load_segment(image: &[u8], ph: &Elf64ProgramHeader) -> Result<(), ElfError> {
+unsafe fn load_segment(
+    pml4_phys: u64,
+    image: &[u8],
+    ph: &Elf64ProgramHeader,
+) -> Result<(), ElfError> {
     if ph.vaddr >= USER_ADDRESS_LIMIT || ph.vaddr.saturating_add(ph.memsz) >= USER_ADDRESS_LIMIT {
         return Err(ElfError::SegmentInKernelSpace);
     }
@@ -310,15 +242,18 @@ unsafe fn load_segment(image: &[u8], ph: &Elf64ProgramHeader) -> Result<(), ElfE
         pages
     );
 
-    // Allocate and map the whole span with its final permissions.
-    paging::map_user_pages(start, pages, flags).map_err(ElfError::MappingFailed)?;
+    // Allocate and map the whole span with its final permissions, in the target
+    // address space rather than the one this code happens to be running in.
+    paging::map_user_pages_in(paging::mapper_for(pml4_phys), start, pages, flags)
+        .map_err(ElfError::MappingFailed)?;
 
     // Fill it in through the physmap. `map_user_pages` already zeroed every
     // frame, which is what makes the .bss tail correct without extra work: we
     // only have to write the `p_filesz` bytes that come from the file.
     for i in 0..ph.filesz as usize {
         let vaddr = ph.vaddr + i as u64;
-        let phys = paging::translate(vaddr).ok_or(ElfError::MappingFailed("segment unmapped"))?;
+        let phys = paging::translate_in(pml4_phys, vaddr)
+            .ok_or(ElfError::MappingFailed("segment unmapped"))?;
         core::ptr::write_volatile(
             (PHYSMAP_BASE + phys) as *mut u8,
             image[ph.offset as usize + i],

--- a/kernel/src/memory/address_space.rs
+++ b/kernel/src/memory/address_space.rs
@@ -1,0 +1,340 @@
+//! Per-process address spaces.
+//!
+//! ## What this replaces
+//!
+//! Every program the kernel has ever loaded shared one set of page tables. They
+//! were protected from each other by page permissions — `USER_ACCESSIBLE`, NX,
+//! read-only text — but not by *separation*: `ksh` could not read `hello`'s
+//! memory, yet both had to be linked at different fixed addresses so their
+//! images would not land on top of each other, and `spawn` had to refuse an
+//! image overlapping one already resident. Every userspace program carrying a
+//! hand-picked link address in its own `user.ld` was the visible symptom.
+//!
+//! An address space here is a PML4 of its own. The lower half — entries 0..256,
+//! the whole of userspace — belongs to it alone. The upper half is the kernel's
+//! and is shared, which is only possible because the kernel moved out of
+//! PML4[0] in the previous phase.
+//!
+//! ## Sharing the upper half
+//!
+//! [`AddressSpace::new_user`] copies PML4 entries 256..512 from the kernel's
+//! table. It copies the *entries*, not the tables they point at, so every
+//! address space walks the same PDPTs for the physmap, the heap and the kernel
+//! image. A page mapped into the kernel heap after a process was created is
+//! therefore visible to it — which is what makes it safe for a syscall to
+//! allocate.
+//!
+//! The one thing that would break that is the kernel populating a *new* PML4
+//! entry after processes exist, because the copy already happened. Nothing does:
+//! the physmap, the heap window and the kernel image are one entry each and are
+//! all created by `paging::init`. [`check_kernel_half`] asserts it rather than
+//! trusting it.
+//!
+//! ## Which frames belong to a space
+//!
+//! Teardown must free the frames a process was given without freeing frames it
+//! merely borrowed — the built-in ring-3 payload lives in the kernel image and
+//! is mapped into user space directly. Leaf entries created by
+//! `map_user_pages_in` carry [`OWNED_BY_ADDRESS_SPACE`]; those from
+//! `map_user_range_in` do not. Teardown frees exactly the tagged ones, plus the
+//! page tables it walked.
+
+use x86_64::registers::control::{Cr3, Cr3Flags};
+use x86_64::structures::paging::{PageTable, PageTableFlags, PhysFrame, Size4KiB};
+use x86_64::PhysAddr;
+
+use crate::memory::paging::{
+    kernel_pml4_phys, mapper_for, KERNEL_PML4_FIRST, OWNED_BY_ADDRESS_SPACE, PHYSMAP_BASE,
+};
+use crate::memory::physical::{allocate_frame, deallocate_frame, PageFrame};
+use crate::serial_println;
+
+/// A process's page tables.
+///
+/// Deliberately not `Clone`: two handles to one PML4 would mean two teardowns.
+#[derive(Debug)]
+pub struct AddressSpace {
+    pml4_phys: u64,
+}
+
+impl AddressSpace {
+    /// A fresh address space: empty lower half, the kernel's upper half.
+    pub fn new_user() -> Result<Self, &'static str> {
+        let frame = allocate_frame().ok_or("out of memory allocating a PML4")?;
+        let pml4_phys = frame.address() as u64;
+
+        let kernel_pml4 = kernel_pml4_phys();
+        if kernel_pml4 == 0 {
+            return Err("paging::init has not run");
+        }
+
+        unsafe {
+            let table = &mut *((PHYSMAP_BASE + pml4_phys) as *mut PageTable);
+            table.zero();
+
+            let kernel = &*((PHYSMAP_BASE + kernel_pml4) as *const PageTable);
+            for i in KERNEL_PML4_FIRST..512 {
+                table[i] = kernel[i].clone();
+            }
+        }
+
+        Ok(Self { pml4_phys })
+    }
+
+    pub fn pml4_phys(&self) -> u64 {
+        self.pml4_phys
+    }
+
+    /// Load this space into CR3.
+    ///
+    /// # Safety
+    /// Every address the caller is currently using — RIP, RSP, the GDT, the IDT,
+    /// the per-CPU block — must be mapped identically in the new space. That
+    /// holds for anything in the kernel's higher half, which is where all of
+    /// those live, and is why this is safe to call from the scheduler.
+    pub unsafe fn activate(&self) {
+        Cr3::write(
+            PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(self.pml4_phys)),
+            Cr3Flags::empty(),
+        );
+    }
+
+    /// Free the lower half and the PML4 itself.
+    ///
+    /// # Safety
+    /// This space must not be in CR3. The exiting thread switches back to the
+    /// kernel's tables before calling this, because freeing the page tables you
+    /// are executing on is only funny once.
+    pub unsafe fn free(self) -> usize {
+        let mut freed = 0;
+        let table = &mut *((PHYSMAP_BASE + self.pml4_phys) as *mut PageTable);
+
+        for i in 0..KERNEL_PML4_FIRST {
+            if table[i].is_unused() {
+                continue;
+            }
+            freed += free_level(table[i].addr().as_u64(), 3);
+            table[i].set_unused();
+        }
+
+        deallocate_frame(PageFrame::from_address(self.pml4_phys as usize));
+        freed + 1
+    }
+}
+
+/// Recursively free one level of page tables and everything under it.
+///
+/// `level` counts down: 3 = PDPT, 2 = PD, 1 = PT. A huge-page entry at level 3
+/// or 2 is a leaf; the kernel never creates one in the lower half, but checking
+/// costs nothing and misreading one as a table pointer would free 512 frames of
+/// somebody else's memory.
+unsafe fn free_level(table_phys: u64, level: u8) -> usize {
+    let mut freed = 0;
+    let table = &mut *((PHYSMAP_BASE + table_phys) as *mut PageTable);
+
+    for i in 0..512 {
+        let entry = &mut table[i];
+        if entry.is_unused() {
+            continue;
+        }
+
+        let flags = entry.flags();
+        let addr = entry.addr().as_u64();
+
+        if level == 1 || flags.contains(PageTableFlags::HUGE_PAGE) {
+            // A leaf. Free the frame only if this space owns it — the built-in
+            // ring-3 payload is mapped straight out of the kernel image.
+            if flags.contains(OWNED_BY_ADDRESS_SPACE) {
+                deallocate_frame(PageFrame::from_address(addr as usize));
+                freed += 1;
+            }
+        } else {
+            freed += free_level(addr, level - 1);
+        }
+
+        entry.set_unused();
+    }
+
+    // The table itself.
+    deallocate_frame(PageFrame::from_address(table_phys as usize));
+    freed + 1
+}
+
+/// Check that every address space still agrees with the kernel about the upper
+/// half.
+///
+/// `new_user` copies PML4 entries 256..512 once, at creation. If the kernel ever
+/// populated a *new* top-level entry afterwards, existing processes would not
+/// see it and a syscall running in one of them would fault on a perfectly valid
+/// kernel address — intermittently, depending on which process was running.
+///
+/// Nothing creates one today. This says so out loud instead of assuming.
+pub fn check_kernel_half(space: &AddressSpace) -> bool {
+    let kernel_pml4 = kernel_pml4_phys();
+    unsafe {
+        let theirs = &*((PHYSMAP_BASE + space.pml4_phys()) as *const PageTable);
+        let kernel = &*((PHYSMAP_BASE + kernel_pml4) as *const PageTable);
+
+        for i in KERNEL_PML4_FIRST..512 {
+            if theirs[i].addr() != kernel[i].addr() || theirs[i].flags() != kernel[i].flags() {
+                serial_println!(
+                    "  address space diverges from the kernel at PML4[{}]: 0x{:x} vs 0x{:x}",
+                    i,
+                    theirs[i].addr().as_u64(),
+                    kernel[i].addr().as_u64()
+                );
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// How many PML4 entries the kernel occupies. Diagnostics.
+pub fn kernel_half_entries() -> usize {
+    let kernel_pml4 = kernel_pml4_phys();
+    if kernel_pml4 == 0 {
+        return 0;
+    }
+    unsafe {
+        let kernel = &*((PHYSMAP_BASE + kernel_pml4) as *const PageTable);
+        (KERNEL_PML4_FIRST..512).filter(|&i| !kernel[i].is_unused()).count()
+    }
+}
+
+/// Prove that two address spaces really are separate.
+///
+/// Maps one page at the *same user virtual address* in two different spaces,
+/// writes a different value into each through the physmap, then activates each
+/// space in turn and reads that address. Under the single shared address space
+/// this kernel had until now, the second mapping would either fail with
+/// `PageAlreadyMapped` or silently replace the first, and both reads would
+/// return the same value.
+///
+/// Deliberately not a test of "can a process read another process's memory" —
+/// that question was already answered by page permissions. The claim being
+/// checked here is narrower and newer: the same number means different memory
+/// depending on which PML4 is loaded.
+pub fn self_test() {
+    use crate::memory::paging::{map_user_pages_in, translate_in};
+    use crate::memory::PAGE_SIZE;
+
+    // Somewhere in the lower half nothing else uses.
+    const PROBE: u64 = 0x0000_0000_1000_0000;
+    const VALUE_A: u64 = 0xAAAA_AAAA_AAAA_AAAA;
+    const VALUE_B: u64 = 0xBBBB_BBBB_BBBB_BBBB;
+
+    serial_println!("Verifying address-space isolation...");
+
+    let flags = PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE;
+
+    let (a, b) = match (AddressSpace::new_user(), AddressSpace::new_user()) {
+        (Ok(a), Ok(b)) => (a, b),
+        _ => {
+            serial_println!("  Address spaces: FAIL — could not allocate two PML4s");
+            return;
+        }
+    };
+
+    let mut mapped_ok = true;
+    for pml4 in [a.pml4_phys(), b.pml4_phys()] {
+        if let Err(e) = map_user_pages_in(unsafe { mapper_for(pml4) }, PROBE, 1, flags) {
+            serial_println!("  Address spaces: FAIL — could not map the probe page: {}", e);
+            mapped_ok = false;
+        }
+    }
+    if !mapped_ok {
+        unsafe {
+            a.free();
+            b.free();
+        }
+        return;
+    }
+
+    // Distinct frames is the first thing to check: if the two spaces shared a
+    // lower half, this is where it shows.
+    let phys_a = translate_in(a.pml4_phys(), PROBE);
+    let phys_b = translate_in(b.pml4_phys(), PROBE);
+
+    match (phys_a, phys_b) {
+        (Some(pa), Some(pb)) if pa != pb => serial_println!(
+            "  0x{:x} -> frame 0x{:x} in one space, 0x{:x} in the other",
+            PROBE,
+            pa,
+            pb
+        ),
+        (Some(pa), Some(pb)) => {
+            serial_println!(
+                "  Address spaces: FAIL — 0x{:x} resolves to the same frame 0x{:x}/0x{:x}",
+                PROBE,
+                pa,
+                pb
+            );
+            unsafe {
+                a.free();
+                b.free();
+            }
+            return;
+        }
+        _ => {
+            serial_println!("  Address spaces: FAIL — the probe page did not map");
+            unsafe {
+                a.free();
+                b.free();
+            }
+            return;
+        }
+    }
+
+    // Write through the physmap, which is shared, so neither write needs the
+    // space it targets to be active.
+    unsafe {
+        core::ptr::write_volatile((PHYSMAP_BASE + phys_a.unwrap()) as *mut u64, VALUE_A);
+        core::ptr::write_volatile((PHYSMAP_BASE + phys_b.unwrap()) as *mut u64, VALUE_B);
+    }
+
+    // Now read the *same address* with each space loaded. Interrupts off: a
+    // context switch in the middle would reload CR3 from under us.
+    let (kernel_cr3, _) = Cr3::read();
+    let (seen_a, seen_b) = crate::interrupts::without_interrupts(|| unsafe {
+        a.activate();
+        let sa = core::ptr::read_volatile(PROBE as *const u64);
+        b.activate();
+        let sb = core::ptr::read_volatile(PROBE as *const u64);
+        Cr3::write(kernel_cr3, Cr3Flags::empty());
+        (sa, sb)
+    });
+
+    if seen_a == VALUE_A && seen_b == VALUE_B {
+        serial_println!(
+            "  same address 0x{:x}: 0x{:x} in one space, 0x{:x} in the other",
+            PROBE,
+            seen_a,
+            seen_b
+        );
+        serial_println!(
+            "  Address spaces: PASS — {} kernel PML4 entries shared, lower half private",
+            kernel_half_entries()
+        );
+    } else {
+        serial_println!(
+            "  Address spaces: FAIL — read 0x{:x} and 0x{:x}, expected 0x{:x} and 0x{:x}",
+            seen_a,
+            seen_b,
+            VALUE_A,
+            VALUE_B
+        );
+    }
+
+    // Both spaces should also still agree with the kernel about the upper half.
+    if !check_kernel_half(&a) || !check_kernel_half(&b) {
+        serial_println!("  Address spaces: FAIL — upper half diverged from the kernel");
+    }
+
+    let freed = unsafe { a.free() + b.free() };
+    serial_println!("  teardown returned {} frame(s), including {} probe pages", freed, 2);
+    let _ = PAGE_SIZE;
+}

--- a/kernel/src/memory/mod.rs
+++ b/kernel/src/memory/mod.rs
@@ -1,5 +1,6 @@
 pub mod physical;
 pub mod paging;
+pub mod address_space;
 pub mod vmm;
 pub mod heap;
 pub mod swap;

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -99,21 +99,6 @@ unsafe impl FrameAllocator<Size4KiB> for KoshFrameAllocator {
     }
 }
 
-/// True once `init` has switched CR3 and the physmap covers all of RAM.
-///
-/// There used to be a `phys_to_virt` here that consulted this and returned
-/// either the physical address unchanged (identity map) or `PHYSMAP_BASE + phys`.
-/// It had no callers, and the higher-half migration is what made it a trap
-/// rather than a convenience: "the kernel-virtual address of this frame" now has
-/// two right answers depending on *when* you ask, and hiding that behind one
-/// function invites using the wrong one. Call [`kernel_virt`] before `init` and
-/// add [`PHYSMAP_BASE`] after it, deliberately.
-static PHYSMAP_ACTIVE: Mutex<bool> = Mutex::new(false);
-
-/// Whether the physmap covers all of physical memory yet.
-pub fn physmap_active() -> bool {
-    *PHYSMAP_ACTIVE.lock()
-}
 
 /// How much physical memory `init` actually mapped into the kernel window.
 ///
@@ -125,6 +110,47 @@ static KERNEL_WINDOW_END: Mutex<u64> = Mutex::new(0);
 pub fn kernel_window_end() -> u64 {
     *KERNEL_WINDOW_END.lock()
 }
+
+/// The PML4 `init` built. Every user address space starts as a copy of its
+/// higher half.
+static KERNEL_PML4: Mutex<u64> = Mutex::new(0);
+
+pub fn kernel_pml4_phys() -> u64 {
+    *KERNEL_PML4.lock()
+}
+
+/// First PML4 index belonging to the kernel.
+///
+/// Entries 0..256 are the lower canonical half and belong entirely to whichever
+/// process is running; 256..512 are the kernel's and are shared by every address
+/// space. The split is the whole reason the higher-half migration happened.
+pub const KERNEL_PML4_FIRST: usize = 256;
+
+/// Borrow an arbitrary PML4 as a mapper, whatever CR3 currently holds.
+///
+/// This is what lets one process load a program into *another* process's
+/// address space — `sys_spawn` runs in the parent and has to populate the
+/// child. It works because the physmap is in the shared higher half, so every
+/// address space can reach every physical frame, including another space's
+/// page tables.
+///
+/// # Safety
+/// `pml4_phys` must be a live PML4, and the caller must not hold two aliasing
+/// mappers over it.
+pub unsafe fn mapper_for(pml4_phys: u64) -> OffsetPageTable<'static> {
+    let table: &'static mut PageTable = &mut *((PHYSMAP_BASE + pml4_phys) as *mut PageTable);
+    OffsetPageTable::new(table, VirtAddr::new(PHYSMAP_BASE))
+}
+
+/// Marks a leaf mapping whose frame belongs to the address space and must be
+/// freed when it is torn down.
+///
+/// `map_user_pages` allocates fresh frames and sets this; `map_user_range` maps
+/// frames it does not own — the `.user` blob lives inside the kernel image — and
+/// does not. Without the distinction, tearing down an address space that had run
+/// the built-in payload would hand the kernel's own text back to the frame
+/// allocator.
+pub const OWNED_BY_ADDRESS_SPACE: PageTableFlags = PageTableFlags::BIT_9;
 
 /// Build the kernel's own page tables and install them.
 ///
@@ -187,8 +213,8 @@ pub fn init(phys_mem_end: u64) -> Result<(), &'static str> {
         );
     }
 
-    *PHYSMAP_ACTIVE.lock() = true;
     *KERNEL_WINDOW_END.lock() = window_end;
+    *KERNEL_PML4.lock() = pml4_phys;
 
     serial_println!("  CR3 -> 0x{:x} (kernel page tables active)", pml4_phys);
     serial_println!(
@@ -422,7 +448,18 @@ pub fn map_user_range(
     pages: usize,
     flags: PageTableFlags,
 ) -> Result<(), &'static str> {
-    let mut mapper = unsafe { active_mapper() };
+    map_user_range_in(unsafe { active_mapper() }, virt, phys, pages, flags)
+}
+
+/// As [`map_user_range`], but into a named address space rather than the live
+/// one. The frames are borrowed, not owned — see [`OWNED_BY_ADDRESS_SPACE`].
+pub fn map_user_range_in(
+    mut mapper: OffsetPageTable<'static>,
+    virt: u64,
+    phys: u64,
+    pages: usize,
+    flags: PageTableFlags,
+) -> Result<(), &'static str> {
     let mut frames = KoshFrameAllocator;
 
     let table_flags =
@@ -451,8 +488,21 @@ pub fn map_user_pages(
     pages: usize,
     flags: PageTableFlags,
 ) -> Result<(), &'static str> {
-    let mut mapper = unsafe { active_mapper() };
+    map_user_pages_in(unsafe { active_mapper() }, virt, pages, flags)
+}
+
+/// As [`map_user_pages`], but into a named address space.
+///
+/// The frames are freshly allocated, so the leaf entries are tagged
+/// [`OWNED_BY_ADDRESS_SPACE`] and tearing the space down returns them.
+pub fn map_user_pages_in(
+    mut mapper: OffsetPageTable<'static>,
+    virt: u64,
+    pages: usize,
+    flags: PageTableFlags,
+) -> Result<(), &'static str> {
     let mut frames = KoshFrameAllocator;
+    let flags = flags | OWNED_BY_ADDRESS_SPACE;
 
     let table_flags =
         PageTableFlags::PRESENT | PageTableFlags::WRITABLE | PageTableFlags::USER_ACCESSIBLE;
@@ -487,23 +537,24 @@ pub fn map_user_pages(
     Ok(())
 }
 
-/// Unmap `pages` user pages at `virt` and return their frames to the allocator.
+/// Unmap `pages` user pages in a named address space and free their frames.
 ///
-/// The counterpart to [`map_user_pages`], and the reason a program can be run
-/// twice. Without it, the second `spawn` of the same binary failed in
-/// `map_to_with_table_flags` with `PageAlreadyMapped` — after the loader had
-/// already allocated a frame for that page, so each attempt also leaked one.
+/// Kept as the surgical counterpart to [`map_user_pages_in`]. Whole-process
+/// teardown does not come through here any more — `AddressSpace::free` walks the
+/// lower half and frees everything tagged [`OWNED_BY_ADDRESS_SPACE`], which is
+/// both cheaper and, unlike a recorded list of ranges, cannot go out of date.
 ///
 /// Returns how many pages were actually unmapped; a page that was not mapped is
-/// skipped rather than treated as an error, so tearing down a partially-loaded
-/// image is safe.
+/// skipped rather than treated as an error.
 ///
 /// # Safety
-/// Nothing may still be using these addresses. In particular the caller must not
-/// be running *on* them — which is why teardown happens from the reaping thread,
-/// not from the exiting one.
-pub unsafe fn unmap_user_pages(virt: u64, pages: usize) -> usize {
-    let mut mapper = active_mapper();
+/// Nothing may still be using these addresses.
+#[allow(dead_code)]
+pub unsafe fn unmap_user_pages_in(
+    mut mapper: OffsetPageTable<'static>,
+    virt: u64,
+    pages: usize,
+) -> usize {
     let mut freed = 0;
 
     for i in 0..pages {
@@ -518,9 +569,7 @@ pub unsafe fn unmap_user_pages(virt: u64, pages: usize) -> usize {
                 ));
                 freed += 1;
             }
-            Err(_) => {
-                // Already absent. Nothing to free, nothing to complain about.
-            }
+            Err(_) => {}
         }
     }
 
@@ -543,6 +592,17 @@ pub unsafe fn active_mapper() -> OffsetPageTable<'static> {
 pub fn translate(virt: u64) -> Option<u64> {
     use x86_64::structures::paging::Translate;
     let mapper = unsafe { active_mapper() };
+    mapper.translate_addr(VirtAddr::new(virt)).map(|p| p.as_u64())
+}
+
+/// Translate an address in a *named* address space rather than the live one.
+///
+/// The ELF loader needs this: it runs in the parent's address space and writes
+/// segment bytes into the child's, so "which frame is this vaddr" has to be
+/// asked of the child's tables.
+pub fn translate_in(pml4_phys: u64, virt: u64) -> Option<u64> {
+    use x86_64::structures::paging::Translate;
+    let mapper = unsafe { mapper_for(pml4_phys) };
     mapper.translate_addr(VirtAddr::new(virt)).map(|p| p.as_u64())
 }
 

--- a/kernel/src/syscall/dispatcher.rs
+++ b/kernel/src/syscall/dispatcher.rs
@@ -246,10 +246,11 @@ fn sys_exec(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
 
 /// `spawn(path, path_len)` -> task id
 ///
-/// Deliberately not called `exec`: `exec` replaces the calling image, and
-/// `fork`+`exec` needs two address spaces. This loads a *second* program into
-/// the one address space that exists and runs it on its own thread — which is
-/// enough for a shell to launch a program, and honest about what it is.
+/// Still not called `exec` — `exec` replaces the *calling* image, and nothing
+/// here does that. But it is no longer "a second program in the one address
+/// space that exists": the child gets a PML4 of its own, so it can be linked at
+/// the same address as its parent, and the overlap check that used to refuse
+/// `ksh` spawning `ksh` is gone along with the reason for it.
 ///
 /// `path` names a boot module (`module2 /boot/hello hello` in grub.cfg), not a
 /// file on the FAT32 volume. Loading from disk needs the loader to read through
@@ -268,9 +269,12 @@ fn sys_spawn(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
         // A shell turns this one into "command not found", so it must not be
         // lumped in with the others.
         Err(SpawnError::NotFound) => Err(SyscallError::NotFound),
-        Err(SpawnError::AddressConflict) => Err(SyscallError::AddressInUse),
         Err(SpawnError::TooManyPrograms) | Err(SpawnError::NoThread(_)) => {
             Err(SyscallError::ResourceExhausted)
+        }
+        Err(SpawnError::Space(e)) => {
+            serial_println!("  spawn could not build an address space: {}", e);
+            Err(SyscallError::OutOfMemory)
         }
         Err(SpawnError::Map(e)) => {
             serial_println!("  spawn mapping failed: {}", e);

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -34,6 +34,7 @@ use core::sync::atomic::{AtomicBool, Ordering};
 use spin::Mutex;
 
 use crate::interrupts::without_interrupts;
+use crate::memory::address_space::AddressSpace;
 use crate::serial_println;
 use switch::kosh_switch_context;
 
@@ -86,6 +87,13 @@ pub struct Thread {
     entry: Option<(fn(usize), usize)>,
     /// Ticks this thread has been scheduled for — a cheap fairness check.
     ticks: u64,
+    /// This thread's page tables, if it has its own.
+    ///
+    /// `None` means "the kernel's" — every kernel thread, and thread 0. Only a
+    /// thread running a loaded program owns one, and it owns it exclusively:
+    /// `AddressSpace` is deliberately not `Clone`, so there is no way to end up
+    /// with two threads freeing the same PML4.
+    address_space: Option<AddressSpace>,
     /// Set by `sys_exit` before the thread retires, collected by `wait_for`.
     exit_code: i32,
     /// Another thread is in `wait_for` on this one, so `reap_finished` must
@@ -187,6 +195,7 @@ pub fn init() {
             state: State::Running,
             entry: None,
             ticks: 0,
+            address_space: None,
             exit_code: 0,
             awaited: false,
         });
@@ -225,6 +234,7 @@ pub fn spawn(name: &'static str, entry: fn(usize), arg: usize) -> Result<usize, 
             state: State::Ready,
             entry: Some((entry, arg)),
             ticks: 0,
+            address_space: None,
             exit_code: 0,
             awaited: false,
         });
@@ -310,21 +320,54 @@ pub fn schedule() {
 
                     let next_rsp = sched.threads[next].as_ref().unwrap().rsp;
                     let next_top = sched.threads[next].as_ref().unwrap().kernel_stack_top;
+                    // The PML4 the incoming thread needs. `None` means the
+                    // kernel's, which is also what CR3 holds while a plain
+                    // kernel thread runs.
+                    let next_cr3 = sched.threads[next]
+                        .as_ref()
+                        .unwrap()
+                        .address_space
+                        .as_ref()
+                        .map(|a| a.pml4_phys())
+                        .unwrap_or_else(crate::memory::paging::kernel_pml4_phys);
                     let prev_rsp = sched.threads[current].as_mut().unwrap().rsp_ptr();
 
-                    Some((prev_rsp, next_rsp, next, next_top))
+                    Some((prev_rsp, next_rsp, next, next_top, next_cr3))
                 }
             }
         }
         // lock dropped here, before the switch
     };
 
-    if let Some((prev_rsp, next_rsp, next, next_top)) = plan {
+    if let Some((prev_rsp, next_rsp, next, next_top, next_cr3)) = plan {
         // Before the switch, not after: the incoming thread may resume straight
         // into `sysretq` and be in ring 3 — able to fault or syscall — before
         // any instruction after `kosh_switch_context` in *this* frame runs.
         // Interrupts are off, so publishing early is not visible to anyone else.
         publish_kernel_stack(next as u64, next_top);
+
+        // Switch page tables if the incoming thread lives somewhere else.
+        //
+        // Safe to do here, mid-scheduler, only because everything this code
+        // touches from now until the incoming thread is running — RIP, RSP, the
+        // scheduler's statics, the GDT, the IDT, the per-CPU block — is in the
+        // kernel's higher half, which every address space shares. That was not
+        // true before the kernel moved out of PML4[0], and is the reason this
+        // could not be written until now.
+        //
+        // Compared rather than written unconditionally: reloading CR3 flushes
+        // the TLB, and most switches here are between kernel threads.
+        let (current_cr3, _) = x86_64::registers::control::Cr3::read();
+        if current_cr3.start_address().as_u64() != next_cr3 {
+            unsafe {
+                x86_64::registers::control::Cr3::write(
+                    x86_64::structures::paging::PhysFrame::containing_address(
+                        x86_64::PhysAddr::new(next_cr3),
+                    ),
+                    x86_64::registers::control::Cr3Flags::empty(),
+                );
+            }
+        }
 
         unsafe { kosh_switch_context(prev_rsp, next_rsp) };
     }
@@ -403,6 +446,33 @@ pub fn current_id() -> usize {
     without_interrupts(|| SCHEDULER.lock().current)
 }
 
+/// Give the running thread its own page tables.
+///
+/// Called once, by the thread itself, before it drops to ring 3. Doing it from
+/// the thread rather than from whoever spawned it means there is no window in
+/// which the scheduler could pick a thread whose `address_space` field has not
+/// been filled in yet.
+pub fn adopt_address_space(space: AddressSpace) {
+    without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+        let current = sched.current;
+        if let Some(t) = sched.threads[current].as_mut() {
+            t.address_space = Some(space);
+        }
+    });
+
+    // The thread is already running; the scheduler will not switch CR3 for it
+    // until the next time it is picked, so do it now.
+    without_interrupts(|| {
+        let sched = SCHEDULER.lock();
+        let current = sched.current;
+        if let Some(space) = sched.threads[current].as_ref().and_then(|t| t.address_space.as_ref())
+        {
+            unsafe { space.activate() };
+        }
+    });
+}
+
 /// Retire the running thread and never come back.
 pub fn exit_current() -> ! {
     // Release this thread's address-space reservations before it becomes
@@ -410,6 +480,34 @@ pub fn exit_current() -> ! {
     // table keyed on thread ids is about to stop having an entry for it.
     let id = current_id();
     crate::usermode::on_thread_exit(id);
+
+    // Hand this thread's page tables back.
+    //
+    // Order matters and is not negotiable: return CR3 to the kernel's tables
+    // *first*, then free. Freeing a PML4 that is still in CR3 hands the frame
+    // holding the live top-level table to the allocator, and the next allocation
+    // overwrites the address space out from under the CPU walking it.
+    //
+    // Safe to switch here because this runs on the thread's kernel stack, which
+    // is in the higher half every address space shares.
+    let space = without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+        let current = sched.current;
+        sched.threads[current].as_mut().and_then(|t| t.address_space.take())
+    });
+
+    if let Some(space) = space {
+        unsafe {
+            x86_64::registers::control::Cr3::write(
+                x86_64::structures::paging::PhysFrame::containing_address(
+                    x86_64::PhysAddr::new(crate::memory::paging::kernel_pml4_phys()),
+                ),
+                x86_64::registers::control::Cr3Flags::empty(),
+            );
+            let freed = space.free();
+            serial_println!("  address space of thread {} released: {} frame(s)", id, freed);
+        }
+    }
 
     without_interrupts(|| {
         let mut sched = SCHEDULER.lock();

--- a/kernel/src/usermode.rs
+++ b/kernel/src/usermode.rs
@@ -24,6 +24,7 @@
 use spin::Mutex;
 use x86_64::structures::paging::PageTableFlags;
 
+use crate::memory::address_space::AddressSpace;
 use crate::memory::paging::{self, PHYSMAP_BASE};
 use crate::memory::PAGE_SIZE;
 use crate::serial_println;
@@ -128,8 +129,8 @@ pub fn boot_module_named(name: &str) -> Option<BootModule> {
 /// round number that keeps the payload clear of the loaded ELFs at 4 and 8 MiB.
 pub const USER_CODE_BASE: u64 = 0x0000_0000_4000_0000;
 
-/// Top of the user stack, growing down.
-pub const USER_STACK_TOP: u64 = 0x0000_0000_5000_0000;
+/// Top of the built-in payload's stack, growing down.
+const BLOB_STACK_TOP: u64 = 0x0000_0000_5000_0000;
 
 /// Pages of user stack.
 const USER_STACK_PAGES: usize = 4;
@@ -150,9 +151,6 @@ pub enum Demo {
     /// Dereference a kernel address directly — must be killed, not survived.
     Fault,
 }
-
-static CODE_MAPPED: core::sync::atomic::AtomicBool =
-    core::sync::atomic::AtomicBool::new(false);
 
 fn sym(s: &u8) -> u64 {
     s as *const u8 as u64
@@ -175,8 +173,6 @@ fn user_blob_phys() -> u64 {
 /// `task::exit_current()` and hand control back to the rest of the kernel —
 /// no unwinding required.
 pub fn run_user_demo(which: usize) {
-    use core::sync::atomic::Ordering;
-
     let demo = if which == 0 { Demo::Syscalls } else { Demo::Fault };
 
     let blob_start = sym(unsafe { &__user_start });
@@ -193,44 +189,70 @@ pub fn run_user_demo(which: usize) {
 
     serial_println!("Preparing ring 3 ({:?}):", demo);
 
-    // Read + execute for the user, and NOT writable — W^X applies to userspace
-    // too.
-    let code_flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
-    if !CODE_MAPPED.swap(true, Ordering::SeqCst) {
-        serial_println!(
-            "  .user section  : 0x{:x}..0x{:x} ({} page(s), phys 0x{:x})",
-            blob_start,
-            blob_end,
-            blob_pages,
-            user_blob_phys()
-        );
-        if let Err(e) =
-            paging::map_user_range(USER_CODE_BASE, user_blob_phys(), blob_pages, code_flags)
-        {
-            serial_println!("  failed to map user code: {}", e);
+    // Its own address space, like every other ring-3 program. This demo used to
+    // map the payload into the *kernel's* PML4[0] and leave it there, which
+    // quietly contradicted the previous phase's claim that PML4[0] belongs to
+    // userspace — and meant the two demos shared a lower half and had to be
+    // given stacks a megabyte apart.
+    let space = match AddressSpace::new_user() {
+        Ok(s) => s,
+        Err(e) => {
+            serial_println!("  no address space for the payload: {}", e);
             return;
         }
-        serial_println!("  code mapped at : 0x{:x} (R-X, user)", USER_CODE_BASE);
+    };
+
+    // Read + execute for the user, and NOT writable — W^X applies to userspace
+    // too. These frames are borrowed from the kernel image, so they are mapped
+    // with `map_user_range_in`, which does not tag them as owned; freeing this
+    // space must not hand the kernel's own `.user` section to the allocator.
+    let code_flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+    serial_println!(
+        "  .user section  : 0x{:x}..0x{:x} ({} page(s), phys 0x{:x})",
+        blob_start,
+        blob_end,
+        blob_pages,
+        user_blob_phys()
+    );
+    if let Err(e) = paging::map_user_range_in(
+        unsafe { paging::mapper_for(space.pml4_phys()) },
+        USER_CODE_BASE,
+        user_blob_phys(),
+        blob_pages,
+        code_flags,
+    ) {
+        serial_println!("  failed to map user code: {}", e);
+        unsafe { space.free() };
+        return;
     }
+    serial_println!("  code mapped at : 0x{:x} (R-X, user)", USER_CODE_BASE);
     serial_println!("  entry          : 0x{:x}", user_entry);
 
-    // Each run gets its own stack region so the second demo cannot observe the
-    // first one's leftovers.
-    let stack_top = USER_STACK_TOP - (which as u64 * 0x10_0000);
+    // Both demos use the same stack address now; they are in different spaces.
+    let stack_top = BLOB_STACK_TOP;
     let stack_bottom = stack_top - (USER_STACK_PAGES * PAGE_SIZE) as u64;
     let stack_flags = PageTableFlags::PRESENT
         | PageTableFlags::WRITABLE
         | PageTableFlags::USER_ACCESSIBLE
         | PageTableFlags::NO_EXECUTE;
-    if let Err(e) = paging::map_user_pages(stack_bottom, USER_STACK_PAGES, stack_flags) {
+    if let Err(e) = paging::map_user_pages_in(
+        unsafe { paging::mapper_for(space.pml4_phys()) },
+        stack_bottom,
+        USER_STACK_PAGES,
+        stack_flags,
+    ) {
         serial_println!("  failed to map user stack: {}", e);
+        unsafe { space.free() };
         return;
     }
     serial_println!(
-        "  stack          : 0x{:x}..0x{:x} (RW-, user, NX)",
+        "  stack          : 0x{:x}..0x{:x} (RW-, user, NX), PML4 0x{:x}",
         stack_bottom,
-        stack_top
+        stack_top,
+        space.pml4_phys()
     );
+
+    crate::task::adopt_address_space(space);
 
     serial_println!("Entering ring 3 via iretq...");
     serial_println!("--- ring 3 output ---");
@@ -239,49 +261,51 @@ pub fn run_user_demo(which: usize) {
 }
 
 // ---------------------------------------------------------------------------
-// Resident programs
+// Programs
 // ---------------------------------------------------------------------------
 
-/// How many loaded programs can be resident at once. Bounded by the thread
-/// table, and small because they all share one address space.
+/// How many programs can be pending or running at once. Bounded by the thread
+/// table.
 const MAX_PROGRAMS: usize = 8;
 
 /// Marker for a reservation whose thread has not claimed it yet.
 const NO_THREAD: usize = usize::MAX;
 
-/// Top of the stack region handed to spawned programs. Each slot gets 1 MiB of
-/// address space, well clear of the fixed stacks the boot demos use.
-const SPAWN_STACK_REGION_TOP: u64 = 0x0000_0000_3000_0000;
-
-/// A program currently occupying part of the address space.
+/// Top of a user program's stack.
 ///
-/// This table is what makes `spawn` safe in a single address space. Every
-/// userspace program here is linked at a fixed `p_vaddr` (`userspace/*/user.ld`),
-/// so two programs whose images overlap cannot both be resident — and `ksh`
-/// spawning `ksh` would overwrite its own `.text` while executing it. The table
-/// is also what lets a program's pages be freed when it exits, which is what
-/// makes running one twice possible.
-#[derive(Clone, Copy)]
-struct Resident {
+/// One constant, used by every program, because every program now has its own
+/// address space. Phase 10 had to hand out a distinct 1 MiB slot per spawn and
+/// keep the boot demos clear of the shell — all of that was bookkeeping around
+/// a shared lower half.
+pub const USER_STACK_TOP: u64 = 0x0000_0000_3000_0000;
+
+/// A program that has been loaded and is waiting for its thread, or is running.
+///
+/// The predecessor of this was a table of *address ranges*, used to refuse a
+/// `spawn` whose image would land on top of a resident program's, and to unmap
+/// that program's pages when it exited. Both jobs are gone: a program that has
+/// its own PML4 cannot collide with anything, and freeing its address space
+/// frees its pages. What is left is the hand-off from the spawning thread to the
+/// spawned one, plus a name for the log.
+struct Program {
     /// Thread that owns this program, or [`NO_THREAD`] until it claims it.
     thread: usize,
     name: [u8; 32],
-    lo: u64,
-    hi: u64,
     entry: u64,
     stack_top: u64,
-    ranges: [Option<crate::elf::MappedRange>; crate::elf::MAX_SEGMENTS],
-    stack: crate::elf::MappedRange,
+    /// Moved into the thread by [`enter_spawned`]. `None` afterwards.
+    space: Option<AddressSpace>,
 }
 
-impl Resident {
+impl Program {
     fn name(&self) -> &str {
         let end = self.name.iter().position(|&b| b == 0).unwrap_or(self.name.len());
         core::str::from_utf8(&self.name[..end]).unwrap_or("")
     }
 }
 
-static RESIDENT: Mutex<[Option<Resident>; MAX_PROGRAMS]> = Mutex::new([None; MAX_PROGRAMS]);
+static PROGRAMS: Mutex<[Option<Program>; MAX_PROGRAMS]> =
+    Mutex::new([const { None }; MAX_PROGRAMS]);
 
 /// Why a `spawn` could not happen.
 #[derive(Debug)]
@@ -289,92 +313,102 @@ pub enum SpawnError {
     /// No boot module by that name. This is what a shell turns into
     /// "command not found", so it must be distinguishable from the rest.
     NotFound,
-    /// The image overlaps a program that is already resident.
-    AddressConflict,
     TooManyPrograms,
     Load(crate::elf::ElfError),
     Map(&'static str),
+    Space(&'static str),
     NoThread(&'static str),
 }
 
-/// Load a boot module and run it on a new kernel thread in ring 3.
+fn name_bytes(name: &str) -> [u8; 32] {
+    let mut buf = [0u8; 32];
+    let bytes = name.as_bytes();
+    let take = core::cmp::min(bytes.len(), buf.len() - 1);
+    buf[..take].copy_from_slice(&bytes[..take]);
+    buf
+}
+
+/// Build a fresh address space with `image` loaded into it and a stack mapped.
 ///
-/// Returns the thread id, which is what `wait` takes.
-///
-/// The ELF is loaded here, in the *caller's* thread, rather than in the new one.
-/// That is deliberate: a load failure is then a synchronous error the caller can
-/// act on, instead of a thread that starts and immediately dies with the reason
-/// only in the kernel log.
+/// The caller does not have to be running in the resulting space — the ELF
+/// loader writes through the physmap, which every address space shares. That is
+/// what lets `spawn_program` do this work in the *parent*, so a load failure is
+/// a synchronous error the shell can report rather than a thread that starts and
+/// immediately dies with the reason only in the kernel log.
+fn prepare_program(image: &[u8]) -> Result<(AddressSpace, u64), SpawnError> {
+    let space = AddressSpace::new_user().map_err(SpawnError::Space)?;
+
+    let loaded = match unsafe { crate::elf::load_into(space.pml4_phys(), image) } {
+        Ok(l) => l,
+        Err(e) => {
+            unsafe { space.free() };
+            return Err(SpawnError::Load(e));
+        }
+    };
+
+    let stack_bottom = USER_STACK_TOP - (USER_STACK_PAGES_MAX * PAGE_SIZE) as u64;
+    let stack_flags = PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE
+        | PageTableFlags::NO_EXECUTE;
+
+    let mapped = paging::map_user_pages_in(
+        unsafe { paging::mapper_for(space.pml4_phys()) },
+        stack_bottom,
+        USER_STACK_PAGES_MAX,
+        stack_flags,
+    );
+
+    if let Err(e) = mapped {
+        unsafe { space.free() };
+        return Err(SpawnError::Map(e));
+    }
+
+    serial_println!(
+        "  loaded {} segment(s), {} bytes, entry 0x{:x}, stack 0x{:x}..0x{:x}",
+        loaded.segments,
+        loaded.bytes_mapped,
+        loaded.entry,
+        stack_bottom,
+        USER_STACK_TOP
+    );
+
+    Ok((space, loaded.entry))
+}
+
+/// Stack pages every program gets. Generous because `ksh` has a
+/// recursive-descent parser and formats strings on the stack.
+const USER_STACK_PAGES_MAX: usize = 16;
+
+/// Load a boot module and run it in ring 3 on a new thread with its own address
+/// space. Returns the thread id, which is what `wait` takes.
 pub fn spawn_program(name: &str) -> Result<usize, SpawnError> {
     let module = boot_module_named(name).ok_or(SpawnError::NotFound)?;
     let image = unsafe { module.bytes() };
 
-    let (lo, hi) = crate::elf::extent_of(image).map_err(SpawnError::Load)?;
+    serial_println!("Loading '{}' into a new address space:", name);
+    let (space, entry) = prepare_program(image)?;
 
-    // Reserve a slot and check for conflicts under one lock, so two concurrent
-    // spawns cannot both pass the check and then both load.
     let slot = {
-        let mut table = RESIDENT.lock();
+        let mut table = PROGRAMS.lock();
+        let Some(slot) = table.iter().position(|s| s.is_none()) else {
+            unsafe { space.free() };
+            return Err(SpawnError::TooManyPrograms);
+        };
 
-        for existing in table.iter().flatten() {
-            if lo < existing.hi && existing.lo < hi {
-                serial_println!(
-                    "spawn '{}' refused: 0x{:x}..0x{:x} overlaps resident '{}' at 0x{:x}..0x{:x}",
-                    name,
-                    lo,
-                    hi,
-                    existing.name(),
-                    existing.lo,
-                    existing.hi
-                );
-                return Err(SpawnError::AddressConflict);
-            }
-        }
-
-        let slot = table
-            .iter()
-            .position(|s| s.is_none())
-            .ok_or(SpawnError::TooManyPrograms)?;
-
-        let mut name_buf = [0u8; 32];
-        let bytes = name.as_bytes();
-        let take = core::cmp::min(bytes.len(), name_buf.len() - 1);
-        name_buf[..take].copy_from_slice(&bytes[..take]);
-
-        // Placeholder, so the range is claimed against other spawns while this
-        // one loads. Filled in properly below.
-        table[slot] = Some(Resident {
+        table[slot] = Some(Program {
             thread: NO_THREAD,
-            name: name_buf,
-            lo,
-            hi,
-            entry: 0,
-            stack_top: 0,
-            ranges: [None; crate::elf::MAX_SEGMENTS],
-            stack: crate::elf::MappedRange { start: 0, pages: 0 },
+            name: name_bytes(name),
+            entry,
+            stack_top: USER_STACK_TOP,
+            space: Some(space),
         });
-
         slot
     };
 
-    match load_into_slot(slot, image) {
-        Ok(()) => {}
-        Err(e) => {
-            release_slot(slot);
-            return Err(e);
-        }
-    }
-
     match crate::task::spawn("spawned", enter_spawned, slot) {
         Ok(thread) => {
-            serial_println!(
-                "spawn '{}': thread {}, entry 0x{:x}, image 0x{:x}..0x{:x}",
-                name,
-                thread,
-                RESIDENT.lock()[slot].as_ref().map(|r| r.entry).unwrap_or(0),
-                lo,
-                hi
-            );
+            serial_println!("spawn '{}': thread {}, entry 0x{:x}", name, thread, entry);
             Ok(thread)
         }
         Err(e) => {
@@ -384,136 +418,91 @@ pub fn spawn_program(name: &str) -> Result<usize, SpawnError> {
     }
 }
 
-fn load_into_slot(slot: usize, image: &[u8]) -> Result<(), SpawnError> {
-    let loaded = unsafe { crate::elf::load(image) }.map_err(SpawnError::Load)?;
-
-    let stack_top = SPAWN_STACK_REGION_TOP - (slot as u64 * 0x10_0000);
-    let stack_bottom = stack_top - (SHELL_STACK_PAGES * PAGE_SIZE) as u64;
-    let stack_flags = PageTableFlags::PRESENT
-        | PageTableFlags::WRITABLE
-        | PageTableFlags::USER_ACCESSIBLE
-        | PageTableFlags::NO_EXECUTE;
-
-    paging::map_user_pages(stack_bottom, SHELL_STACK_PAGES, stack_flags)
-        .map_err(SpawnError::Map)?;
-
-    let mut table = RESIDENT.lock();
-    if let Some(r) = table[slot].as_mut() {
-        r.entry = loaded.entry;
-        r.stack_top = stack_top;
-        r.ranges = loaded.ranges;
-        r.stack = crate::elf::MappedRange {
-            start: stack_bottom,
-            pages: SHELL_STACK_PAGES,
-        };
-    }
-
-    Ok(())
-}
-
-/// Entry point of a spawned thread: claim the slot, then drop to ring 3.
+/// Entry point of a spawned thread: take the address space, switch to it, and
+/// drop to ring 3.
 fn enter_spawned(slot: usize) {
     let target = {
-        let mut table = RESIDENT.lock();
+        let mut table = PROGRAMS.lock();
         match table.get_mut(slot).and_then(|s| s.as_mut()) {
             None => None,
-            Some(r) => {
+            Some(p) => {
                 // Claimed by the thread itself, as its first action. Doing it in
                 // the parent would race: the child can be scheduled — and can
                 // exit — between `task::spawn` returning and the parent writing
-                // the id, and then nothing would free its pages.
-                r.thread = crate::task::current_id();
-                Some((r.entry, r.stack_top))
+                // the id, and then nothing would free its address space.
+                p.thread = crate::task::current_id();
+                p.space.take().map(|space| (space, p.entry, p.stack_top))
             }
         }
     };
 
     match target {
-        Some((entry, stack_top)) => unsafe { enter_ring3(entry, stack_top) },
-        None => serial_println!("spawned thread has no program slot {}", slot),
+        Some((space, entry, stack_top)) => {
+            crate::task::adopt_address_space(space);
+            unsafe { enter_ring3(entry, stack_top) }
+        }
+        None => serial_println!("spawned thread has no program in slot {}", slot),
     }
 }
 
-/// Record an image loaded by the running thread, so its pages are freed when it
-/// exits. Used by the boot-time demos, which load in their own thread.
-fn adopt_resident(name: &str, loaded: &crate::elf::LoadedImage, stack: crate::elf::MappedRange) {
-    let (lo, hi) = loaded.extent();
-    let mut table = RESIDENT.lock();
-
+/// Register a program the running thread loaded for itself.
+fn register_running(name: &str) {
+    let mut table = PROGRAMS.lock();
     let Some(slot) = table.iter().position(|s| s.is_none()) else {
-        serial_println!("  (no resident slot for '{}'; its pages will not be freed)", name);
+        serial_println!("  (no program slot for '{}'; it will not appear in the count)", name);
         return;
     };
-
-    let mut name_buf = [0u8; 32];
-    let bytes = name.as_bytes();
-    let take = core::cmp::min(bytes.len(), name_buf.len() - 1);
-    name_buf[..take].copy_from_slice(&bytes[..take]);
-
-    table[slot] = Some(Resident {
+    table[slot] = Some(Program {
         thread: crate::task::current_id(),
-        name: name_buf,
-        lo,
-        hi,
-        entry: loaded.entry,
-        stack_top: stack.start + (stack.pages * PAGE_SIZE) as u64,
-        ranges: loaded.ranges,
-        stack,
+        name: name_bytes(name),
+        entry: 0,
+        stack_top: 0,
+        space: None,
     });
 }
 
 fn release_slot(slot: usize) {
-    let entry = RESIDENT.lock().get_mut(slot).and_then(|s| s.take());
-    if let Some(r) = entry {
-        unmap_resident(&r);
+    let taken = PROGRAMS.lock().get_mut(slot).and_then(|s| s.take());
+    if let Some(p) = taken {
+        if let Some(space) = p.space {
+            unsafe { space.free() };
+        }
     }
 }
 
-fn unmap_resident(r: &Resident) {
-    let mut freed = 0;
-    for range in r.ranges.iter().flatten() {
-        freed += unsafe { paging::unmap_user_pages(range.start, range.pages) };
-    }
-    if r.stack.pages > 0 {
-        freed += unsafe { paging::unmap_user_pages(r.stack.start, r.stack.pages) };
-    }
-
-    // The used-page count is printed on purpose: it is the only way to see, from
-    // the log alone, that running a program twice does not cost twice the memory.
-    // Two `hello` runs should report the same number here.
-    let used = crate::memory::physical::memory_stats()
-        .map(|s| s.used_pages)
-        .unwrap_or(0);
-
-    serial_println!(
-        "  released '{}': {} page(s) returned, {} used system-wide",
-        r.name(),
-        freed,
-        used
-    );
-}
-
-/// Free the address space a finished thread was using.
+/// Forget a finished thread's program.
 ///
-/// Called from `task::exit_current`, while the exiting thread is still current
-/// and still on its *kernel* stack — so unmapping its user pages cannot pull the
-/// ground out from under it. A thread with no program registered is a plain
-/// kernel thread and this does nothing.
+/// The address space itself is freed by `task::exit_current`, which owns it —
+/// this only clears the registry. Before per-process address spaces this
+/// function did the unmapping too, walking a recorded list of ranges; that list
+/// existed because there was nothing else that knew what a program had mapped.
 pub fn on_thread_exit(thread: usize) {
-    let entry = {
-        let mut table = RESIDENT.lock();
-        let found = table.iter().position(|s| matches!(s, Some(r) if r.thread == thread));
+    let taken = {
+        let mut table = PROGRAMS.lock();
+        let found = table.iter().position(|s| matches!(s, Some(p) if p.thread == thread));
         found.and_then(|i| table[i].take())
     };
 
-    if let Some(r) = entry {
-        unmap_resident(&r);
+    if let Some(mut p) = taken {
+        // A program whose thread never claimed its space — `spawn` failed after
+        // loading — still owns one.
+        if let Some(space) = p.space.take() {
+            unsafe { space.free() };
+        }
+
+        // The used-page count is printed on purpose: it is the only way to see,
+        // from the log alone, that running a program twice does not cost twice
+        // the memory. Two `hello` runs report the same number.
+        let used = crate::memory::physical::memory_stats()
+            .map(|s| s.used_pages)
+            .unwrap_or(0);
+        serial_println!("  released '{}': {} used system-wide", p.name(), used);
     }
 }
 
-/// Names of resident programs, for diagnostics.
+/// Programs currently loaded.
 pub fn resident_count() -> usize {
-    RESIDENT.lock().iter().flatten().count()
+    PROGRAMS.lock().iter().flatten().count()
 }
 
 /// Top of the ping-pong payload's stacks. Each thread gets its own 1 MiB below
@@ -537,35 +526,62 @@ pub fn run_pingpong(which: usize) {
     let blob_pages = ((blob_end - blob_start) as usize).div_ceil(PAGE_SIZE).max(1);
     let entry = USER_CODE_BASE + (kosh_user_pingpong_entry as usize as u64 - blob_start);
 
-    let code_flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
-    if !CODE_MAPPED.swap(true, Ordering::SeqCst) {
-        if let Err(e) =
-            paging::map_user_range(USER_CODE_BASE, user_blob_phys(), blob_pages, code_flags)
-        {
-            serial_println!("  failed to map user code: {}", e);
+    let space = match AddressSpace::new_user() {
+        Ok(s) => s,
+        Err(e) => {
+            serial_println!("  no address space for the ping-pong payload: {}", e);
             return;
         }
+    };
+
+    // The payload lives in the kernel image, so these frames are *borrowed*:
+    // `map_user_range_in` does not tag them, and tearing the space down leaves
+    // them alone. Both threads map the same frames into their own tables — the
+    // same read-only text at the same address in two address spaces, which is
+    // what shared libraries look like from the kernel's side.
+    let code_flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+    if let Err(e) = paging::map_user_range_in(
+        unsafe { paging::mapper_for(space.pml4_phys()) },
+        USER_CODE_BASE,
+        user_blob_phys(),
+        blob_pages,
+        code_flags,
+    ) {
+        serial_println!("  failed to map user code: {}", e);
+        unsafe { space.free() };
+        return;
     }
 
-    let stack_top = PINGPONG_STACK_TOP - (which as u64 * 0x10_0000);
+    // Both threads use the *same* stack address now. Under one address space
+    // they had to be given a megabyte apart.
+    let stack_top = PINGPONG_STACK_TOP;
     let stack_bottom = stack_top - (USER_STACK_PAGES * PAGE_SIZE) as u64;
     let stack_flags = PageTableFlags::PRESENT
         | PageTableFlags::WRITABLE
         | PageTableFlags::USER_ACCESSIBLE
         | PageTableFlags::NO_EXECUTE;
-    if let Err(e) = paging::map_user_pages(stack_bottom, USER_STACK_PAGES, stack_flags) {
+    if let Err(e) = paging::map_user_pages_in(
+        unsafe { paging::mapper_for(space.pml4_phys()) },
+        stack_bottom,
+        USER_STACK_PAGES,
+        stack_flags,
+    ) {
         serial_println!("  failed to map ping-pong stack: {}", e);
+        unsafe { space.free() };
         return;
     }
 
     let tag = if which == 0 { b'A' } else { b'B' };
     serial_println!(
-        "  ring 3 '{}': entry 0x{:x}, user stack 0x{:x}, kernel stack 0x{:x}",
+        "  ring 3 '{}': entry 0x{:x}, user stack 0x{:x}, PML4 0x{:x}, kernel stack 0x{:x}",
         tag as char,
         entry,
         stack_top,
+        space.pml4_phys(),
         crate::task::current_kernel_stack_top()
     );
+
+    crate::task::adopt_address_space(space);
 
     unsafe { enter_ring3_with_arg(entry, stack_top, tag as u64) }
 }
@@ -575,19 +591,22 @@ pub fn run_pingpong(which: usize) {
 /// This is the real path: a program the kernel was not compiled with, parsed
 /// out of an ELF, mapped at the addresses it was linked for, and entered.
 pub fn run_boot_module(_arg: usize) {
-    run_module("hello", ELF_USER_STACK_TOP)
+    run_module("hello")
 }
 
 /// Load the userspace shell and hand it the console.
 pub fn run_shell(_arg: usize) {
-    run_module("ksh", SHELL_USER_STACK_TOP)
+    run_module("ksh")
 }
 
-/// Stack for the shell. Distinct from the loader demo's so a fault dump makes it
-/// obvious which program was running.
-const SHELL_USER_STACK_TOP: u64 = 0x0000_0000_7000_0000;
-
-fn run_module(name: &str, stack_top: u64) {
+/// Load a boot module into a fresh address space and enter it.
+///
+/// Runs *in* the thread that will execute the program, so it adopts the address
+/// space rather than handing it over. There is no `stack_top` parameter any
+/// more: each program has the lower half to itself, so they all use the same
+/// one, and the three distinct constants that used to keep the boot demos, the
+/// ELF demo and the shell from colliding are gone.
+fn run_module(name: &str) {
     let Some(module) = boot_module_named(name) else {
         serial_println!("No boot module named '{}'", name);
         serial_println!("  (add `module2 /boot/{} {}` to grub.cfg)", name, name);
@@ -598,64 +617,28 @@ fn run_module(name: &str, stack_top: u64) {
     let image = unsafe { module.bytes() };
     crate::elf::describe(image);
 
-    let loaded = match unsafe { crate::elf::load(image) } {
-        Ok(l) => l,
+    let (space, entry) = match prepare_program(image) {
+        Ok(v) => v,
         Err(e) => {
-            serial_println!("  ELF load FAILED: {:?}", e);
+            serial_println!("  load FAILED: {:?}", e);
             return;
         }
     };
 
-    serial_println!(
-        "  loaded {} segment(s), {} bytes, entry 0x{:x}",
-        loaded.segments,
-        loaded.bytes_mapped,
-        loaded.entry
-    );
-
-    // A fresh stack, well clear of the image's own segments.
-    let stack_bottom = stack_top - (SHELL_STACK_PAGES * PAGE_SIZE) as u64;
-    let stack_flags = PageTableFlags::PRESENT
-        | PageTableFlags::WRITABLE
-        | PageTableFlags::USER_ACCESSIBLE
-        | PageTableFlags::NO_EXECUTE;
-
-    if let Err(e) = paging::map_user_pages(stack_bottom, SHELL_STACK_PAGES, stack_flags) {
-        serial_println!("  failed to map stack for loaded image: {}", e);
+    if !crate::memory::address_space::check_kernel_half(&space) {
+        serial_println!("  FATAL: new address space does not share the kernel's upper half");
+        unsafe { space.free() };
         return;
     }
-    serial_println!(
-        "  stack          : 0x{:x}..0x{:x} (RW-, user, NX)",
-        stack_bottom,
-        stack_top
-    );
 
-    // Register before entering ring 3, so `task::exit_current` frees these pages
-    // when the program exits. Without this the boot-time load of `hello` stayed
-    // mapped forever, and `ksh` spawning `hello` later failed with
-    // `PageAlreadyMapped` — leaking a frame per attempt.
-    adopt_resident(
-        name,
-        &loaded,
-        crate::elf::MappedRange {
-            start: stack_bottom,
-            pages: SHELL_STACK_PAGES,
-        },
-    );
+    register_running(name);
+    crate::task::adopt_address_space(space);
 
     serial_println!("Entering loaded ELF in ring 3...");
     serial_println!("--- loaded program output ---");
 
-    unsafe { enter_ring3(loaded.entry, stack_top) }
+    unsafe { enter_ring3(entry, USER_STACK_TOP) }
 }
-
-/// Stack for the ELF-loaded program. Separate from the built-in payload's, so
-/// the two demos cannot interfere.
-const ELF_USER_STACK_TOP: u64 = 0x0000_0000_6000_0000;
-
-/// Loaded programs get more stack than the hand-written payload: the shell has a
-/// recursive-descent parser and formats strings on the stack.
-const SHELL_STACK_PAGES: usize = 16;
 
 /// Drop to ring 3 at `entry` with `stack_top`.
 ///

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -237,6 +237,7 @@ check)
         "physmap aliases identity map: OK" \
         "page 0 unmapped: OK" \
         "kernel out of PML4[0]: OK" \
+        "Address spaces: PASS" \
         "PASS: heap fully reclaimed" \
         "Scheduler: PASS" \
         "hello from ring 3" \
@@ -348,10 +349,14 @@ check-cli)
         # of the first one's mappings.
         type_line "hello"
         type_line "hello"
-        # One address space, so a program cannot be loaded on top of one that is
-        # already resident. Spawning ksh from ksh has to be refused, not
-        # attempted — it would overwrite the .text currently executing.
+        # ksh inside ksh. This was *refused* until per-process address spaces:
+        # both are linked at 8 MiB, so a second copy in one address space would
+        # have overwritten the .text the first one was executing. Now each has
+        # its own PML4 and the same address means different memory.
         type_line "ksh"
+        type_line "getpid"
+        type_line "exit"
+        type_line "getpid"
         # The shell must refuse redirection rather than silently dropping it.
         type_line "echo a > out.txt"
         # QEMU's sendkey cannot produce a '|' through this keyboard layout, so
@@ -396,8 +401,9 @@ check-cli)
         "spawn 'hello': thread" \
         "hello from a loaded ELF binary" \
         "released 'hello'" \
-        "overlaps resident 'ksh'" \
-        "ksh: could not start (error -98)" \
+        "Loading 'ksh' into a new address space" \
+        "spawn 'ksh': thread" \
+        "address space of thread" \
         "redirection needs a writable filesystem" \
         "pipe yes" \
         "redirect out" \

--- a/userspace/hello/user.ld
+++ b/userspace/hello/user.ld
@@ -1,16 +1,24 @@
-/* Link userspace programs at 4 MiB.
+/* Link at 8 MiB — the *same* address as ksh (userspace/shell/user.ld).
  *
- * Clear of the kernel's low identity window (which ends around 4 MiB) and far
- * below the higher half. The ELF loader honours p_vaddr, so this is where the
- * program genuinely runs — unlike the Phase 5 payload, which was
- * position-independent assembly mapped wherever we liked.
+ * Deliberately the same, as a standing test. Until per-process address spaces
+ * every program had to be given its own address so their images would not land
+ * on top of each other in the one set of page tables, and `spawn` refused any
+ * image that overlapped a resident one. Two programs sharing a link address
+ * would have meant one overwriting the other's `.text` while it executed.
+ *
+ * With a PML4 each, 0x800000 in `hello` and 0x800000 in `ksh` are simply
+ * different memory. `ksh` spawning `hello` — which the scripted console session
+ * does twice — exercises exactly that, and would fail loudly if the spaces were
+ * ever shared again.
+ *
+ * The ELF loader honours p_vaddr, so this is where the program genuinely runs.
  */
 
 ENTRY(_start)
 
 SECTIONS
 {
-    . = 0x400000;
+    . = 0x800000;
 
     .text ALIGN(4K) : { *(.text .text.*) }
     .rodata ALIGN(4K) : { *(.rodata .rodata.*) }

--- a/userspace/shell/user.ld
+++ b/userspace/shell/user.ld
@@ -1,5 +1,9 @@
-/* Link ksh at 8 MiB — clear of the kernel's low identity window and of
- * userspace/hello at 4 MiB, so the two are easy to tell apart in a fault dump.
+/* Link ksh at 8 MiB.
+ *
+ * `userspace/hello` is linked at the same address on purpose — see the comment
+ * in its own `user.ld`. Two programs at one address is a thing per-process page
+ * tables make unremarkable and a shared address space made impossible.
+ *
  * The ELF loader honours p_vaddr, so this is where it genuinely runs.
  */
 


### PR DESCRIPTION
Phase 11 got the kernel out of PML4[0]. This puts a process in it.

An `AddressSpace` is a PML4 of its own: the lower half is the process's alone, and entries 256..512 are copied from the kernel's table so every space walks the same PDPTs for the physmap, the heap and the kernel image. Three entries; the copy happens once, so a new top-level kernel entry appearing later would be invisible to existing processes — `check_kernel_half` asserts that rather than assuming it.

`task::schedule` reloads CR3 when the incoming thread lives somewhere else, which it can only do mid-scheduler because RIP, RSP, the GDT, the IDT and the per-CPU block are all in the shared upper half. `exit_current` returns CR3 to the kernel's tables *before* freeing, because the other order hands the live top-level table to the frame allocator.

Teardown walks the lower half and frees every page table, but a leaf frame only if its entry carries OWNED_BY_ADDRESS_SPACE. `map_user_pages_in` sets it; `map_user_range_in` does not, because the built-in ring-3 payload lives inside the kernel image and an untagged teardown would free the kernel's own .user section.

The interesting part of the diff is the deletions. The `Resident` address-range table, `elf::extent_of`, `LoadedImage::ranges`/`MappedRange`/`MAX_SEGMENTS`/ `TooManySegments`, `SpawnError::AddressConflict`, whole-process `unmap_user_pages`, and four separate user-stack base constants were all bookkeeping around a shared lower half. Programs load at their own p_vaddr and get a stack at one USER_STACK_TOP.

`userspace/hello` is now linked at 0x800000 — the same address as ksh — on purpose, as a standing test: ksh executing at 0x800000 spawns hello, also at 0x800000, twice in the scripted session. ksh can also spawn ksh, which the previous phase refused with error -98.

`address_space::self_test` maps one page at the same user address in two spaces, writes different values through the physmap and reads each back after activating it. Pointing both maps at one space gives PageAlreadyMapped — the error the old overlap check existed to pre-empt.

Also fixes an inconsistency Phase 11 left: `run_user_demo` mapped the built-in payload into the kernel's own PML4[0] and left it there, so "PML4[0] is empty" held only until the first ring-3 demo ran.

34 boot markers and 29 console markers pass from a clean build.


Claude-Session: https://claude.ai/code/session_01P1GdpYMiKP5Gj1Jmub59gw