### PR TITLE
syscalls: stop reporting success for work not done; rewrite the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,189 +1,263 @@
-NOTE: 
-Initially, I build this using kiro, using a spec based approach.
+NOTE:
+Initially, I built this using Kiro, using a spec based approach.
 Now using Claude to build further.
 
-Intial thoughs and ideas: https://blog.tovganesh.in/2012/01/kosh-building-mobile-user-experience.html
+Initial thoughts and ideas: https://blog.tovganesh.in/2012/01/kosh-building-mobile-user-experience.html
 
 At this point this is my personal toy project. I currently have no idea if this will actually work. If you are interested in writing a rust based OS with or without AI tools you can poke me.
 
+---
 
-# Kosh Operating System
+# Kosh
 
-A modern, microkernel-based operating system written in Rust, designed with security, modularity, and cross-platform support in mind.
+An x86-64 operating system kernel written in Rust. It boots on QEMU from a
+Multiboot2 ISO, runs programs in ring 3 with per-process address spaces, reads a
+FAT32 disk, and gives you a shell.
 
-## Features
+```
+ksh: the Kosh shell, in ring 3. Type 'help'.
+ksh:/$ ls
+d           -  DOCS
+-         199  README.TXT
+-       22000  BIG.TXT
+-          26  A Long File Name.txt
 
-- **Microkernel Architecture**: Minimal kernel with services running in userspace
-- **Memory Safety**: Written in Rust for memory safety and performance
-- **Cross-Platform**: Supports x86-64 and ARM64 architectures
-- **Modular Design**: Pluggable driver system and userspace services
-- **Capability-Based Security**: Fine-grained access control system
+6 entries, 22280 bytes
+ksh:/$ date
+2026-07-30 11:42:25 UTC
+ksh:/$ hello
+hello from a loaded ELF binary
+  my pid is 3
+  mmap gave me 8192 usable bytes at 0x0000000010000000
+  exiting cleanly
+ksh:/$ ksh
+ksh: the Kosh shell, in ring 3. Type 'help'.
+ksh:/$ getpid
+pid 4
+ksh:/$ exit
+ksh:/$ getpid
+pid 3
+```
 
-## Architecture
+## About this README
 
-### Core Components
+This project has spent most of its life describing things it could not do. The
+kernel had a "virtual memory manager" that read the bootloader's page tables and
+described them; a shell whose `read_line` replayed a hardcoded array of six
+commands; a `sys_open` that returned the literal `3` for every path. For 27
+commits the kernel never executed a single instruction, because Multiboot2 hands
+off in 32-bit mode and nothing bridged the gap.
 
-- **Kernel**: Minimal microkernel handling basic system operations
-- **Drivers**: Modular drivers for storage, network, and graphics
-- **Userspace Services**: 
-  - Init process for system startup
-  - Filesystem service
-  - Driver manager for dynamic driver loading
+Unwinding that is most of the work that has happened since, so this file tries to
+be accurate about what runs and blunt about what doesn't. If something is listed
+under **Works**, there is a marker in `scripts/run.sh` that fails if it stops
+working.
 
-### Shared Libraries
+`docs/BOOT.md` is the long version: 1,100 lines on how the boot chain, paging,
+scheduling, ring 3, the filesystem and the address-space work actually function,
+including the bugs found along the way and how each was caught.
 
-- **kosh-types**: Common type definitions and interfaces
-- **kosh-ipc**: Inter-process communication primitives
+## Running it
 
-## Building
-
-### Prerequisites
-
-- Rust nightly toolchain (automatically configured via `rust-toolchain.toml`)
-- GRUB tools (optional, for ISO creation)
-
-### Quick Start
+One command builds the kernel, both userspace programs, a GRUB ISO and a FAT32
+test disk, then boots the lot:
 
 ```bash
-# Build all components
-./scripts/build.sh
-
-# Create bootable ISO
-./scripts/build-iso.sh
+./scripts/run.sh              # boot it, serial on stdio (ctrl-a x to quit)
+./scripts/run.sh --check      # boot headless, assert 39 serial markers (CI)
+./scripts/run.sh --check-cli  # drive the shell through QEMU's monitor, assert 30
+./scripts/run.sh --debug      # same as plain run, plus a gdb stub on :1234
 ```
 
-### Manual Building
+You need `cargo` (nightly), `grub-mkrescue`, `xorriso`, `qemu-system-x86_64`,
+`mkfs.vfat` and `mcopy`. `scripts/run.sh` checks for all of them and tells you
+what to install.
 
-```bash
-# Build kernel for x86-64
-cargo build --package kosh-kernel --target x86_64-kosh.json --release -Z build-std=core,alloc
+The other scripts in `scripts/` predate the current build and are stale —
+`build.sh` and `build-iso.sh` in particular do not build the two userspace
+binaries that actually ship, and do not handle the `-Z build-std` flags the
+kernel now needs. `run.sh` is the only supported entry point.
 
-# Build userspace components
-cargo build --package kosh-init --target x86_64-kosh.json --release -Z build-std=core,alloc
-cargo build --package kosh-fs-service --target x86_64-kosh.json --release -Z build-std=core,alloc
-cargo build --package kosh-driver-manager --target x86_64-kosh.json --release -Z build-std=core,alloc
+`.github/workflows/boot.yml` runs `--check` on every push, so "it boots" is a
+merge gate rather than a claim.
 
-# Build drivers (standard target)
-cargo build --package kosh-storage-driver --release
-cargo build --package kosh-network-driver --release
-cargo build --package kosh-graphics-driver --release
+## What works
+
+Each of these is asserted by a serial marker in `--check` or a scripted console
+interaction in `--check-cli`.
+
+**Boot**
+- Multiboot2 hand-off, a 32-bit trampoline into long mode, and a **higher-half
+  kernel** linked at `0xFFFFFFFF80100000` and loaded at 1 MiB
+- Early COM1 output from assembly, so a failure before Rust is visible
+- GRUB's own output on the serial port too, because a kernel GRUB refuses to load
+  otherwise looks identical to one that hung
+
+**Memory**
+- Page tables the kernel builds itself, with **W^X** enforced — `.text` is
+  read-execute, `.rodata` and everything else is NX, and `CR0.WP` plus
+  `EFER.NXE` are set so those bits actually bind in ring 0
+- A physmap of all RAM at `0xFFFF800000000000`, a heap window at
+  `0xFFFF900000000000`, and page 0 left unmapped as a null guard
+- A bitmap frame allocator that excludes the running kernel and the boot tables
+- A first-fit kernel heap with coalescing, alignment handling and stats
+
+**Processes and scheduling**
+- Preemptive round-robin over kernel threads, driven by the PIT at 100 Hz
+- **Per-process address spaces**: a PML4 each, kernel's upper half shared. Two
+  programs can be — and `hello` and `ksh` are — linked at the same address
+- **Per-thread kernel stacks**, so more than one thread can be inside a syscall
+- Real blocking: `wait` parks a thread in `State::Blocked` rather than spinning
+
+**Ring 3**
+- `SYSCALL`/`SYSRET` with a `swapgs`-free per-CPU block reached through `gs:`
+- User-pointer validation that checks range *and* page permissions, tested from
+  the user side by a payload that deliberately passes a kernel address
+- A ring-3 fault kills the process and the kernel carries on
+- A static ELF64 loader: `PT_LOAD` segments mapped at their `p_vaddr` with
+  per-segment permissions and a zeroed `.bss` tail
+
+**Devices and storage**
+- 8259 PIC remap, PIT timer, PS/2 keyboard on IRQ1
+- ATA PIO driver on the legacy IDE ports — IDENTIFY, LBA28 reads
+- Read-only FAT32: BPB validation, cluster-chain walking, long filenames
+- CMOS RTC, so `date` prints the real date
+
+**Userspace**
+- `hello` — a static ELF that proves the loader, and exercises `mmap`,
+  `munmap`, `clock_gettime` and `debug_print`
+- `ksh` — a shell in ring 3 with line editing, history, arrow keys, a
+  recursive-descent parser, and `ls`/`cat`/`cd`/`stat`/`date`/`getpid`
+- `ksh` can launch programs: unknown commands become `spawn` + `wait`
+
+**In-kernel console**
+- A fallback shell on the same keyboard, which takes over when `ksh` exits — so
+  there is a prompt on a system whose userspace has died
+
+## The syscall surface
+
+44 numbers are defined; **18 do the work** and the other 26 return an error
+saying so. Nothing returns success for work it did not do — that was true of six
+of them until recently, and fixing it is the most recent change.
+
+**Working** (all 18 exercised from ring 3, not just by the kernel checking
+itself):
+
+`exit` `wait` `getpid` `yield` `spawn` · `mmap` `munmap` · `open` `close` `read`
+`write` `lseek` `stat` `getdents` · `time` `clock_gettime` · `debug_print`
+`debug_dump`
+
+**Refuses with `NotSupported`, honestly:**
+
+`fork` `exec` `kill` `getppid` · `mprotect` `brk` `sbrk` · `fstat` `mkdir`
+`rmdir` `unlink` · all 5 IPC calls · all 4 driver calls · all 4 capability
+calls · `uname` `sysinfo`
+
+## What does not work
+
+Being explicit about this, because the earlier version of this file claimed most
+of it.
+
+- **No `fork`.** Every process starts from an ELF. Duplicating a running address
+  space needs copy-on-write and a `#PF` handler that does the copying.
+- **No demand paging.** Every page of a program is populated at load time, so
+  `ksh`'s 256 KiB `.bss` costs 65 frames whether it is touched or not.
+- **The filesystem is read-only.** `ksh` refuses redirection rather than
+  pretending; there is no `mkdir`, `unlink` or write path.
+- **No IPC from userspace.** `kernel/src/ipc/` is ~85 KB of real queueing and
+  capability machinery, and it is unreachable: `syscall/entry.rs` passes a
+  *thread* id where the IPC layer expects a `ProcessTable` entry, and those two
+  namespaces are unrelated. Reconciling them is the next IPC job.
+- **Capability-based security is not enforced.** Same story: the machinery exists
+  in-kernel, all four capability syscalls return `NotSupported`, and no code path
+  checks a capability on behalf of a user process.
+- **Not actually a microkernel yet.** The ATA driver, the filesystem and the
+  keyboard driver are all *in* the kernel. That is the opposite of the intended
+  design and is where the IPC work above leads.
+- **`userspace/init`, `fs-service`, `driver-manager` do not run.** They are not
+  built, not on the ISO, have no linker scripts, and depend on `fork`/`exec`.
+- **`drivers/*` are not drivers.** `storage` and `network` are trait skeletons
+  whose `init` sets a bool and returns `Ok(())`; `keyboard` declares the PS/2
+  ports and then returns `0` from `read_data` with a comment saying it would use
+  them in a real implementation; `graphics` does touch `0xB8000` but is built for
+  the host and never loaded. The kernel's own ATA and keyboard drivers are the
+  real ones.
+- **`shared/kosh-ipc` and `shared/kosh-driver` are used by nothing that ships.**
+- **No ARM64.** `aarch64-kosh.json` is a valid target spec and nothing more: the
+  build does not compile for it (the panic handler, `serial`, `vga_buffer` and
+  `memory` are all x86-only and not gated), there is no boot path, and
+  `kernel/src/platform/aarch64/` says "stub implementations" in its own module
+  docs.
+- **No network, no graphics beyond VGA text, no UEFI, no SMP.**
+- **Swap and power management are disabled** in `boot.rs`, with the reason
+  in-line: swap tried to allocate 8 MiB from a 1 MiB heap, and power management
+  was entirely simulated.
+
+## Layout
+
+```
+kernel/src/
+  boot32.rs        32-bit Multiboot2 trampoline; builds the bootstrap map
+  boot.rs          init_kernel: brings each subsystem up, in order
+  gdt.rs           GDT/TSS, with the descriptor order sysret forces
+  percpu.rs        per-CPU block reached through gs:, for the syscall stub
+  interrupts/      IDT, exception handlers, PIC, PIT, keyboard
+  memory/
+    physical.rs      bitmap frame allocator
+    paging.rs        the kernel's own page tables, W^X, physmap
+    address_space.rs per-process PML4s
+    heap.rs          first-fit allocator with coalescing
+  task/            preemptive kernel threads and the context switch
+  syscall/         SYSCALL entry, dispatcher, user-pointer checks, files
+  elf.rs           static ELF64 loader
+  block/ata.rs     ATA PIO driver
+  fs/fat32.rs      read-only FAT32
+  console/         the in-kernel fallback shell
+  platform/rtc.rs  CMOS real-time clock
+userspace/
+  hello/           static ELF that proves the loader and the newer syscalls
+  shell/           ksh
+docs/BOOT.md       how all of the above actually works
+scripts/run.sh     build, ISO, disk image, boot, and the two CI gates
 ```
 
-## Project Structure
+Everything else in the tree — `drivers/`, `userspace/init`, `fs-service`,
+`driver-manager`, `shared/`, and the other scripts — is either vestigial or not
+yet wired up. See **What does not work**.
 
-```
-kosh/
-├── kernel/                 # Microkernel implementation
-├── drivers/               # Hardware drivers
-│   ├── storage/          # Storage device drivers
-│   ├── network/          # Network device drivers
-│   └── graphics/         # Graphics device drivers
-├── userspace/            # Userspace services
-│   ├── init/            # System initialization
-│   ├── fs-service/      # Filesystem service
-│   └── driver-manager/  # Driver management service
-├── shared/              # Shared libraries
-│   ├── kosh-types/     # Common type definitions
-│   └── kosh-ipc/       # IPC primitives
-├── scripts/            # Build and utility scripts
-├── iso/               # ISO image structure (generated)
-└── build/             # Build artifacts (generated)
-```
+## Where this is going
 
-## Supported Platforms
+Roughly in order, each unblocking the next:
 
-- **x86-64**: Primary development target
-- **ARM64**: Planned support (target specification ready)
+- [x] Boot to long mode, higher-half kernel
+- [x] Page tables, W^X, physmap, heap
+- [x] Preemptive scheduling
+- [x] Ring 3, `SYSCALL`/`SYSRET`, ELF loading
+- [x] ATA + read-only FAT32
+- [x] A shell in userspace that can launch programs
+- [x] Per-process address spaces
+- [ ] `fork` with copy-on-write, and demand paging
+- [ ] One process-id namespace, so the IPC and capability machinery becomes
+      reachable from ring 3
+- [ ] Move the disk and filesystem out of the kernel — the point of the whole
+      exercise
+- [ ] FAT32 writes
+- [ ] `userspace/init` doing its job
 
-## Development
+## Screenshots
 
-### Target Specifications
+<img width="1456" height="812" alt="image" src="https://github.com/user-attachments/assets/5ed82d95-751e-447d-9177-4d340a2eed97" />
 
-- `x86_64-kosh.json`: Custom target for x86-64 bare-metal
-- `aarch64-kosh.json`: Custom target for ARM64 bare-metal
+(The first boot)
 
-### Build Configuration
+## Why Rust
 
-The project uses Rust nightly with custom target specifications for bare-metal development. The build system automatically handles:
-
-- Cross-compilation for multiple architectures
-- No-std environment setup
-- Custom bootloader integration
-- ISO image generation
-
-## Testing
-
-```bash
-# Run tests for workspace components
-cargo test --workspace
-
-# Test kernel specifically
-cargo test --package kosh-kernel --target x86_64-kosh.json -Z build-std=core,alloc
-```
-
-## Running
-
-### QEMU
-
-```bash
-# Run with QEMU (x86-64)
-qemu-system-x86_64 -cdrom kosh.iso
-
-# Run with QEMU (ARM64)
-qemu-system-aarch64 -M virt -cpu cortex-a57 -cdrom kosh.iso
-```
-
-### Real Hardware
-
-Flash the generated ISO to a USB drive or burn to CD/DVD for real hardware testing.
-
-## Contributing
-
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Run tests and ensure builds pass
-5. Submit a pull request
+Memory safety without a runtime, and `unsafe` as a marker rather than a mode:
+the places where this kernel talks to hardware are visible in the source because
+they have to be spelled out. It has not prevented a single one of the bugs in
+`docs/BOOT.md` — those were all logic, not memory safety — but it did keep them
+to logic.
 
 ## License
 
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Roadmap
-
-- [x] Basic project structure and build system
-- [ ] Memory management implementation
-- [ ] Process management and scheduling
-- [ ] IPC mechanism implementation
-- [ ] Driver framework completion
-- [ ] Filesystem implementation
-- [ ] Network stack
-- [ ] Graphics subsystem
-- [ ] ARM64 support completion
-- [ ] UEFI boot support
-
-## Architecture Decisions
-
-### Microkernel Design
-
-Kosh follows a microkernel architecture where the kernel provides only essential services:
-- Memory management
-- Process scheduling
-- Basic IPC
-- Hardware abstraction
-
-All other services (filesystem, networking, drivers) run in userspace for better isolation and reliability.
-
-### Capability-Based Security
-
-The system implements capability-based security where processes must have explicit capabilities to access resources, providing fine-grained access control.
-
-### Screenshots
-
-<img width="1456" height="812" alt="image" src="https://github.com/user-attachments/assets/5ed82d95-751e-447d-9177-4d340a2eed97" />
-(The first boot)
-
-
-### Rust Language Choice
-
-Rust was chosen for its memory safety guarantees, zero-cost abstractions, and excellent support for systems programming without sacrificing performance.
+MIT. See [LICENSE](LICENSE).

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -1164,6 +1164,110 @@ up until the first ring-3 demo ran. It gets its own address space now, like
 everything else, and the two demos share a stack address instead of being handed
 regions a megabyte apart.
 
+## Telling the truth about the syscall surface (Phase 13)
+
+An audit of every syscall against what its handler actually does turned up **six
+that reported success for work they had not done**. That is the specific failure
+mode this whole series has been unwinding, and it was still present in the ABI.
+
+| syscall | what it did | now |
+|---|---|---|
+| `mmap` | returned the constant `0x40000000` and logged "mmap successful" | allocates and maps real pages |
+| `debug_print` | printed the *address* of the string under a `// TODO: Read string from user space` | prints the message |
+| `debug_dump` | printed `DEBUG DUMP[1]: type 0` and dumped nothing | dumps memory, threads, syscall count or open files |
+| `time` | returned `Ok(0)` — a valid timestamp, 1 Jan 1970 | reads the CMOS RTC |
+| `getppid` | returned `Ok(0)` under a TODO, indistinguishable from "no parent" | `NotSupported` |
+| `send_message` | substituted a synthetic string for the caller's payload | `NotSupported` |
+| `receive_message` | dequeued for real, then dropped the payload | `NotSupported` |
+
+`mmap` is the clearest case. It validated `length`, built a `MemoryProtection`
+struct, threw it away, and returned a hardcoded address — then logged
+`mmap successful: mapped at 0x40000000`. A caller that wrote to the pointer took
+a page fault, having been told the mapping existed.
+
+### mmap, for real
+
+Per-process address spaces are what made this easy: the pages go into the calling
+process's own tables, so there is no shared region to arbitrate. Anonymous
+private mappings only, in a 256 MiB window at `0x10000000`, with W^X enforced —
+a request for write+execute is refused rather than quietly granted.
+
+Address selection is a linear scan of the process's own page tables for a hole,
+rather than a bump pointer. A bump pointer would need somewhere per-process to
+live and would leak address space across `munmap`.
+
+`munmap` works too, and refuses anything outside the mmap window: letting a
+process unmap its own `.text` turns a userspace bug into an unexplainable fault.
+
+### A bug the test found immediately
+
+The first version discriminated file-backed mappings on `fd`:
+
+```rust
+if args[4] >= 0 { return Err(NotSupported); }   // wrong
+```
+
+`args[4]` arrives in **R8**, and a caller using a three-argument syscall wrapper
+never sets R8 — so the check read whatever was left in that register and refused
+every mapping. `hello` printed `WARNING: mmap failed` on the first run.
+
+The fix is to discriminate on `MAP_ANONYMOUS`, a flag the caller definitely
+passed. The general lesson is worth stating: **a syscall must not read an
+argument the ABI does not require the caller to set.** There is no way to tell a
+deliberate zero from a stale register.
+
+### The RTC
+
+`platform/rtc.rs`, and the two things that make it more than a port read:
+
+The RTC updates its registers once a second, and a read part-way through an
+update returns a mix of old and new fields — 10:59:59 can read as 11:59:59. So it
+waits for the update-in-progress flag, reads everything, reads everything again,
+and only accepts values the two agree on. The wait is bounded, because a machine
+with no RTC leaves that flag set forever and hanging the kernel on `time()` would
+be worse than having no clock.
+
+Status register B says whether the values are BCD or binary, and whether the hour
+is 12- or 24-hour. Both are checked rather than assumed: a kernel that assumes
+BCD on a binary RTC reports plausible-looking nonsense.
+
+Verified against the host: the kernel logged 1785411504 while `date -u +%s` on
+the host said 1785411523, and the difference is the boot delay.
+
+### Why the IPC calls became errors instead of working
+
+Copying the payload is the easy part; `uaccess::copy_from_user` already exists.
+The blocker is that there are **two unrelated id namespaces**. `syscall/entry.rs`
+passes the calling *thread's* id as a `ProcessId`, while
+`ipc::message::send_message` looks the sender up in `process::ProcessTable`, whose
+only entries are the three synthetic ones the boot self-test creates. A ring-3
+caller is not in that table, so every send would fail `SenderNotFound` even with
+a real payload.
+
+Making `send_message` copy the buffer would have turned a fabrication into a
+different fabrication. One process table that `spawn` registers into — with a
+thread as a *member* of a process rather than a synonym for one — is the actual
+work, and `kernel/src/ipc/` is ~85 KB of implemented queueing and capability
+machinery waiting on it.
+
+### Testing
+
+`hello` gained the new calls, so each is exercised from ring 3 rather than by the
+kernel checking itself:
+
+```
+hello from a loaded ELF binary
+  mmap gave me 8192 usable bytes at 0x0000000010000000
+  munmap returned the pages
+  CLOCK_MONOTONIC moves forwards
+DEBUG[1]: hello reached the kernel log through debug_print
+  debug_print echoed my message
+```
+
+It writes to the first and last word of the mapping and reads both back, so a
+mapping that is present but wrong fails rather than passing. `ksh` gained `date`,
+which is the RTC end to end: RTC → `sys_time` → ring 3 → civil date.
+
 ## What is deliberately still missing
 - **The filesystem is read-only.** Allocating clusters and keeping both FAT
   copies consistent is a separate problem, and a read-only filesystem that is
@@ -1185,6 +1289,9 @@ regions a megabyte apart.
 - **The descriptor table is still global.** One table for the system, because
   `Program` has nowhere to hang a per-process one yet. `sys_exit` works around
   it by only closing everything when it is the last program running.
+- **No IPC or capabilities from ring 3.** Both subsystems are implemented
+  in-kernel and unreachable, waiting on a single process-id namespace — see
+  Phase 13 above.
 - **No pipes or background jobs.** `ksh` parses them; running them needs two
   programs connected by a shared descriptor, which needs per-process descriptor
   tables. The table is currently global — see the note in `sys_exit`.

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -758,6 +758,7 @@ fn init_storage_selftest() {
 #[cfg(target_arch = "x86_64")]
 fn init_usermode() {
     crate::syscall::uaccess::self_test();
+    crate::platform::rtc::report();
     crate::memory::address_space::self_test();
     serial_println!();
 

--- a/kernel/src/memory/address_space.rs
+++ b/kernel/src/memory/address_space.rs
@@ -219,8 +219,10 @@ pub fn self_test() {
     use crate::memory::paging::{map_user_pages_in, translate_in};
     use crate::memory::PAGE_SIZE;
 
-    // Somewhere in the lower half nothing else uses.
-    const PROBE: u64 = 0x0000_0000_1000_0000;
+    // Somewhere in the lower half nothing else uses. Above the `mmap` region, so
+    // the two are not confusable in a log even though these spaces are private
+    // and thrown away.
+    const PROBE: u64 = 0x0000_0000_2800_0000;
     const VALUE_A: u64 = 0xAAAA_AAAA_AAAA_AAAA;
     const VALUE_B: u64 = 0xBBBB_BBBB_BBBB_BBBB;
 

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -549,7 +549,6 @@ pub fn map_user_pages_in(
 ///
 /// # Safety
 /// Nothing may still be using these addresses.
-#[allow(dead_code)]
 pub unsafe fn unmap_user_pages_in(
     mut mapper: OffsetPageTable<'static>,
     virt: u64,

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -7,6 +7,8 @@
 use core::fmt;
 
 pub mod traits;
+#[cfg(target_arch = "x86_64")]
+pub mod rtc;
 pub mod x86_64;
 pub mod aarch64;
 

--- a/kernel/src/platform/rtc.rs
+++ b/kernel/src/platform/rtc.rs
@@ -1,0 +1,212 @@
+//! The CMOS real-time clock.
+//!
+//! ## Why this exists
+//!
+//! `sys_time` returned `Ok(0)` under a `// TODO: Implement time getting`. Zero is
+//! a perfectly valid Unix timestamp — midnight, 1 January 1970 — so a caller had
+//! no way to distinguish "the clock says 1970" from "there is no clock". This is
+//! the smallest thing that makes the answer true.
+//!
+//! ## Reading it without getting a torn value
+//!
+//! The RTC updates its registers once a second, and reading part-way through an
+//! update gives a mix of old and new fields: 10:59:59 can be read as 10:59:00 or
+//! 11:59:59 depending on which registers were caught. Status register A bit 7 is
+//! the update-in-progress flag; the standard approach is to wait for it to clear,
+//! read everything, then read everything again and accept the values only if the
+//! two agree. That is what [`read_raw`] does.
+//!
+//! ## BCD
+//!
+//! By default the RTC reports binary-coded decimal — 0x59 means fifty-nine, not
+//! eighty-nine. Status register B bit 2 says whether the values are binary
+//! instead, and bit 1 whether the hour is 24-hour. Both are checked rather than
+//! assumed, because QEMU and real hardware do not always agree, and a kernel that
+//! assumes BCD on a binary RTC reports plausible-looking nonsense.
+
+use x86_64::instructions::port::Port;
+
+use crate::serial_println;
+
+const CMOS_ADDRESS: u16 = 0x70;
+const CMOS_DATA: u16 = 0x71;
+
+const REG_SECONDS: u8 = 0x00;
+const REG_MINUTES: u8 = 0x02;
+const REG_HOURS: u8 = 0x04;
+const REG_DAY: u8 = 0x07;
+const REG_MONTH: u8 = 0x08;
+const REG_YEAR: u8 = 0x09;
+const REG_STATUS_A: u8 = 0x0A;
+const REG_STATUS_B: u8 = 0x0B;
+
+/// A reading, in whatever encoding the RTC uses.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Raw {
+    second: u8,
+    minute: u8,
+    hour: u8,
+    day: u8,
+    month: u8,
+    year: u8,
+}
+
+fn cmos_read(register: u8) -> u8 {
+    let mut address: Port<u8> = Port::new(CMOS_ADDRESS);
+    let mut data: Port<u8> = Port::new(CMOS_DATA);
+    unsafe {
+        // Bit 7 disables NMI while the index is latched. Leaving it clear is the
+        // conventional choice and matches what every other reader does.
+        address.write(register);
+        data.read()
+    }
+}
+
+fn update_in_progress() -> bool {
+    cmos_read(REG_STATUS_A) & 0x80 != 0
+}
+
+fn read_once() -> Raw {
+    Raw {
+        second: cmos_read(REG_SECONDS),
+        minute: cmos_read(REG_MINUTES),
+        hour: cmos_read(REG_HOURS),
+        day: cmos_read(REG_DAY),
+        month: cmos_read(REG_MONTH),
+        year: cmos_read(REG_YEAR),
+    }
+}
+
+/// Read the clock twice and only accept a value both reads agree on.
+fn read_raw() -> Option<Raw> {
+    // Bounded rather than a bare `while`: a machine with no RTC leaves the
+    // update flag set forever, and hanging the kernel on `time()` would be a
+    // worse failure than not having a clock.
+    for _ in 0..1_000_000 {
+        if !update_in_progress() {
+            break;
+        }
+    }
+    if update_in_progress() {
+        return None;
+    }
+
+    let mut previous = read_once();
+    for _ in 0..16 {
+        let current = read_once();
+        if current == previous {
+            return Some(current);
+        }
+        previous = current;
+    }
+
+    None
+}
+
+fn bcd_to_binary(value: u8) -> u8 {
+    (value & 0x0F) + ((value >> 4) * 10)
+}
+
+/// Days from 1 January 1970 to 1 January of `year`.
+fn days_before_year(year: u64) -> u64 {
+    let mut days = 0;
+    for y in 1970..year {
+        days += if is_leap(y) { 366 } else { 365 };
+    }
+    days
+}
+
+fn is_leap(year: u64) -> bool {
+    (year % 4 == 0 && year % 100 != 0) || year % 400 == 0
+}
+
+fn days_before_month(year: u64, month: u64) -> u64 {
+    const LENGTHS: [u64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let mut days = 0;
+    for m in 1..month {
+        days += LENGTHS[(m - 1) as usize];
+        if m == 2 && is_leap(year) {
+            days += 1;
+        }
+    }
+    days
+}
+
+/// Seconds since the Unix epoch, or `None` if the clock cannot be read.
+///
+/// The RTC keeps no timezone, and there is no configuration to tell us what it
+/// is set to. UTC is assumed — which is what QEMU provides by default and what
+/// most systems set it to. Getting that wrong shifts the answer by hours, not
+/// years, and there is nothing here that could detect it.
+pub fn unix_time() -> Option<u64> {
+    let raw = read_raw()?;
+    let status_b = cmos_read(REG_STATUS_B);
+    let binary = status_b & 0x04 != 0;
+    let twenty_four_hour = status_b & 0x02 != 0;
+
+    let convert = |v: u8| if binary { v } else { bcd_to_binary(v) };
+
+    let second = convert(raw.second) as u64;
+    let minute = convert(raw.minute) as u64;
+    let day = convert(raw.day) as u64;
+    let month = convert(raw.month) as u64;
+    let year_in_century = convert(raw.year & 0x7F) as u64;
+
+    // In 12-hour mode bit 7 of the hour register is the PM flag, and it survives
+    // the BCD conversion, so it has to come off first.
+    let hour = if twenty_four_hour {
+        convert(raw.hour) as u64
+    } else {
+        let pm = raw.hour & 0x80 != 0;
+        let h = convert(raw.hour & 0x7F) as u64;
+        match (pm, h) {
+            (false, 12) => 0,
+            (false, h) => h,
+            (true, 12) => 12,
+            (true, h) => h + 12,
+        }
+    };
+
+    // No century register is guaranteed, so the century is inferred. 70..99 maps
+    // to the 1900s and 00..69 to the 2000s, the same window the C library uses.
+    let year = if year_in_century >= 70 {
+        1900 + year_in_century
+    } else {
+        2000 + year_in_century
+    };
+
+    if !(1..=12).contains(&month) || !(1..=31).contains(&day) || hour > 23 || minute > 59
+        || second > 60
+    {
+        serial_println!(
+            "RTC returned an implausible reading: {:04}-{:02}-{:02} {:02}:{:02}:{:02}",
+            year,
+            month,
+            day,
+            hour,
+            minute,
+            second
+        );
+        return None;
+    }
+
+    let days = days_before_year(year) + days_before_month(year, month) + (day - 1);
+    Some(((days * 24 + hour) * 60 + minute) * 60 + second)
+}
+
+/// Log the clock once at boot, so a wrong reading is visible without a program
+/// having to ask for it.
+pub fn report() {
+    match unix_time() {
+        Some(secs) => {
+            let status_b = cmos_read(REG_STATUS_B);
+            serial_println!(
+                "RTC: {} seconds since the epoch ({}, {}-hour)",
+                secs,
+                if status_b & 0x04 != 0 { "binary" } else { "BCD" },
+                if status_b & 0x02 != 0 { "24" } else { "12" }
+            );
+        }
+        None => serial_println!("RTC: unreadable; time() will report ENOSYS"),
+    }
+}

--- a/kernel/src/syscall/dispatcher.rs
+++ b/kernel/src/syscall/dispatcher.rs
@@ -336,10 +336,15 @@ fn sys_getpid(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
     Ok(process_id.0 as u64)
 }
 
-fn sys_getppid(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
-    // TODO: Get actual parent process ID
-    // For now, return 0 (no parent)
-    Ok(0)
+/// Not implemented, and no longer pretending otherwise.
+///
+/// This returned `Ok(0)` under a TODO, which userspace cannot tell apart from a
+/// genuine "no parent" — and 0 is what a real `getppid` returns for the process
+/// that has none. There is no parent to report: `spawn` hands back a task id and
+/// records nothing about who called it, so a process hierarchy does not exist
+/// yet. Refusing says that; returning 0 says the opposite.
+fn sys_getppid(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
+    Err(SyscallError::NotSupported)
 }
 
 fn sys_kill(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
@@ -359,55 +364,207 @@ fn sys_kill(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
 }
 
 // Memory management system calls
+
+/// Where anonymous mappings go when the caller does not ask for an address.
+///
+/// A fixed base is safe because each process has the lower half to itself; the
+/// only thing it has to stay clear of is that process's own image and stack.
+/// 256 MiB is above every `p_vaddr` the userspace link scripts use and below the
+/// stack at [`crate::usermode::USER_STACK_TOP`].
+const MMAP_BASE: u64 = 0x0000_0000_1000_0000;
+
+/// Highest address `mmap` will hand out.
+const MMAP_LIMIT: u64 = 0x0000_0000_2000_0000;
+
+/// `mmap` flags. Only anonymous private mappings exist, so these are the only
+/// two that mean anything — but `MAP_ANONYMOUS` must be set, because it is the
+/// one argument the kernel can trust the caller to have passed deliberately.
+const MAP_ANONYMOUS: u64 = 0x20;
+#[allow(dead_code)]
+const MAP_PRIVATE: u64 = 0x02;
+
+/// `mmap(addr, length, prot, flags, fd, offset)` -> address
+///
+/// Anonymous private mappings only. What this replaces is the clearest example
+/// of the pattern this project keeps unwinding: it validated `length`, built a
+/// `MemoryProtection` struct, threw it away, and returned the constant
+/// `0x40000000` — then logged "mmap successful: mapped at 0x40000000" and
+/// returned it as a success. No frame was allocated and no page table was
+/// touched, so a caller that wrote to the pointer took a page fault, having been
+/// told the mapping existed.
+///
+/// It works now because per-process address spaces made it easy: the pages go
+/// into the calling process's own tables, so there is no shared region to
+/// arbitrate and no chance of handing out an address another program is using.
+#[cfg(target_arch = "x86_64")]
 fn sys_mmap(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
+    use x86_64::structures::paging::PageTableFlags;
+
     let addr = args[0];
     let length = args[1];
     let prot = args[2];
     let flags = args[3];
-    let _fd = args[4];
-    let _offset = args[5];
-    
-    serial_println!("Process {} requesting mmap: addr=0x{:x}, len={}, prot={}, flags={}", 
-                   process_id.0, addr, length, prot, flags);
-    
-    // Basic implementation for anonymous memory mapping
+    let fd = args[4] as i64;
+
     if length == 0 {
         return Err(SyscallError::InvalidArgument);
     }
-    
-    // Convert protection flags to MemoryProtection
-    let protection = crate::memory::vmm::MemoryProtection {
-        readable: (prot & 0x1) != 0,    // PROT_READ
-        writable: (prot & 0x2) != 0,    // PROT_WRITE
-        executable: (prot & 0x4) != 0,  // PROT_EXEC
-        user_accessible: true,
-    };
-    
-    // For now, implement simple anonymous mapping
-    // In a real implementation, we would:
-    // 1. Find suitable virtual address space
-    // 2. Allocate physical pages
-    // 3. Set up page table entries
-    
-    // Return a dummy address for now (in user space)
-    let mapped_addr = if addr == 0 {
-        0x40000000u64 // Default user space address
-    } else {
+
+    // `MAP_ANONYMOUS` has to be asked for explicitly, and `fd` is deliberately
+    // *not* consulted.
+    //
+    // Both because of a bug this test found: the first version checked
+    // `args[4] >= 0` and refused, reasoning that a non-negative fd meant a
+    // file-backed mapping. But `args[4]` arrives in R8, and a caller using a
+    // three-argument syscall wrapper never sets R8 — so the check read whatever
+    // was left in that register and refused every mapping. Discriminating on a
+    // flag the caller definitely passed is the only safe way to read an argument
+    // this ABI does not require them to set.
+    //
+    // File-backed mappings need the page-fault handler to read through the VFS,
+    // which does not exist; that is what the refusal below is about.
+    if flags & MAP_ANONYMOUS == 0 {
+        serial_println!(
+            "Process {} mmap without MAP_ANONYMOUS: file mappings are not implemented",
+            process_id.0
+        );
+        return Err(SyscallError::NotSupported);
+    }
+    let _ = fd;
+
+    let pages = (length as usize).div_ceil(crate::memory::PAGE_SIZE);
+
+    let mut page_flags = PageTableFlags::PRESENT | PageTableFlags::USER_ACCESSIBLE;
+    if prot & 0x2 != 0 {
+        page_flags |= PageTableFlags::WRITABLE;
+    }
+    if prot & 0x4 == 0 {
+        page_flags |= PageTableFlags::NO_EXECUTE;
+    }
+    // W^X, for userspace too. A caller asking for both gets neither rather than
+    // a writable code page.
+    if prot & 0x2 != 0 && prot & 0x4 != 0 {
+        serial_println!("Process {} mmap asked for write+execute; refused", process_id.0);
+        return Err(SyscallError::InvalidArgument);
+    }
+
+    let base = if addr != 0 {
+        // MAP_FIXED semantics without the flag: honour the hint exactly or fail,
+        // rather than silently moving it somewhere the caller will not look.
+        if addr % crate::memory::PAGE_SIZE as u64 != 0 {
+            return Err(SyscallError::InvalidArgument);
+        }
+        if !region_free(addr, pages) {
+            return Err(SyscallError::AddressInUse);
+        }
         addr
+    } else {
+        find_free_region(pages).ok_or(SyscallError::OutOfMemory)?
     };
-    
-    serial_println!("Process {} mmap successful: mapped at 0x{:x}", process_id.0, mapped_addr);
-    Ok(mapped_addr)
+
+    crate::memory::paging::map_user_pages(base, pages, page_flags)
+        .map_err(|e| {
+            serial_println!("Process {} mmap failed: {}", process_id.0, e);
+            SyscallError::OutOfMemory
+        })?;
+
+    if syscall_trace_enabled() {
+        serial_println!(
+            "Process {} mmap: {} page(s) at 0x{:x} (prot {}, flags {})",
+            process_id.0,
+            pages,
+            base,
+            prot,
+            flags
+        );
+    }
+
+    Ok(base)
 }
 
+#[cfg(not(target_arch = "x86_64"))]
+fn sys_mmap(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
+    Err(SyscallError::NotSupported)
+}
+
+/// Is every page of this span currently unmapped in the calling process?
+#[cfg(target_arch = "x86_64")]
+fn region_free(base: u64, pages: usize) -> bool {
+    (0..pages).all(|i| {
+        crate::memory::paging::translate(base + (i * crate::memory::PAGE_SIZE) as u64).is_none()
+    })
+}
+
+/// First `pages`-page hole in the mmap region.
+///
+/// A linear scan of the process's own tables rather than a bump pointer, because
+/// a bump pointer would need per-process state to live in and would leak address
+/// space across `munmap`. The region is 256 MiB, so the scan is bounded.
+#[cfg(target_arch = "x86_64")]
+fn find_free_region(pages: usize) -> Option<u64> {
+    let step = crate::memory::PAGE_SIZE as u64;
+    let mut base = MMAP_BASE;
+
+    while base + (pages as u64 * step) <= MMAP_LIMIT {
+        if region_free(base, pages) {
+            return Some(base);
+        }
+        base += step;
+    }
+
+    None
+}
+
+/// `munmap(addr, length)`
+///
+/// Previously a `NotSupported` under a TODO — which was at least honest, but it
+/// meant a program could not give memory back. The pages return to the frame
+/// allocator immediately.
+#[cfg(target_arch = "x86_64")]
 fn sys_munmap(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
     let addr = args[0];
     let length = args[1];
-    
-    serial_println!("Process {} requesting munmap: addr=0x{:x}, len={}", 
-                   process_id.0, addr, length);
-    
-    // TODO: Implement memory unmapping
+
+    if length == 0 || addr % crate::memory::PAGE_SIZE as u64 != 0 {
+        return Err(SyscallError::InvalidArgument);
+    }
+
+    // Only addresses this syscall could have handed out. Letting a process
+    // unmap its own `.text` is a good way to turn a userspace bug into an
+    // unexplainable fault.
+    if addr < MMAP_BASE || addr >= MMAP_LIMIT {
+        serial_println!(
+            "Process {} munmap 0x{:x} is outside the mmap region",
+            process_id.0,
+            addr
+        );
+        return Err(SyscallError::InvalidArgument);
+    }
+
+    let pages = (length as usize).div_ceil(crate::memory::PAGE_SIZE);
+    let freed = unsafe {
+        crate::memory::paging::unmap_user_pages_in(
+            crate::memory::paging::active_mapper(),
+            addr,
+            pages,
+        )
+    };
+
+    if syscall_trace_enabled() {
+        serial_println!(
+            "Process {} munmap: {} of {} page(s) at 0x{:x}",
+            process_id.0,
+            freed,
+            pages,
+            addr
+        );
+    }
+
+    Ok(freed as u64)
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn sys_munmap(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
     Err(SyscallError::NotSupported)
 }
 
@@ -527,64 +684,60 @@ fn sys_unlink(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
 }
 
 // IPC system calls
+/// `send_message(receiver, ptr, len)`
+///
+/// Not implemented, and it now says so instead of delivering something else.
+///
+/// What it used to do is the most subtle fabrication in this kernel, because
+/// most of it was real. It reached `ipc::message::send_message`, which genuinely
+/// validates the sender and receiver, checks a `SendMessage` capability and
+/// enqueues — but `args[1]`, the caller's buffer, was bound to `_message_ptr`
+/// and never read. In its place went:
+///
+/// ```text
+/// MessageData::Text(format!("Message from process {} (len={})", pid, len))
+/// ```
+///
+/// so the receiver got a synthetic string describing the message instead of the
+/// message, and the sender got `Ok(0)`.
+///
+/// Copying the payload is the easy part — `uaccess::copy_from_user` already
+/// exists. What blocks this is that there are **two unrelated id namespaces**:
+/// `syscall/entry.rs` passes the calling *thread's* id as the `ProcessId`, while
+/// `ipc::message::send_message` looks the sender up in `process::ProcessTable`,
+/// whose only entries are the three synthetic ones the boot self-test creates.
+/// A ring-3 caller is not in that table, so every send would fail
+/// `SenderNotFound` even with a real payload.
+///
+/// Reconciling those namespaces — one process table that `spawn` registers into,
+/// with the thread as a member of a process rather than a synonym for one — is
+/// the work. `kernel/src/ipc/` is ~85 KB of implemented queueing and capability
+/// machinery waiting on it.
 fn sys_send_message(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
-    let receiver_pid = args[0];
-    let _message_ptr = args[1];
-    let message_len = args[2];
-    
-    serial_println!("Process {} sending message to process {}: ptr=0x{:x}, len={}", 
-                   process_id.0, receiver_pid, _message_ptr, message_len);
-    
-    // Basic implementation using existing IPC system
-    if message_len > 4096 {
-        return Err(SyscallError::InvalidArgument);
-    }
-    
-    // Create a simple text message for demonstration
-    // In a real implementation, we would read the actual message data from user space
-    let message_data = crate::ipc::message::MessageData::Text(
-        alloc::format!("Message from process {} (len={})", process_id.0, message_len)
+    serial_println!(
+        "Process {} called send_message({}, 0x{:x}, {}): IPC needs one process-id namespace first",
+        process_id.0,
+        args[0],
+        args[1],
+        args[2]
     );
-    
-    let message = crate::ipc::message::create_message(
-        process_id,
-        ProcessId::new(receiver_pid as u32),
-        crate::ipc::message::MessageType::ServiceRequest,
-        message_data,
-    );
-    
-    match crate::ipc::message::send_message(message) {
-        Ok(()) => {
-            serial_println!("Process {} successfully sent message to process {}", 
-                           process_id.0, receiver_pid);
-            Ok(0)
-        }
-        Err(e) => {
-            serial_println!("Process {} failed to send message: {:?}", process_id.0, e);
-            Err(e.into())
-        }
-    }
+    Err(SyscallError::NotSupported)
 }
 
+/// `receive_message(timeout_ms)`
+///
+/// Not implemented, for the same reason as [`sys_send_message`]. This one did
+/// dequeue for real — and then returned only `message_id`, dropping the payload
+/// on the floor under a `// In a real implementation, we would copy the message
+/// data to user space`. A caller that got a message id had no way to read the
+/// message.
 fn sys_receive_message(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
-    let _timeout_ms = args[0];
-    
-    serial_println!("Process {} receiving message with timeout {}", process_id.0, _timeout_ms);
-    
-    // Basic implementation using existing IPC system
-    match crate::ipc::message::receive_message(process_id) {
-        Ok(message) => {
-            serial_println!("Process {} received message {} from process {}", 
-                           process_id.0, message.header.message_id.0, message.header.sender.0);
-            // Return the message ID for now
-            // In a real implementation, we would copy the message data to user space
-            Ok(message.header.message_id.0)
-        }
-        Err(e) => {
-            serial_println!("Process {} failed to receive message: {:?}", process_id.0, e);
-            Err(e.into())
-        }
-    }
+    serial_println!(
+        "Process {} called receive_message({}): IPC needs one process-id namespace first",
+        process_id.0,
+        args[0]
+    );
+    Err(SyscallError::NotSupported)
 }
 
 fn sys_reply_message(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
@@ -680,24 +833,65 @@ fn sys_sysinfo(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
     Err(SyscallError::NotSupported)
 }
 
-fn sys_time(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
-    let time_ptr = args[0];
-    
-    serial_println!("Process {} requesting time: buf=0x{:x}", process_id.0, time_ptr);
-    
-    // TODO: Implement time getting
-    // For now, return 0 (epoch time)
+/// `time()` -> seconds since the Unix epoch
+///
+/// Read from the CMOS RTC. It used to return `Ok(0)` under a TODO, which is a
+/// perfectly valid timestamp — midnight on 1 January 1970 — so a caller had no
+/// way to know the clock was fiction.
+fn sys_time(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
+    #[cfg(target_arch = "x86_64")]
+    {
+        match crate::platform::rtc::unix_time() {
+            Some(secs) => Ok(secs),
+            None => Err(SyscallError::NotSupported),
+        }
+    }
+    #[cfg(not(target_arch = "x86_64"))]
+    Err(SyscallError::NotSupported)
+}
+
+/// Clock ids, matching Linux's for the two that exist here.
+const CLOCK_REALTIME: u64 = 0;
+const CLOCK_MONOTONIC: u64 = 1;
+
+/// `clock_gettime(clock_id, timespec_ptr)`
+///
+/// `CLOCK_MONOTONIC` comes from the PIT tick counter, which is the only clock
+/// this kernel has that is guaranteed to move forwards; `CLOCK_REALTIME` comes
+/// from the RTC and therefore has one-second resolution, which the nanoseconds
+/// field reports honestly as zero rather than interpolating.
+#[cfg(target_arch = "x86_64")]
+fn sys_clock_gettime(_process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
+    let clock_id = args[0];
+    let out = args[1];
+
+    let (secs, nanos) = match clock_id {
+        CLOCK_MONOTONIC => {
+            let ms = crate::interrupts::timer::uptime_ms();
+            (ms / 1000, (ms % 1000) * 1_000_000)
+        }
+        CLOCK_REALTIME => match crate::platform::rtc::unix_time() {
+            // No sub-second source behind the RTC, so nanoseconds is 0. Faking
+            // it from the tick counter would drift against the seconds field.
+            Some(secs) => (secs, 0),
+            None => return Err(SyscallError::NotSupported),
+        },
+        _ => return Err(SyscallError::InvalidArgument),
+    };
+
+    // struct timespec { i64 tv_sec; i64 tv_nsec; }
+    let mut buf = [0u8; 16];
+    buf[..8].copy_from_slice(&secs.to_le_bytes());
+    buf[8..].copy_from_slice(&nanos.to_le_bytes());
+
+    crate::syscall::uaccess::copy_to_user(out, &buf)
+        .map_err(|_| SyscallError::InvalidArgument)?;
+
     Ok(0)
 }
 
-fn sys_clock_gettime(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
-    let clock_id = args[0];
-    let timespec_ptr = args[1];
-    
-    serial_println!("Process {} requesting clock_gettime: clock={}, buf=0x{:x}", 
-                   process_id.0, clock_id, timespec_ptr);
-    
-    // TODO: Implement high-resolution time getting
+#[cfg(not(target_arch = "x86_64"))]
+fn sys_clock_gettime(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
     Err(SyscallError::NotSupported)
 }
 
@@ -748,28 +942,87 @@ fn sys_list_capabilities(process_id: ProcessId, args: [u64; 6]) -> SyscallResult
 }
 
 // Debug system calls (only in debug builds)
+/// `debug_print(ptr, len)`
+///
+/// Prints the caller's message. It used to print
+/// `DEBUG[1]: <message at 0x800abc>` — the *address* of the string, under a
+/// `// TODO: Read string from user space and print it` — and return `Ok(0)`. A
+/// debug facility that tells you it printed something it did not read is worse
+/// than no debug facility, because you spend the time doubting the program
+/// instead of the kernel.
 fn sys_debug_print(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
-    let message_ptr = args[0];
-    let message_len = args[1];
-    
-    serial_println!("Process {} debug print: ptr=0x{:x}, len={}", 
-                   process_id.0, message_ptr, message_len);
-    
-    // TODO: Read string from user space and print it
-    println!("DEBUG[{}]: <message at 0x{:x}>", process_id.0, message_ptr);
-    
+    const MAX_DEBUG_LEN: usize = 256;
+
+    let ptr = args[0];
+    let len = args[1] as usize;
+
+    if len == 0 || len > MAX_DEBUG_LEN {
+        return Err(SyscallError::InvalidArgument);
+    }
+
+    let mut buf = [0u8; MAX_DEBUG_LEN];
+    crate::syscall::uaccess::copy_from_user(ptr, &mut buf[..len])
+        .map_err(|_| SyscallError::InvalidArgument)?;
+
+    match core::str::from_utf8(&buf[..len]) {
+        Ok(text) => {
+            serial_println!("DEBUG[{}]: {}", process_id.0, text);
+            Ok(len as u64)
+        }
+        Err(_) => Err(SyscallError::InvalidArgument),
+    }
+}
+
+/// What `debug_dump` will report.
+const DUMP_MEMORY: u64 = 0;
+const DUMP_THREADS: u64 = 1;
+const DUMP_SYSCALLS: u64 = 2;
+const DUMP_FILES: u64 = 3;
+
+/// `debug_dump(what)`
+///
+/// Dumps real kernel state to the serial log. It used to print
+/// `DEBUG DUMP[1]: type 0` and return `Ok(0)`, having dumped nothing.
+///
+/// Everything it reports is already available to the in-kernel console; the
+/// point of the syscall is that a ring-3 program can ask for it when something
+/// has gone wrong from its side.
+#[cfg(target_arch = "x86_64")]
+fn sys_debug_dump(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
+    let what = args[0];
+
+    match what {
+        DUMP_MEMORY => {
+            serial_println!("DUMP[{}] physical memory:", process_id.0);
+            crate::memory::physical::print_memory_stats();
+            crate::memory::heap::print_heap_stats();
+        }
+        DUMP_THREADS => {
+            serial_println!("DUMP[{}] threads:", process_id.0);
+            crate::task::print_threads();
+        }
+        DUMP_SYSCALLS => {
+            serial_println!(
+                "DUMP[{}] {} syscalls serviced since boot",
+                process_id.0,
+                crate::syscall::entry::syscall_count()
+            );
+        }
+        DUMP_FILES => {
+            serial_println!("DUMP[{}] {} open file(s):", process_id.0, crate::syscall::files::open_count());
+            crate::syscall::files::describe_open(|fd, path, size, offset| {
+                serial_println!("  fd {} {} ({} bytes, at {})", fd, path, size, offset);
+            });
+        }
+        _ => return Err(SyscallError::InvalidArgument),
+    }
+
     Ok(0)
 }
 
-fn sys_debug_dump(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
-    let dump_type = args[0];
-    
-    serial_println!("Process {} debug dump: type={}", process_id.0, dump_type);
-    
-    // TODO: Implement various debug dumps (memory, processes, etc.)
-    println!("DEBUG DUMP[{}]: type {}", process_id.0, dump_type);
-    
-    Ok(0)
+#[cfg(not(target_arch = "x86_64"))]
+fn sys_debug_dump(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
+    Err(SyscallError::NotSupported)
 }
 
 #[cfg(test)]

--- a/kernel/src/syscall/numbers.rs
+++ b/kernel/src/syscall/numbers.rs
@@ -68,11 +68,17 @@ pub const SYS_REVOKE_CAPABILITY: u64 = 61;
 pub const SYS_CHECK_CAPABILITY: u64 = 62;
 pub const SYS_LIST_CAPABILITIES: u64 = 63;
 
-/// Debug and testing system calls (only available in debug builds)
-// Deliberately NOT cfg(debug_assertions): userspace calls this unconditionally
-// (see userspace/shell/src/output.rs), and having the number vanish from
-// release kernels is exactly the kind of silent difference that hides bugs
-// until the release build is the one that matters.
+/// Debug and testing system calls.
+//
+// Deliberately NOT cfg(debug_assertions): a syscall number that exists in debug
+// builds and vanishes in release is exactly the kind of silent difference that
+// hides bugs until the release build is the one that matters.
+//
+// (An earlier version of this comment cited `userspace/shell/src/output.rs` as a
+// caller. That file was deleted two phases ago along with the rest of the shell's
+// fake service layer. The reasoning still holds on its own — SYS_GETDENTS, which
+// ksh does call, is above the old release-only limit of 63 — but the citation was
+// stale, which is its own small lesson about comments that name files.)
 pub const SYS_DEBUG_PRINT: u64 = 100;
 pub const SYS_DEBUG_DUMP: u64 = 101;
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -251,6 +251,11 @@ check)
         "hello from a loaded ELF binary" \
         ".bss was zeroed correctly" \
         "stack is writable and readable" \
+        "mmap gave me 8192 usable bytes" \
+        "munmap returned the pages" \
+        "CLOCK_MONOTONIC moves forwards" \
+        "debug_print echoed my message" \
+        "seconds since the epoch" \
         "ELF loader: PASS" \
         "Storage: PASS" \
         "Filesystem: PASS" \
@@ -330,6 +335,7 @@ check-cli)
         # --- the userspace shell, in ring 3 ---
         type_line "help"
         type_line "getpid"
+        type_line "date"
         type_line "pwd"
         type_line "ls"
         type_line "cat hello.txt"
@@ -396,6 +402,7 @@ check-cli)
         "NOTES.TXT" \
         "hello from ring 3 shell" \
         "type  file" \
+        " UTC" \
         "cat: /nope.txt: no such file" \
         "nosuchcommand: command not found" \
         "spawn 'hello': thread" \

--- a/userspace/hello/src/main.rs
+++ b/userspace/hello/src/main.rs
@@ -20,7 +20,22 @@ use core::panic::PanicInfo;
 
 const SYS_EXIT: u64 = 1;
 const SYS_GETPID: u64 = 5;
+const SYS_MMAP: u64 = 10;
+const SYS_MUNMAP: u64 = 11;
 const SYS_WRITE: u64 = 23;
+const SYS_CLOCK_GETTIME: u64 = 53;
+const SYS_DEBUG_PRINT: u64 = 100;
+
+/// mmap protection bits, as the kernel reads them.
+const PROT_READ: u64 = 0x1;
+const PROT_WRITE: u64 = 0x2;
+
+/// mmap flags. `MAP_ANONYMOUS` is not optional: the kernel discriminates on it
+/// rather than on `fd`, because `fd` lives in R8 and `syscall3` never sets it.
+const MAP_PRIVATE: u64 = 0x02;
+const MAP_ANONYMOUS: u64 = 0x20;
+
+const CLOCK_MONOTONIC: u64 = 1;
 
 /// Zero-initialised, so it occupies no space in the file. If the loader forgets
 /// to zero the gap between `p_filesz` and `p_memsz`, this reads as garbage.
@@ -43,12 +58,54 @@ unsafe fn syscall3(number: u64, a1: u64, a2: u64, a3: u64) -> i64 {
     ret
 }
 
+#[inline(always)]
+unsafe fn syscall4(number: u64, a1: u64, a2: u64, a3: u64, a4: u64) -> i64 {
+    let ret: i64;
+    core::arch::asm!(
+        "syscall",
+        inlateout("rax") number => ret,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        // Argument four is in R10, not RCX: `syscall` destroys RCX.
+        in("r10") a4,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack)
+    );
+    ret
+}
+
 fn write(fd: u64, bytes: &[u8]) -> i64 {
     unsafe { syscall3(SYS_WRITE, fd, bytes.as_ptr() as u64, bytes.len() as u64) }
 }
 
 fn getpid() -> i64 {
     unsafe { syscall3(SYS_GETPID, 0, 0, 0) }
+}
+
+fn mmap(length: u64, prot: u64) -> i64 {
+    // addr = 0: let the kernel choose.
+    unsafe { syscall4(SYS_MMAP, 0, length, prot, MAP_PRIVATE | MAP_ANONYMOUS) }
+}
+
+fn munmap(addr: u64, length: u64) -> i64 {
+    unsafe { syscall3(SYS_MUNMAP, addr, length, 0) }
+}
+
+fn clock_gettime(clock: u64, out: &mut [u64; 2]) -> i64 {
+    unsafe { syscall3(SYS_CLOCK_GETTIME, clock, out.as_mut_ptr() as u64, 0) }
+}
+
+fn debug_print(message: &str) -> i64 {
+    unsafe {
+        syscall3(
+            SYS_DEBUG_PRINT,
+            message.as_ptr() as u64,
+            message.len() as u64,
+            0,
+        )
+    }
 }
 
 fn exit(code: u64) -> ! {
@@ -152,8 +209,83 @@ pub extern "C" fn kosh_main() -> ! {
         print("  WARNING: stack check failed\n");
     }
 
+    // mmap: memory the program was not given at load time. Until this release
+    // `mmap` returned the constant 0x40000000 and reported success, so writing
+    // to the result faulted.
+    let mapped = mmap(8192, PROT_READ | PROT_WRITE);
+    if mapped < 0 {
+        print("  WARNING: mmap failed\n");
+    } else {
+        let p = mapped as u64 as *mut u64;
+        unsafe {
+            core::ptr::write_volatile(p, 0x1234_5678_9abc_def0);
+            core::ptr::write_volatile(p.add(1023), 0x0fed_cba9_8765_4321);
+        }
+        let ok = unsafe {
+            core::ptr::read_volatile(p) == 0x1234_5678_9abc_def0
+                && core::ptr::read_volatile(p.add(1023)) == 0x0fed_cba9_8765_4321
+        };
+        if ok {
+            print("  mmap gave me 8192 usable bytes at 0x");
+            print_hex(mapped as u64);
+            print("\n");
+        } else {
+            print("  WARNING: mmap memory did not hold its contents\n");
+        }
+
+        if munmap(mapped as u64, 8192) < 0 {
+            print("  WARNING: munmap failed\n");
+        } else {
+            print("  munmap returned the pages\n");
+        }
+    }
+
+    // A clock that moves. CLOCK_MONOTONIC comes from the PIT, so two reads
+    // either side of some work must not go backwards.
+    let mut first = [0u64; 2];
+    let mut second = [0u64; 2];
+    if clock_gettime(CLOCK_MONOTONIC, &mut first) == 0 {
+        let mut spin = 0u64;
+        for i in 0..2_000_000u64 {
+            spin = spin.wrapping_add(i);
+        }
+        core::hint::black_box(spin);
+        if clock_gettime(CLOCK_MONOTONIC, &mut second) == 0 {
+            let a = first[0] * 1_000_000_000 + first[1];
+            let b = second[0] * 1_000_000_000 + second[1];
+            if b >= a {
+                print("  CLOCK_MONOTONIC moves forwards\n");
+            } else {
+                print("  WARNING: CLOCK_MONOTONIC went backwards\n");
+            }
+        } else {
+            print("  WARNING: second clock_gettime failed\n");
+        }
+    } else {
+        print("  WARNING: clock_gettime failed\n");
+    }
+
+    // debug_print used to log the *address* of this string.
+    if debug_print("hello reached the kernel log through debug_print") < 0 {
+        print("  WARNING: debug_print failed\n");
+    } else {
+        print("  debug_print echoed my message\n");
+    }
+
     print("  exiting cleanly\n");
     exit(0)
+}
+
+fn print_hex(mut value: u64) {
+    let mut buf = [0u8; 16];
+    for i in (0..16).rev() {
+        buf[i] = match (value & 0xF) as u8 {
+            d @ 0..=9 => b'0' + d,
+            d => b'a' + (d - 10),
+        };
+        value >>= 4;
+    }
+    write(1, &buf);
 }
 
 #[panic_handler]

--- a/userspace/shell/src/main.rs
+++ b/userspace/shell/src/main.rs
@@ -257,6 +257,7 @@ fn cmd_help() {
     println("  stat <path>           file details");
     println("  history               previous commands");
     println("  parsetest             run the tokenizer over sample inputs");
+    println("  date                  the wall clock, from the RTC");
     println("  getpid                this process's id");
     println("  exit                  leave the shell");
     println("");
@@ -476,6 +477,75 @@ fn report_unsupported(parsed: &ParsedCommand) -> bool {
     false
 }
 
+/// The wall clock, from the kernel's RTC.
+///
+/// Formatted here rather than in the kernel because a shell is the right place to
+/// decide how a date looks. `sys_time` used to return `Ok(0)` under a TODO, which
+/// would have printed a confident 1970-01-01.
+fn cmd_date() {
+    let secs = sys::time();
+    if secs < 0 {
+        println("date: the kernel has no clock");
+        return;
+    }
+
+    let (y, mo, d, h, mi, s) = civil_from_unix(secs as u64);
+    print_u64_padded(y, 4);
+    print("-");
+    print_two(mo);
+    print("-");
+    print_two(d);
+    print(" ");
+    print_two(h);
+    print(":");
+    print_two(mi);
+    print(":");
+    print_two(s);
+    println(" UTC");
+}
+
+fn print_two(v: u64) {
+    if v < 10 {
+        print("0");
+    }
+    print_u64(v);
+}
+
+/// Unix seconds to a civil date. UTC only — the kernel does not know a timezone
+/// and neither does this.
+fn civil_from_unix(secs: u64) -> (u64, u64, u64, u64, u64, u64) {
+    const LENGTHS: [u64; 12] = [31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+    let is_leap = |y: u64| (y % 4 == 0 && y % 100 != 0) || y % 400 == 0;
+
+    let mut days = secs / 86_400;
+    let rem = secs % 86_400;
+
+    let mut year = 1970;
+    loop {
+        let len = if is_leap(year) { 366 } else { 365 };
+        if days < len {
+            break;
+        }
+        days -= len;
+        year += 1;
+    }
+
+    let mut month = 1;
+    loop {
+        let mut len = LENGTHS[(month - 1) as usize];
+        if month == 2 && is_leap(year) {
+            len += 1;
+        }
+        if days < len {
+            break;
+        }
+        days -= len;
+        month += 1;
+    }
+
+    (year, month, days + 1, rem / 3600, (rem % 3600) / 60, rem % 60)
+}
+
 /// Run an external program: spawn it, wait for it, report a non-zero exit.
 ///
 /// The shell blocks in the kernel's `wait` — `State::Blocked`, not a yield loop —
@@ -596,6 +666,7 @@ pub extern "C" fn ksh_main() -> ! {
             "stat" => cmd_stat(&cwd, &parsed.args),
             "history" => cmd_history(&history),
             "parsetest" => cmd_parsetest(&parser),
+            "date" => cmd_date(),
             "getpid" => {
                 print("pid ");
                 print_u64(sys::getpid() as u64);

--- a/userspace/shell/src/syscall.rs
+++ b/userspace/shell/src/syscall.rs
@@ -21,6 +21,7 @@ pub const SYS_READ: u64 = 22;
 pub const SYS_WRITE: u64 = 23;
 pub const SYS_LSEEK: u64 = 24;
 pub const SYS_STAT: u64 = 25;
+pub const SYS_TIME: u64 = 52;
 pub const SYS_GETDENTS: u64 = 70;
 
 pub const STDIN: u64 = 0;
@@ -118,6 +119,11 @@ pub fn stat(path: &str, out: &mut RawDirEntry) -> i64 {
     }
 }
 
+/// Seconds since the Unix epoch, from the CMOS RTC. Negative on failure.
+pub fn time() -> i64 {
+    unsafe { syscall(SYS_TIME, 0, 0, 0, 0) }
+}
+
 pub fn getpid() -> i64 {
     unsafe { syscall(SYS_GETPID, 0, 0, 0, 0) }
 }
@@ -133,8 +139,10 @@ pub const ENOENT: i64 = -2;
 
 /// Load a program by name and run it on its own task. Returns the task id.
 ///
-/// Not `fork`/`exec` — the kernel has one address space, so there is nothing to
-/// duplicate. The name is a boot-module name, not a filesystem path.
+/// Not `fork`/`exec`: the child starts from an ELF rather than as a copy of the
+/// caller. It does get its own address space, so it can be — and `hello` is —
+/// linked at the same address as this shell. The name is a boot-module name, not
+/// a filesystem path.
 pub fn spawn(name: &str) -> i64 {
     unsafe { syscall(SYS_SPAWN, name.as_ptr() as u64, name.len() as u64, 0, 0) }
 }


### PR DESCRIPTION
An audit of every syscall against what its handler actually does found six that returned success for work they had not performed — the exact failure mode this series has spent twelve phases unwinding, still present in the ABI.

mmap was the clearest: it validated length, built a MemoryProtection struct, threw it away, returned the constant 0x40000000 and logged "mmap successful". A caller that wrote to the pointer faulted, having been told the mapping existed. It allocates and maps real pages now — anonymous private only, in a 256 MiB window, with W^X enforced and an address found by scanning the calling process's own tables. munmap works too, and refuses anything outside that window. Per-process address spaces are what made both straightforward.

debug_print printed the *address* of the caller's string under a "// TODO: Read string from user space" and returned Ok(0); it prints the message now. debug_dump printed "type 0" and dumped nothing; it dumps memory, threads, the syscall count or open files. time returned Ok(0) — a valid timestamp, 1 Jan 1970 — and now reads the CMOS RTC, with the double-read the update-in- progress flag requires and BCD/24-hour detection rather than assumption. clock_gettime gained CLOCK_MONOTONIC from the PIT.

getppid returned Ok(0), which userspace cannot distinguish from a genuine "no parent"; it refuses. send_message substituted a synthetic string for the caller's payload and receive_message dropped the payload entirely; both refuse, because copying the buffer would only turn one fabrication into another — the real blocker is that syscall entry passes a *thread* id where the IPC layer expects a ProcessTable entry, and those namespaces are unrelated.

A bug the new test caught immediately: the first mmap discriminated file-backed mappings on args[4] >= 0, but args[4] arrives in R8 and a three-argument syscall wrapper never sets it, so the check read a stale register and refused every mapping. It discriminates on MAP_ANONYMOUS now. A syscall must not read an argument the ABI does not require the caller to set.

hello exercises mmap, munmap, clock_gettime and debug_print from ring 3, writing to the first and last word of the mapping so a present-but-wrong mapping fails. ksh gained `date`, which is the RTC end to end. Verified against the host clock.

The README described a microkernel with capability-based security, ARM64 support and a driver framework. None of that runs: the drivers are in the kernel, the capability syscalls all return NotSupported, aarch64 does not compile, and drivers/keyboard returns 0 from read_data with a comment saying it would use the PS/2 ports in a real implementation. It now says what works, what does not, and why — with the working set backed by markers.

39 boot markers and 30 console markers pass from a clean build.


Claude-Session: https://claude.ai/code/session_01P1GdpYMiKP5Gj1Jmub59gw