### PR TITLE
kernel: fork and exec

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "drivers/keyboard",
     "userspace/init",
     "userspace/hello",
+    "userspace/hello2",
     "userspace/fs-service",
     "userspace/driver-manager",
     "userspace/shell",

--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ test disk, then boots the lot:
 
 ```bash
 ./scripts/run.sh              # boot it, serial on stdio (ctrl-a x to quit)
-./scripts/run.sh --check      # boot headless, assert 39 serial markers (CI)
-./scripts/run.sh --check-cli  # drive the shell through QEMU's monitor, assert 30
+./scripts/run.sh --check      # boot headless, assert 44 serial markers (CI)
+./scripts/run.sh --check-cli  # drive the shell through QEMU's monitor, assert 31
 ./scripts/run.sh --debug      # same as plain run, plus a gdb stub on :1234
 ```
 
@@ -105,7 +105,10 @@ interaction in `--check-cli`.
 **Processes and scheduling**
 - Preemptive round-robin over kernel threads, driven by the PIT at 100 Hz
 - **Per-process address spaces**: a PML4 each, kernel's upper half shared. Two
-  programs can be — and `hello` and `ksh` are — linked at the same address
+  programs can be — and `hello`, `hello2` and `ksh` all are — linked at the
+  same address
+- **`fork` and `exec`**: the child returns from a syscall it never executed,
+  into its own copy of the parent's memory; `exec` replaces the whole image
 - **Per-thread kernel stacks**, so more than one thread can be inside a syscall
 - Real blocking: `wait` parks a thread in `State::Blocked` rather than spinning
 
@@ -128,7 +131,8 @@ interaction in `--check-cli`.
   `munmap`, `clock_gettime` and `debug_print`
 - `ksh` — a shell in ring 3 with line editing, history, arrow keys, a
   recursive-descent parser, and `ls`/`cat`/`cd`/`stat`/`date`/`getpid`
-- `ksh` can launch programs: unknown commands become `spawn` + `wait`
+- `ksh` can launch programs: unknown commands become `spawn` + `wait`, and
+  `cmd &` starts one in the background
 
 **In-kernel console**
 - A fallback shell on the same keyboard, which takes over when `ksh` exits — so
@@ -136,32 +140,37 @@ interaction in `--check-cli`.
 
 ## The syscall surface
 
-44 numbers are defined; **18 do the work** and the other 26 return an error
-saying so. Nothing returns success for work it did not do — that was true of six
-of them until recently, and fixing it is the most recent change.
+44 numbers are defined; **20 do the work** and the other 24 return an error
+saying so. Nothing returns success for work it did not do.
 
-**Working** (all 18 exercised from ring 3, not just by the kernel checking
+**Working** (all 20 exercised from ring 3, not just by the kernel checking
 itself):
 
-`exit` `wait` `getpid` `yield` `spawn` · `mmap` `munmap` · `open` `close` `read`
-`write` `lseek` `stat` `getdents` · `time` `clock_gettime` · `debug_print`
-`debug_dump`
+`exit` `fork` `exec` `wait` `getpid` `yield` `spawn` · `mmap` `munmap` · `open`
+`close` `read` `write` `lseek` `stat` `getdents` · `time` `clock_gettime` ·
+`debug_print` `debug_dump`
 
 **Refuses with `NotSupported`, honestly:**
 
-`fork` `exec` `kill` `getppid` · `mprotect` `brk` `sbrk` · `fstat` `mkdir`
-`rmdir` `unlink` · all 5 IPC calls · all 4 driver calls · all 4 capability
-calls · `uname` `sysinfo`
+`kill` `getppid` · `mprotect` `brk` `sbrk` · `fstat` `mkdir` `rmdir` `unlink` ·
+all 5 IPC calls · all 4 driver calls · all 4 capability calls · `uname`
+`sysinfo`
 
 ## What does not work
 
 Being explicit about this, because the earlier version of this file claimed most
 of it.
 
-- **No `fork`.** Every process starts from an ELF. Duplicating a running address
-  space needs copy-on-write and a `#PF` handler that does the copying.
+- **`fork` copies eagerly.** Every owned page is duplicated immediately rather
+  than shared copy-on-write. That is correct `fork` semantics at the cost of one
+  memcpy per page — forking `ksh` copies about 400 KiB — and it is deliberate:
+  copy-on-write needs a per-frame reference count, and getting that wrong
+  produces double frees that surface somewhere unrelated, much later.
 - **No demand paging.** Every page of a program is populated at load time, so
-  `ksh`'s 256 KiB `.bss` costs 65 frames whether it is touched or not.
+  `ksh`'s 256 KiB `.bss` costs 65 frames whether it is touched or not — and a
+  `fork` copies all 65.
+- **No `argv`.** `exec` takes a program name and nothing else; passing arguments
+  needs somewhere to put the strings in the new address space.
 - **The filesystem is read-only.** `ksh` refuses redirection rather than
   pretending; there is no `mkdir`, `unlink` or write path.
 - **No IPC from userspace.** `kernel/src/ipc/` is ~85 KB of real queueing and
@@ -216,6 +225,7 @@ kernel/src/
   platform/rtc.rs  CMOS real-time clock
 userspace/
   hello/           static ELF that proves the loader and the newer syscalls
+  hello2/          what hello execs into — a different image at the same address
   shell/           ksh
 docs/BOOT.md       how all of the above actually works
 scripts/run.sh     build, ISO, disk image, boot, and the two CI gates
@@ -236,7 +246,9 @@ Roughly in order, each unblocking the next:
 - [x] ATA + read-only FAT32
 - [x] A shell in userspace that can launch programs
 - [x] Per-process address spaces
-- [ ] `fork` with copy-on-write, and demand paging
+- [x] `fork` and `exec`
+- [ ] Copy-on-write and demand paging, so a `fork` costs a page table rather
+      than a program
 - [ ] One process-id namespace, so the IPC and capability machinery becomes
       reachable from ring 3
 - [ ] Move the disk and filesystem out of the kernel — the point of the whole

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -1268,6 +1268,137 @@ It writes to the first and last word of the mapping and reads both back, so a
 mapping that is present but wrong fails rather than passing. `ksh` gained `date`,
 which is the RTC end to end: RTC → `sys_time` → ring 3 → civil date.
 
+## fork and exec (Phase 14)
+
+Every process so far started from an ELF, via `spawn`. `fork` produces a process
+from a *running* one, which is a different problem: the child has to appear in
+ring 3 at the parent's next instruction, with the parent's registers and its own
+copy of the parent's memory, without ever having executed the `syscall`
+instruction that created it.
+
+```
+Thread 1 forking: 20 page(s) copied into PML4 0x5c5000
+  forked thread 2 (kernel stack 0xffff90000005cdd0, resumes in ring 3 at 0x800f5c)
+  child: my copy of the witness is mine
+Thread 2 exec 'hello2':
+  old image released: 26 frame(s)
+  entering 'hello2' at 0x800000
+  hello2 here: exec replaced the whole image
+  parent: the child did not touch my memory
+  child exec'd and exited 7
+```
+
+### The control-flow half
+
+`0x800f5c` above is the instruction after the parent's `syscall`. The child gets
+there entirely through the layout of its kernel stack, written by
+`task::spawn_forked`. From the top down:
+
+```text
+  top-8    frame.user_rsp        a copy of the parent's SyscallFrame,
+  ...        ...                 highest field first
+  top-80   frame.rax  = 0
+  top-88   return address = kosh_syscall_return
+  top-96   rbp                   the switch frame kosh_switch_context pops
+  ...        ...
+  top-144  rflags
+```
+
+`kosh_switch_context` pops the seven-word switch frame and `ret`s, which leaves
+RSP at `top-80` — exactly the base of the `SyscallFrame` — with RIP at
+`kosh_syscall_return`. That is the tail of the syscall stub, newly given a label:
+it pops the frame and `sysretq`s. The child runs no kernel code written for it.
+
+`rax = 0` is the entire fork convention. The parent's `sys_fork` returns the
+child's id; the child's frame carries a zero.
+
+The parent's user RSP is reused unchanged, which is correct *only* because the
+child has its own address space: the same number names the child's own copy of
+that stack. Under the shared lower half of two phases ago, both would have been
+using one stack.
+
+### The memory half
+
+`AddressSpace::fork` copies the parent's lower half — same contents at the same
+addresses, in different frames. Leaves without `OWNED_BY_ADDRESS_SPACE` are
+frames the parent borrowed (the built-in payload lives in the kernel image) and
+are mapped into the child by reference; copying one would give the child a
+private duplicate of the kernel's `.user` section.
+
+**Eager, not copy-on-write, deliberately.** The textbook implementation marks
+both copies read-only, shares the frames, and copies one page at a time in the
+page-fault handler. That needs a per-frame reference count, and a reference count
+that is wrong produces double frees and use-after-free of page tables — memory
+corruption that surfaces somewhere unrelated, much later. An eager copy is
+*correct* fork semantics at a cost of one memcpy per page; forking `ksh` copies
+about 400 KiB. The cost is real and worth stating plainly: without an `exec`
+following, a fork is pure waste, and with demand paging an untouched `.bss` would
+not need copying at all. Both are the next piece of work.
+
+### exec
+
+A fresh address space with the new image, swapped in, and the old one freed —
+in that order, because freeing first hands the page tables the CPU is walking to
+the allocator.
+
+The new space is built *completely* before anything is disturbed. An `exec` that
+fails half-way has destroyed the only thing it could return to, so a load failure
+has to leave the caller running its current program.
+
+`exec` does not need the caller's register frame; there is nothing to return to.
+The syscall frame on the kernel stack is simply abandoned when `enter_ring3`
+takes over.
+
+### Where fork had to be intercepted
+
+`dispatch_syscall` takes `(pid, number, args)` — arguments, not registers. `fork`
+is the one syscall that needs the whole frame, so `kosh_syscall_handler` handles
+it before dispatching rather than threading a `&mut SyscallFrame` through a
+signature every other handler would ignore. The dispatcher's `sys_fork` still
+exists, and logs `BUG:` if it is ever reached.
+
+### Proving it
+
+`hello` writes a witness value, forks, and both sides write a different one. If
+the address spaces were shared, the child's write would be visible to the parent.
+`hello2` is a separate program linked at the same address as `hello` and `ksh`,
+so the only evidence `exec` worked is that something else is running there.
+
+Making `fork_from` share the lower half instead of copying it — one line — is
+more instructive than expected:
+
+```
+Thread 1 forking: 0 page(s) copied into PML4 0x5c4000
+  child: my copy of the witness is mine
+Thread 2 exec 'hello2':
+  old image released: 26 frame(s)
+...
+Process 1 syscall wait failed: InvalidArgument
+
+==================== PAGE FAULT ====================
+  accessed address : 0x0000000000800f84
+  cause            : page not present while fetching an instruction in user mode
+```
+
+The child's `exec` freed the *parent's* pages, because they were the same pages,
+and the parent then faulted fetching its own `.text`. Five markers fail.
+
+### One refusal that had outlived its reason
+
+`ksh` refused `cmd &` with "background jobs need fork". They do not, quite: what
+a background job needs is a way to start a program and *not* block, which `spawn`
+has provided since Phase 10. The refusal was written when it was true and never
+revisited.
+
+```
+ksh:/$ hello2 &
+[3] hello2
+ksh:/$   hello2 here: exec replaced the whole image
+```
+
+No job control — no `jobs`, no `fg`, no notification on exit. The task id is
+printed so a `wait` is at least possible by hand.
+
 ## What is deliberately still missing
 - **The filesystem is read-only.** Allocating clusters and keeping both FAT
   copies consistent is a separate problem, and a read-only filesystem that is

--- a/kernel/src/memory/address_space.rs
+++ b/kernel/src/memory/address_space.rs
@@ -85,6 +85,38 @@ impl AddressSpace {
         self.pml4_phys
     }
 
+    /// A copy of this address space: same contents at the same addresses, in
+    /// different frames.
+    ///
+    /// ## Eager, not copy-on-write
+    ///
+    /// Every owned page is duplicated immediately. The textbook implementation
+    /// marks both copies read-only, shares the frames, and copies one page at a
+    /// time in the page-fault handler — which is faster, and is what makes
+    /// `fork` cheap enough to be followed immediately by `exec`.
+    ///
+    /// It is not done here, deliberately. Copy-on-write needs a per-frame
+    /// reference count, and getting that wrong produces double frees and
+    /// use-after-free of page tables: memory corruption that shows up somewhere
+    /// unrelated, much later. An eager copy is *correct* `fork` semantics — a
+    /// child that sees the parent's memory as it was and diverges from there —
+    /// at a cost of one memcpy per page. Forking `ksh` copies about 400 KiB.
+    ///
+    /// The cost is real and worth stating: without `exec` following, a fork is
+    /// pure waste, and with demand paging a program's untouched `.bss` would not
+    /// need copying at all. Both are the next piece of work.
+    ///
+    /// ## Shared versus copied
+    ///
+    /// A leaf without [`OWNED_BY_ADDRESS_SPACE`] is a frame this space borrowed
+    /// — the built-in ring-3 payload lives in the kernel image — and is mapped
+    /// into the child *by reference*, exactly as it is here. Copying it would
+    /// hand the child a private duplicate of the kernel's own `.user` section,
+    /// and freeing that duplicate would be freeing a kernel frame.
+    pub fn fork(&self) -> Result<(Self, usize), &'static str> {
+        fork_from(self.pml4_phys)
+    }
+
     /// Load this space into CR3.
     ///
     /// # Safety
@@ -158,6 +190,95 @@ unsafe fn free_level(table_phys: u64, level: u8) -> usize {
     // The table itself.
     deallocate_frame(PageFrame::from_address(table_phys as usize));
     freed + 1
+}
+
+/// [`AddressSpace::fork`], over a bare PML4 address.
+///
+/// The caller has the parent's PML4 but not an owning handle to it — the handle
+/// lives in the thread table behind a lock, and holding that lock across a
+/// memcpy per page would block the timer interrupt for the whole copy.
+pub fn fork_from(parent_pml4: u64) -> Result<(AddressSpace, usize), &'static str> {
+    let child = AddressSpace::new_user()?;
+    let mut copied = 0;
+
+    unsafe {
+        let parent = &*((PHYSMAP_BASE + parent_pml4) as *const PageTable);
+        let target = &mut *((PHYSMAP_BASE + child.pml4_phys) as *mut PageTable);
+
+        for i in 0..KERNEL_PML4_FIRST {
+            if parent[i].is_unused() {
+                continue;
+            }
+            match clone_level(parent[i].addr().as_u64(), parent[i].flags(), 3) {
+                Ok((frame, n)) => {
+                    target[i].set_addr(PhysAddr::new(frame), parent[i].flags());
+                    copied += n;
+                }
+                Err(e) => {
+                    // Partial copy: hand the whole thing back rather than
+                    // leaving the caller with half an address space.
+                    child.free();
+                    return Err(e);
+                }
+            }
+        }
+    }
+
+    Ok((child, copied))
+}
+
+/// Duplicate one level of page tables, allocating a new table and recursing.
+///
+/// Returns the new table's frame and how many *data* pages were copied under it.
+unsafe fn clone_level(
+    table_phys: u64,
+    _flags: PageTableFlags,
+    level: u8,
+) -> Result<(u64, usize), &'static str> {
+    let new_frame = allocate_frame().ok_or("out of memory forking page tables")?;
+    let new_phys = new_frame.address() as u64;
+
+    let source = &*((PHYSMAP_BASE + table_phys) as *const PageTable);
+    let target = &mut *((PHYSMAP_BASE + new_phys) as *mut PageTable);
+    target.zero();
+
+    let mut copied = 0;
+
+    for i in 0..512 {
+        if source[i].is_unused() {
+            continue;
+        }
+
+        let flags = source[i].flags();
+        let addr = source[i].addr().as_u64();
+
+        if level == 1 || flags.contains(PageTableFlags::HUGE_PAGE) {
+            if flags.contains(OWNED_BY_ADDRESS_SPACE) {
+                // A page this process owns: give the child its own copy.
+                let copy = match allocate_frame() {
+                    Some(f) => f.address() as u64,
+                    None => return Err("out of memory forking a page"),
+                };
+                core::ptr::copy_nonoverlapping(
+                    (PHYSMAP_BASE + addr) as *const u8,
+                    (PHYSMAP_BASE + copy) as *mut u8,
+                    crate::memory::PAGE_SIZE,
+                );
+                target[i].set_addr(PhysAddr::new(copy), flags);
+                copied += 1;
+            } else {
+                // Borrowed. Share it, and leave it untagged in the child too, so
+                // neither teardown tries to free it.
+                target[i].set_addr(PhysAddr::new(addr), flags);
+            }
+        } else {
+            let (child_table, n) = clone_level(addr, flags, level - 1)?;
+            target[i].set_addr(PhysAddr::new(child_table), flags);
+            copied += n;
+        }
+    }
+
+    Ok((new_phys, copied))
 }
 
 /// Check that every address space still agrees with the kernel about the upper

--- a/kernel/src/syscall/dispatcher.rs
+++ b/kernel/src/syscall/dispatcher.rs
@@ -194,23 +194,19 @@ fn sys_exit(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
     Ok(0)
 }
 
-/// Not implemented, and now says so.
+/// Never reached.
 ///
-/// This used to add a row to the process table, log "Fork successful", and
-/// return the new PID — without duplicating an address space, copying a stack,
-/// or creating anything that could run. Userspace saw a positive return value,
-/// concluded it was the parent, and carried on; the "child" never existed. A
-/// syscall that reports success for work it did not do is worse than one that
-/// refuses, because the caller has no way to find out.
-///
-/// Honest `fork` needs per-process page tables, which needs the kernel out of
-/// the low identity mapping first. Until then, `Err`.
+/// `fork` needs the caller's whole register frame, not just its arguments, so
+/// `kosh_syscall_handler` intercepts it before the dispatcher and calls
+/// `syscall::fork::sys_fork` directly. This entry exists so the dispatch table
+/// stays exhaustive, and returns an error that would be a real bug if anyone
+/// ever saw it.
 fn sys_fork(process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
     serial_println!(
-        "Process {} called fork, which needs per-process address spaces (not implemented)",
+        "BUG: fork reached the dispatcher for process {} — the entry stub should have taken it",
         process_id.0
     );
-    Err(SyscallError::NotSupported)
+    Err(SyscallError::InternalError)
 }
 
 /// Give up the rest of the current time slice.
@@ -227,20 +223,20 @@ fn sys_yield(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
     Ok(0)
 }
 
-fn sys_exec(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
-    let path_ptr = args[0];
-    let argv_ptr = args[1];
-    let envp_ptr = args[2];
-    
-    serial_println!("Process {} attempting to exec program at 0x{:x}", process_id.0, path_ptr);
-    
-    // TODO: Implement program execution
-    // This would involve:
-    // 1. Loading the new program from filesystem
-    // 2. Setting up new memory space
-    // 3. Parsing arguments and environment
-    // 4. Starting execution at program entry point
-    
+/// `exec(path, path_len)` — replaces the calling program, never returns.
+///
+/// The implementation is in `syscall::fork`, next to `fork`, because the two are
+/// halves of one mechanism and share the address-space plumbing.
+///
+/// This used to be a `serial_println!` and `Err(NotSupported)` under a four-line
+/// TODO listing what a real implementation would involve.
+#[cfg(target_arch = "x86_64")]
+fn sys_exec(_process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
+    crate::syscall::fork::sys_exec(args)
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn sys_exec(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
     Err(SyscallError::NotSupported)
 }
 

--- a/kernel/src/syscall/entry.rs
+++ b/kernel/src/syscall/entry.rs
@@ -39,7 +39,10 @@ use crate::serial_println;
 
 /// Registers the stub pushes, in push order (so the first field is at the
 /// lowest address — the layout the stub builds by pushing RAX last).
+///
+/// `Copy`, because `fork` has to duplicate one onto the child's kernel stack.
 #[repr(C)]
+#[derive(Debug, Clone, Copy)]
 pub struct SyscallFrame {
     pub rax: u64,
     pub rdi: u64,
@@ -65,6 +68,11 @@ pub struct SyscallFrame {
 
 extern "C" {
     fn kosh_syscall_entry();
+    /// Tail of the syscall stub: pops a [`SyscallFrame`] and `sysretq`s.
+    ///
+    /// Not called — jumped to, by `ret`, from a stack `task::spawn_forked` laid
+    /// out. Declaring it here is how its address is obtained.
+    pub fn kosh_syscall_return();
 }
 
 core::arch::global_asm!(
@@ -108,6 +116,17 @@ kosh_syscall_entry:
 
     movq    %rax, (%rsp)        /* return value into frame.rax */
 
+/* The return path, entered with RSP pointing at a complete SyscallFrame whose
+   rax already holds the value to give the caller.
+
+   Exposed as a symbol because a forked child has to come out here without ever
+   having executed the `syscall` instruction: `fork` builds a copy of the
+   parent's frame on the child's fresh kernel stack, with rax set to 0, and
+   arranges for the context switch to `ret` straight to this label. The child
+   then returns to ring 3 at the parent's RIP, on the parent's user RSP — which
+   in the child's address space is its own copy of that stack. */
+.global kosh_syscall_return
+kosh_syscall_return:
     popq    %rax
     popq    %rdi
     popq    %rsi
@@ -132,6 +151,18 @@ pub extern "C" fn kosh_syscall_handler(frame: &mut SyscallFrame) -> u64 {
 
     SYSCALL_COUNT.fetch_add(1, Ordering::Relaxed);
 
+    // `fork` is the one syscall that needs the caller's register frame rather
+    // than just its arguments: the child returns to exactly where the parent
+    // called from. Handled here instead of threading a `&mut SyscallFrame`
+    // through `dispatch_syscall`, which every other handler would have to
+    // ignore.
+    if number == crate::syscall::numbers::SYS_FORK {
+        return match crate::syscall::fork::sys_fork(frame) {
+            Ok(v) => v,
+            Err(e) => negative_errno(e),
+        };
+    }
+
     // The calling thread's id, which is now a real answer rather than the
     // hardcoded `1` this used while only one thread could be in ring 3. It is
     // also what `spawn` returns and what `wait` takes, so a log line naming a
@@ -153,11 +184,22 @@ pub extern "C" fn kosh_syscall_handler(frame: &mut SyscallFrame) -> u64 {
             // something named "errno". Negating it here — the obvious thing to
             // write — flips errors positive, and userspace then reads every
             // failure as success. Normalise instead of assuming.
-            let errno = err.to_errno() as i64;
-            let negative = if errno > 0 { -errno } else { errno };
-            negative as u64
+            negative_errno(err)
         }
     }
+}
+
+/// Normalise a `SyscallError` into the negative value userspace tests the sign
+/// of.
+///
+/// `to_errno()` already returns *negative* numbers (-22 for EINVAL, and so on),
+/// which is unusual for something named "errno". Negating it — the obvious thing
+/// to write — flips errors positive, and userspace then reads every failure as
+/// success.
+fn negative_errno(err: crate::syscall::SyscallError) -> u64 {
+    let errno = err.to_errno() as i64;
+    let negative = if errno > 0 { -errno } else { errno };
+    negative as u64
 }
 
 static SYSCALL_COUNT: AtomicU64 = AtomicU64::new(0);

--- a/kernel/src/syscall/fork.rs
+++ b/kernel/src/syscall/fork.rs
@@ -1,0 +1,122 @@
+//! `fork` and `exec`.
+//!
+//! ## What was here before
+//!
+//! `sys_fork` used to add a row to the process table, log "Fork successful", and
+//! return the new PID — for a child with no address space, no stack, no context
+//! and no way to run. Userspace read the positive return value, concluded it was
+//! the parent, and carried on. It was replaced by an honest `NotSupported` three
+//! phases ago; this is the implementation that refusal was waiting for.
+//!
+//! ## The two halves of fork
+//!
+//! **Memory** is [`AddressSpace::fork`]: a copy of the parent's lower half, same
+//! contents at the same addresses in different frames.
+//!
+//! **Control flow** is [`crate::task::spawn_forked`]. The child has to appear in
+//! ring 3 at the parent's RIP with the parent's registers and `rax = 0`, without
+//! ever having executed the `syscall` instruction. That is arranged by writing a
+//! copy of the parent's `SyscallFrame` onto the child's fresh kernel stack and
+//! pointing the context switch's `ret` at the syscall stub's return path.
+//!
+//! The parent's user RSP is reused unchanged, which is only correct because the
+//! child has its own address space: the same number names the child's own copy
+//! of that stack.
+//!
+//! ## Why `spawn` still exists
+//!
+//! `spawn` is `fork`+`exec` fused, and it is what a shell should keep using when
+//! it has nothing to do between the two. The pair earns its place when there
+//! *is* something to do in the child before the new image arrives — setting up
+//! redirections, closing descriptors — which is the shape a shell needs and
+//! which `spawn` cannot express.
+
+use crate::serial_println;
+use crate::syscall::entry::SyscallFrame;
+use crate::syscall::{SyscallError, SyscallResult};
+
+/// `fork()` -> child task id in the parent, 0 in the child
+///
+/// Reached directly from `kosh_syscall_handler` rather than through the
+/// dispatcher, because it is the one syscall that needs the caller's whole
+/// register frame and not just its arguments.
+pub fn sys_fork(frame: &SyscallFrame) -> SyscallResult {
+    let parent = crate::task::current_id();
+
+    // A thread with no address space of its own is a kernel thread. Forking one
+    // would produce a child with a user register frame and nowhere to run it.
+    let space = match crate::task::current_address_space_pml4() {
+        Some(pml4) => pml4,
+        None => {
+            serial_println!("Thread {} called fork without an address space", parent);
+            return Err(SyscallError::NotSupported);
+        }
+    };
+
+    // Takes the PML4 by value rather than an `&AddressSpace`, because the space
+    // is owned by the thread table and borrowing it across a lock we would have
+    // to hold for the whole copy is worse than passing the one number the copy
+    // needs.
+    let (child_space, copied) = crate::memory::address_space::fork_from(space).map_err(|e| {
+        serial_println!("fork failed: {}", e);
+        SyscallError::OutOfMemory
+    })?;
+
+    serial_println!(
+        "Thread {} forking: {} page(s) copied into PML4 0x{:x}",
+        parent,
+        copied,
+        child_space.pml4_phys()
+    );
+
+    match crate::task::spawn_forked("forked", frame, child_space) {
+        Ok(child) => {
+            crate::usermode::register_forked(child, parent);
+            Ok(child as u64)
+        }
+        Err(e) => {
+            serial_println!("fork could not create a thread: {}", e);
+            Err(SyscallError::ResourceExhausted)
+        }
+    }
+}
+
+/// `exec(path_ptr, path_len)` — never returns on success
+///
+/// Replaces the calling thread's program: a new address space with the named
+/// boot module loaded, swapped in, and entered. The old address space is freed
+/// once the new one is live.
+///
+/// Unlike `fork`, this does not need the caller's register frame — there is
+/// nothing to return to. The syscall frame on the kernel stack is simply
+/// abandoned when `enter_ring3` takes over.
+pub fn sys_exec(args: [u64; 6]) -> SyscallResult {
+    let name = crate::syscall::files::path_from_user(args[0], args[1])?;
+    let name = name.trim_start_matches('/');
+
+    let thread = crate::task::current_id();
+
+    if crate::task::current_address_space_pml4().is_none() {
+        serial_println!("Thread {} called exec without an address space", thread);
+        return Err(SyscallError::NotSupported);
+    }
+
+    serial_println!("Thread {} exec '{}':", thread, name);
+
+    // Build the replacement completely before disturbing anything. A failure
+    // here has to leave the caller running its current program — an `exec` that
+    // half-succeeds has destroyed the only thing it could return to.
+    let (space, entry) = crate::usermode::prepare_named_program(name)?;
+
+    crate::usermode::rename_program(thread, name);
+
+    // Swap, then free. The new space is in CR3 before the old one is touched;
+    // the reverse order frees the page tables the CPU is walking.
+    if let Some(old) = crate::task::replace_address_space(space) {
+        let freed = unsafe { old.free() };
+        serial_println!("  old image released: {} frame(s)", freed);
+    }
+
+    serial_println!("  entering '{}' at 0x{:x}", name, entry);
+    unsafe { crate::usermode::enter_ring3_at(entry, crate::usermode::USER_STACK_TOP) }
+}

--- a/kernel/src/syscall/mod.rs
+++ b/kernel/src/syscall/mod.rs
@@ -5,6 +5,7 @@ use crate::{serial_println, println};
 pub mod dispatcher;
 pub mod entry;
 pub mod files;
+pub mod fork;
 pub mod numbers;
 pub mod uaccess;
 pub mod validation;

--- a/kernel/src/syscall/validation.rs
+++ b/kernel/src/syscall/validation.rs
@@ -127,22 +127,21 @@ fn validate_fork_args(args: &[u64; 6]) -> Result<(), SyscallError> {
     Ok(())
 }
 
+/// `exec(path_ptr, path_len)`.
+///
+/// The same shape as `spawn`: an explicit length rather than a NUL terminator,
+/// so the span can be bound-checked before the kernel walks user memory. The
+/// previous version validated `args[1]` and `args[2]` as `argv`/`envp` pointer
+/// arrays, which this ABI does not have — and `argv` support needs somewhere to
+/// put the strings in the new address space, which is its own job.
 fn validate_exec_args(process_id: ProcessId, args: &[u64; 6]) -> Result<(), SyscallError> {
     let path_ptr = args[0];
-    let argv_ptr = args[1];
-    let envp_ptr = args[2];
-    
-    validate_user_string(process_id, path_ptr, 4096)?;
-    
-    if argv_ptr != 0 {
-        validate_user_pointer(process_id, argv_ptr, 8, false)?; // At least one pointer
+    let path_len = args[1];
+
+    if path_len == 0 || path_len > 255 {
+        return Err(SyscallError::InvalidArgument);
     }
-    
-    if envp_ptr != 0 {
-        validate_user_pointer(process_id, envp_ptr, 8, false)?; // At least one pointer
-    }
-    
-    Ok(())
+    validate_user_pointer(process_id, path_ptr, path_len as usize, false)
 }
 
 /// `wait(task_id, status_ptr)`.

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -250,6 +250,150 @@ pub fn spawn(name: &'static str, entry: fn(usize), arg: usize) -> Result<usize, 
     })
 }
 
+/// Create a thread that will return from a system call it never executed.
+///
+/// This is what `fork` needs and what `spawn` cannot express. A normal thread
+/// starts at a Rust `fn(usize)`; a forked child has to appear in ring 3 at the
+/// parent's RIP, on the parent's user RSP, with every register the parent had
+/// and `rax` set to 0.
+///
+/// It is arranged entirely by how the child's kernel stack is laid out. From the
+/// top down:
+///
+/// ```text
+///   top-8    frame.user_rsp        the SyscallFrame the syscall stub's tail
+///   ...        ...                 expects, highest field first
+///   top-80   frame.rax  = 0
+///   top-88   return address = kosh_syscall_return
+///   top-96   rbp                   the switch frame kosh_switch_context pops
+///   ...        ...
+///   top-144  rflags
+/// ```
+///
+/// `kosh_switch_context` pops the seven-word switch frame and `ret`s, which
+/// leaves RSP at `top-80` — exactly the base of the `SyscallFrame` — with RIP at
+/// `kosh_syscall_return`. That code pops the frame and `sysretq`s. The child has
+/// never run a single instruction of kernel code written for it.
+///
+/// The parent's user RSP is used unchanged, which is correct precisely because
+/// the child has its own address space: the same number names the child's own
+/// copy of that stack.
+pub fn spawn_forked(
+    name: &'static str,
+    frame: &crate::syscall::entry::SyscallFrame,
+    space: AddressSpace,
+) -> Result<usize, &'static str> {
+    let mut stack = alloc::vec![0u8; STACK_SIZE].into_boxed_slice();
+    let top = (stack.as_mut_ptr() as u64 + stack.len() as u64) & !0xF;
+
+    let mut child_frame = *frame;
+    // The one difference between parent and child, and the whole of the fork
+    // convention: the parent gets the child's id, the child gets 0.
+    child_frame.rax = 0;
+
+    unsafe {
+        let put = |offset: u64, value: u64| {
+            core::ptr::write((top - offset) as *mut u64, value);
+        };
+
+        // The SyscallFrame, in the layout the stub's tail pops.
+        put(8, child_frame.user_rsp);
+        put(16, child_frame.rflags);
+        put(24, child_frame.rip);
+        put(32, child_frame.r9);
+        put(40, child_frame.r8);
+        put(48, child_frame.r10);
+        put(56, child_frame.rdx);
+        put(64, child_frame.rsi);
+        put(72, child_frame.rdi);
+        put(80, child_frame.rax);
+
+        // Where `ret` goes.
+        put(88, crate::syscall::entry::kosh_syscall_return as usize as u64);
+
+        // The switch frame. Callee-saved registers do not matter — the frame
+        // above overwrites everything the child will actually use — but they
+        // have to be *there*, because the switch pops them.
+        put(96, 0); // rbp
+        put(104, 0); // rbx
+        put(112, 0); // r12
+        put(120, 0); // r13
+        put(128, 0); // r14
+        put(136, 0); // r15
+
+        // IF clear: the switch happens inside the scheduler with interrupts off.
+        // The child's real RFLAGS come from the frame, at `sysretq`.
+        put(144, 0x0000_0002);
+    }
+
+    let rsp = top - 144;
+
+    without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+
+        let slot = sched
+            .threads
+            .iter()
+            .position(|t| t.is_none())
+            .ok_or("thread table full")?;
+
+        sched.threads[slot] = Some(Thread {
+            id: slot,
+            name,
+            rsp,
+            _stack: Some(stack),
+            kernel_stack_top: top,
+            state: State::Ready,
+            // No entry function: this thread never enters Rust.
+            entry: None,
+            ticks: 0,
+            address_space: Some(space),
+            exit_code: 0,
+            awaited: false,
+        });
+
+        serial_println!(
+            "  forked thread {} (kernel stack 0x{:x}, resumes in ring 3 at 0x{:x})",
+            slot,
+            top,
+            child_frame.rip
+        );
+        Ok(slot)
+    })
+}
+
+/// PML4 of the running thread's own address space, if it has one.
+///
+/// `None` means the thread is running on the kernel's tables — a kernel thread,
+/// which cannot be forked.
+pub fn current_address_space_pml4() -> Option<u64> {
+    without_interrupts(|| {
+        let sched = SCHEDULER.lock();
+        let current = sched.current;
+        sched.threads[current]
+            .as_ref()
+            .and_then(|t| t.address_space.as_ref())
+            .map(|a| a.pml4_phys())
+    })
+}
+
+/// Swap the running thread's address space, returning the old one.
+///
+/// `exec`'s half of the work. The new space is activated before the old is
+/// handed back, so the caller can free it — which is safe only in that order,
+/// and only because this runs on a kernel stack the two spaces share.
+pub fn replace_address_space(space: AddressSpace) -> Option<AddressSpace> {
+    without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+        let current = sched.current;
+        let thread = sched.threads[current].as_mut()?;
+        let old = thread.address_space.replace(space);
+        // Safe: everything executing right now is in the shared upper half.
+        unsafe { thread.address_space.as_ref().unwrap().activate() };
+        old
+    })
+}
+
 /// Begin preempting. Called once the demo threads exist.
 pub fn start() {
     ENABLED.store(true, Ordering::SeqCst);

--- a/kernel/src/usermode.rs
+++ b/kernel/src/usermode.rs
@@ -418,6 +418,71 @@ pub fn spawn_program(name: &str) -> Result<usize, SpawnError> {
     }
 }
 
+/// Build an address space with the named boot module loaded, ready to enter.
+///
+/// The `exec` half of the loader path: same work `spawn_program` does, without
+/// creating a thread, because `exec` reuses the caller's.
+pub fn prepare_named_program(
+    name: &str,
+) -> Result<(AddressSpace, u64), crate::syscall::SyscallError> {
+    use crate::syscall::SyscallError;
+
+    let module = boot_module_named(name).ok_or(SyscallError::NotFound)?;
+    let image = unsafe { module.bytes() };
+
+    prepare_program(image).map_err(|e| match e {
+        SpawnError::NotFound => SyscallError::NotFound,
+        SpawnError::Space(_) | SpawnError::Map(_) => SyscallError::OutOfMemory,
+        SpawnError::Load(_) => SyscallError::InvalidArgument,
+        _ => SyscallError::ResourceExhausted,
+    })
+}
+
+/// Record a forked child in the program table, inheriting its parent's name.
+///
+/// Not a new program — a second thread running the same one — so it gets the
+/// parent's name with a marker, which is what makes a `fork` visible in the log
+/// without pretending a new image was loaded.
+pub fn register_forked(child: usize, parent: usize) {
+    let mut table = PROGRAMS.lock();
+
+    let parent_name = table
+        .iter()
+        .flatten()
+        .find(|p| p.thread == parent)
+        .map(|p| p.name)
+        .unwrap_or_else(|| name_bytes("forked"));
+
+    let Some(slot) = table.iter().position(|s| s.is_none()) else {
+        serial_println!("  (no program slot for the fork of thread {})", parent);
+        return;
+    };
+
+    table[slot] = Some(Program {
+        thread: child,
+        name: parent_name,
+        entry: 0,
+        stack_top: 0,
+        space: None,
+    });
+}
+
+/// Point a thread's program entry at a different name, after `exec`.
+pub fn rename_program(thread: usize, name: &str) {
+    let mut table = PROGRAMS.lock();
+    if let Some(p) = table.iter_mut().flatten().find(|p| p.thread == thread) {
+        p.name = name_bytes(name);
+    } else if let Some(slot) = table.iter().position(|s| s.is_none()) {
+        table[slot] = Some(Program {
+            thread,
+            name: name_bytes(name),
+            entry: 0,
+            stack_top: 0,
+            space: None,
+        });
+    }
+}
+
 /// Entry point of a spawned thread: take the address space, switch to it, and
 /// drop to ring 3.
 fn enter_spawned(slot: usize) {
@@ -654,6 +719,15 @@ fn run_module(name: &str) {
 /// carry ring-3 code and data descriptors.
 unsafe fn enter_ring3(entry: u64, stack_top: u64) -> ! {
     enter_ring3_with_arg(entry, stack_top, 0)
+}
+
+/// [`enter_ring3`], for `exec`, which lives in another module.
+///
+/// # Safety
+/// As [`enter_ring3`]: the address space holding `entry` and `stack_top` must
+/// already be in CR3.
+pub unsafe fn enter_ring3_at(entry: u64, stack_top: u64) -> ! {
+    enter_ring3(entry, stack_top)
 }
 
 /// As [`enter_ring3`], but with `arg` in RDI at entry.

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -69,7 +69,7 @@ echo "==> building userspace programs"
 # libc, and anything that moves a String around needs them.
 USER_STD=(-Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem)
 
-for pkg in kosh-hello kosh-shell; do
+for pkg in kosh-hello kosh-hello2 kosh-shell; do
     USER_FLAGS=(--package "$pkg" --target "$TARGET_JSON" "${USER_STD[@]}")
     [ "$PROFILE" = "release" ] && USER_FLAGS+=(--release)
     cargo build "${USER_FLAGS[@]}" -Z json-target-spec 2>/dev/null \
@@ -77,8 +77,9 @@ for pkg in kosh-hello kosh-shell; do
 done
 
 HELLO="$ROOT/target/$TARGET_NAME/$PROFILE/kosh-hello"
+HELLO2="$ROOT/target/$TARGET_NAME/$PROFILE/kosh-hello2"
 KSH="$ROOT/target/$TARGET_NAME/$PROFILE/ksh"
-for bin in "$HELLO" "$KSH"; do
+for bin in "$HELLO" "$HELLO2" "$KSH"; do
     [ -f "$bin" ] || { echo "error: userspace binary not found at $bin" >&2; exit 1; }
     echo "==> $(basename "$bin"): entry $(readelf -h "$bin" | awk '/Entry point/ {print $4}')"
 done
@@ -102,6 +103,7 @@ rm -rf "$ISO_DIR"
 mkdir -p "$ISO_DIR/boot/grub"
 cp "$KERNEL" "$ISO_DIR/boot/kosh-kernel"
 cp "$HELLO" "$ISO_DIR/boot/hello"
+cp "$HELLO2" "$ISO_DIR/boot/hello2"
 cp "$KSH"   "$ISO_DIR/boot/ksh"
 
 cat > "$ISO_DIR/boot/grub/grub.cfg" <<'EOF'
@@ -120,6 +122,7 @@ set default=0
 menuentry "Kosh" {
     multiboot2 /boot/kosh-kernel
     module2 /boot/hello hello
+    module2 /boot/hello2 hello2
     module2 /boot/ksh ksh
     boot
 }
@@ -255,6 +258,11 @@ check)
         "munmap returned the pages" \
         "CLOCK_MONOTONIC moves forwards" \
         "debug_print echoed my message" \
+        "child: my copy of the witness is mine" \
+        "hello2 here: exec replaced the whole image" \
+        "hello2: my .bss is mine and it is zero" \
+        "parent: the child did not touch my memory" \
+        "and exited 7" \
         "seconds since the epoch" \
         "ELF loader: PASS" \
         "Storage: PASS" \
@@ -363,6 +371,9 @@ check-cli)
         type_line "getpid"
         type_line "exit"
         type_line "getpid"
+        # `cmd &` was refused as "needs fork" for three phases; what it actually
+        # needed was to start a program and not block, which spawn already did.
+        type_line "hello2 &"
         # The shell must refuse redirection rather than silently dropping it.
         type_line "echo a > out.txt"
         # QEMU's sendkey cannot produce a '|' through this keyboard layout, so
@@ -415,6 +426,7 @@ check-cli)
         "pipe yes" \
         "redirect out" \
         "background" \
+        "hello2 here: exec replaced the whole image" \
         "ksh: exiting" \
         "ksh exited with code 0, falling back to the kernel console" \
         "Kosh console" \

--- a/userspace/hello/src/main.rs
+++ b/userspace/hello/src/main.rs
@@ -19,6 +19,9 @@
 use core::panic::PanicInfo;
 
 const SYS_EXIT: u64 = 1;
+const SYS_FORK: u64 = 2;
+const SYS_EXEC: u64 = 3;
+const SYS_WAIT: u64 = 4;
 const SYS_GETPID: u64 = 5;
 const SYS_MMAP: u64 = 10;
 const SYS_MUNMAP: u64 = 11;
@@ -36,6 +39,12 @@ const MAP_PRIVATE: u64 = 0x02;
 const MAP_ANONYMOUS: u64 = 0x20;
 
 const CLOCK_MONOTONIC: u64 = 1;
+
+/// Written before `fork` and again after it, by both parent and child, to prove
+/// they are looking at different memory. A `static mut` rather than a stack
+/// variable because it lives in `.bss` — the part of the address space the
+/// eager copy has to duplicate.
+static mut FORK_WITNESS: u64 = 0;
 
 /// Zero-initialised, so it occupies no space in the file. If the loader forgets
 /// to zero the gap between `p_filesz` and `p_memsz`, this reads as garbage.
@@ -106,6 +115,18 @@ fn debug_print(message: &str) -> i64 {
             0,
         )
     }
+}
+
+fn fork() -> i64 {
+    unsafe { syscall3(SYS_FORK, 0, 0, 0) }
+}
+
+fn wait(task: i64, status: &mut i32) -> i64 {
+    unsafe { syscall3(SYS_WAIT, task as u64, status as *mut i32 as u64, 0) }
+}
+
+fn exec(name: &str) -> i64 {
+    unsafe { syscall3(SYS_EXEC, name.as_ptr() as u64, name.len() as u64, 0) }
 }
 
 fn exit(code: u64) -> ! {
@@ -270,6 +291,57 @@ pub extern "C" fn kosh_main() -> ! {
         print("  WARNING: debug_print failed\n");
     } else {
         print("  debug_print echoed my message\n");
+    }
+
+    // fork. The parent writes a witness value, forks, and then both sides write
+    // a different one — if the address spaces were shared, the second write would
+    // be visible to the first process and the values would agree.
+    //
+    // `hello` is spawned by `ksh` and also run at boot, so this must not recurse:
+    // the child execs `hello2`, a different program, and does not fork again.
+    unsafe { core::ptr::write_volatile(&raw mut FORK_WITNESS, 0x1111_1111) };
+
+    let child = fork();
+    if child < 0 {
+        print("  WARNING: fork failed\n");
+    } else if child == 0 {
+        // Child. Prove the copy diverged, then become a different program.
+        unsafe { core::ptr::write_volatile(&raw mut FORK_WITNESS, 0x2222_2222) };
+        let seen = unsafe { core::ptr::read_volatile(&raw const FORK_WITNESS) };
+        if seen == 0x2222_2222 {
+            print("  child: my copy of the witness is mine\n");
+        } else {
+            print("  WARNING: child could not write its own memory\n");
+        }
+
+        // exec never returns. If it does, it failed.
+        let err = exec("hello2");
+        print("  WARNING: exec returned ");
+        print_i64(err);
+        print("\n");
+        exit(1);
+    } else {
+        // Parent. The child has written 0x22222222 to *its* copy by now, or will
+        // shortly; either way the parent's must still read 0x11111111.
+        let mut status: i32 = 0;
+        wait(child, &mut status);
+
+        let seen = unsafe { core::ptr::read_volatile(&raw const FORK_WITNESS) };
+        if seen == 0x1111_1111 {
+            print("  parent: the child did not touch my memory\n");
+        } else {
+            print("  WARNING: fork shared memory, witness reads ");
+            print_hex(seen);
+            print("\n");
+        }
+
+        if status == 7 {
+            print("  child exec'd and exited 7\n");
+        } else {
+            print("  WARNING: unexpected child status ");
+            print_i64(status as i64);
+            print("\n");
+        }
     }
 
     print("  exiting cleanly\n");

--- a/userspace/hello2/Cargo.toml
+++ b/userspace/hello2/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "kosh-hello2"
+version = "0.1.0"
+edition = "2021"
+
+# The program `hello` execs into.
+#
+# It exists to be a *different* image at the same link address: `exec` has to
+# replace the caller's entire address space, and the only way to tell that
+# happened is for something else to be running afterwards.
+
+[dependencies]
+
+[[bin]]
+name = "kosh-hello2"
+path = "src/main.rs"

--- a/userspace/hello2/build.rs
+++ b/userspace/hello2/build.rs
@@ -1,0 +1,8 @@
+use std::path::PathBuf;
+
+fn main() {
+    let dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    println!("cargo:rustc-link-arg=-T{}", dir.join("user.ld").display());
+    println!("cargo:rerun-if-changed=user.ld");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/userspace/hello2/src/main.rs
+++ b/userspace/hello2/src/main.rs
@@ -1,0 +1,94 @@
+//! The program `hello` execs into.
+//!
+//! Deliberately minimal, and deliberately linked at the same address as `hello`
+//! and `ksh`. `exec` builds a fresh address space, loads this image into it,
+//! swaps CR3 and frees the old one — so the only evidence that any of that
+//! happened is that a *different* program is now running at the same address,
+//! having inherited nothing but its thread.
+//!
+//! It exits with 7, which the parent checks. An `exec` that silently failed and
+//! let the caller carry on would otherwise be indistinguishable from one that
+//! worked, since the caller is the same program either way.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+const SYS_EXIT: u64 = 1;
+const SYS_WRITE: u64 = 23;
+
+/// Distinct from anything `hello` writes, so a stale image would be obvious.
+static GREETING: &str = "  hello2 here: exec replaced the whole image\n";
+
+#[inline(always)]
+unsafe fn syscall3(number: u64, a1: u64, a2: u64, a3: u64) -> i64 {
+    let ret: i64;
+    core::arch::asm!(
+        "syscall",
+        inlateout("rax") number => ret,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack)
+    );
+    ret
+}
+
+fn print(s: &str) {
+    unsafe { syscall3(SYS_WRITE, 1, s.as_ptr() as u64, s.len() as u64) };
+}
+
+// System V says RSP is 16-byte aligned at process entry, but a Rust
+// `extern "C"` function assumes RSP is 8 *past* a boundary — the state a `call`
+// leaves. Wiring Rust straight to the entry point makes the first SSE spill #GP.
+core::arch::global_asm!(
+    r#"
+.section .text._start, "ax"
+.global _start
+.type _start, @function
+_start:
+    xorq    %rbp, %rbp
+    andq    $-16, %rsp
+    call    hello2_main
+1:
+    jmp     1b
+"#,
+    options(att_syntax)
+);
+
+#[no_mangle]
+pub extern "C" fn hello2_main() -> ! {
+    print(GREETING);
+
+    // A .bss touch, because exec has to have zeroed this image's own tail rather
+    // than leaving whatever the previous program had at the same address.
+    static mut CANARY: [u64; 16] = [0; 16];
+    let mut nonzero = 0;
+    for i in 0..16 {
+        if unsafe { core::ptr::read_volatile(&raw const CANARY[i]) } != 0 {
+            nonzero += 1;
+        }
+    }
+    if nonzero == 0 {
+        print("  hello2: my .bss is mine and it is zero\n");
+    } else {
+        print("  WARNING: hello2 .bss is not zero\n");
+    }
+
+    unsafe { syscall3(SYS_EXIT, 7, 0, 0) };
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    print("hello2 panic\n");
+    unsafe { syscall3(SYS_EXIT, 1, 0, 0) };
+    loop {
+        core::hint::spin_loop();
+    }
+}

--- a/userspace/hello2/user.ld
+++ b/userspace/hello2/user.ld
@@ -1,0 +1,29 @@
+/* Link at 8 MiB — the *same* address as ksh (userspace/shell/user.ld).
+ *
+ * Deliberately the same, as a standing test. Until per-process address spaces
+ * every program had to be given its own address so their images would not land
+ * on top of each other in the one set of page tables, and `spawn` refused any
+ * image that overlapped a resident one. Two programs sharing a link address
+ * would have meant one overwriting the other's `.text` while it executed.
+ *
+ * With a PML4 each, 0x800000 in `hello` and 0x800000 in `ksh` are simply
+ * different memory. `ksh` spawning `hello` — which the scripted console session
+ * does twice — exercises exactly that, and would fail loudly if the spaces were
+ * ever shared again.
+ *
+ * The ELF loader honours p_vaddr, so this is where the program genuinely runs.
+ */
+
+ENTRY(_start)
+
+SECTIONS
+{
+    . = 0x800000;
+
+    .text ALIGN(4K) : { *(.text .text.*) }
+    .rodata ALIGN(4K) : { *(.rodata .rodata.*) }
+    .data ALIGN(4K) : { *(.data .data.*) }
+    .bss ALIGN(4K) : { *(COMMON) *(.bss .bss.*) }
+
+    /DISCARD/ : { *(.comment) *(.eh_frame) *(.eh_frame_hdr) *(.note .note.*) }
+}

--- a/userspace/shell/src/main.rs
+++ b/userspace/shell/src/main.rs
@@ -265,9 +265,10 @@ fn cmd_help() {
     println("runs it on its own task, and this shell blocks until it exits.");
     println("Try 'hello'.");
     println("");
-    println("Pipes, redirection and background jobs parse but do not run:");
-    println("they need per-process address spaces, which the kernel does not");
-    println("have yet — spawn puts a second program in the same one.");
+    println("  cmd &                 start cmd without waiting for it");
+    println("");
+    println("Pipes and redirection parse but do not run: pipes need per-process");
+    println("descriptor tables, redirection needs a writable filesystem.");
 }
 
 fn cmd_ls(cwd: &str, args: &[String]) {
@@ -463,18 +464,48 @@ fn cmd_parsetest(parser: &AdvancedParser) {
 /// option; accepting the syntax and ignoring it is not.
 fn report_unsupported(parsed: &ParsedCommand) -> bool {
     if parsed.pipe_to.is_some() {
-        println("ksh: pipes need fork and exec, which the kernel does not have yet");
+        println("ksh: pipes need a way to connect two programs, which needs");
+        println("     per-process descriptor tables — the table is global today");
         return true;
     }
     if parsed.output_redirect.is_some() || parsed.input_redirect.is_some() {
         println("ksh: redirection needs a writable filesystem, which does not exist yet");
         return true;
     }
-    if parsed.background {
-        println("ksh: background jobs need fork, which the kernel does not have yet");
-        return true;
-    }
     false
+}
+
+/// Start a program without waiting for it.
+///
+/// `cmd &` used to be refused with "background jobs need fork". They do not,
+/// quite: what they need is a way to start a program and *not* block, which
+/// `spawn` has always given. The refusal outlived its reason.
+///
+/// No job control — no `jobs`, no `fg`, no notification when it finishes. The
+/// task id is printed so `wait` is at least possible by hand, and so a
+/// background job that dies is not silently gone.
+fn cmd_background(name: &str) {
+    let task = sys::spawn(name);
+
+    if task == sys::ENOENT {
+        print("ksh: ");
+        print(name);
+        println(": command not found");
+        return;
+    }
+    if task < 0 {
+        print("ksh: ");
+        print(name);
+        print(": could not start (error ");
+        print_i64(task);
+        println(")");
+        return;
+    }
+
+    print("[");
+    print_i64(task);
+    print("] ");
+    println(name);
 }
 
 /// The wall clock, from the kernel's RTC.
@@ -679,7 +710,13 @@ pub extern "C" fn ksh_main() -> ! {
             // Not a builtin: ask the kernel to run a program by that name. This
             // is the one thing a shell exists for, and until `spawn` landed it
             // was the one thing this shell could not do.
-            other => cmd_run(other),
+            other => {
+                if parsed.background {
+                    cmd_background(other)
+                } else {
+                    cmd_run(other)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Every process so far started from an ELF, via spawn. fork produces one from a *running* process: the child appears in ring 3 at the parent's next instruction, with the parent's registers and its own copy of the parent's memory, without ever having executed the syscall instruction that created it.

The control-flow half is entirely the layout of the child's kernel stack. A copy of the parent's SyscallFrame goes at the top with rax = 0, below it the address of `kosh_syscall_return` — the syscall stub's tail, newly given a label — and below that the seven-word switch frame. kosh_switch_context pops the switch frame and `ret`s, landing at the stub's tail with RSP exactly at the frame base; it pops that and sysretqs. The child runs no kernel code written for it.

The parent's user RSP is reused unchanged, which is correct only because the child has its own address space: the same number names the child's own copy of that stack.

The memory half is AddressSpace::fork — the parent's lower half copied, same contents at the same addresses in different frames. Borrowed leaves (the built-in payload lives in the kernel image) are shared rather than duplicated.

Eager, not copy-on-write, deliberately: CoW needs a per-frame reference count, and a wrong one gives double frees that surface somewhere unrelated much later. An eager copy is correct fork semantics at one memcpy per page. The cost is stated rather than hidden — forking ksh copies ~400 KiB, and without demand paging that includes 65 frames of untouched .bss.

exec builds the replacement address space completely before disturbing anything, then swaps CR3 and frees the old — in that order, because the reverse hands the page tables the CPU is walking to the allocator. A load failure leaves the caller running its current program.

fork is intercepted in kosh_syscall_handler rather than dispatched, because it is the one syscall that needs the caller's whole register frame; the dispatcher's entry logs BUG: if it is ever reached.

hello writes a witness, forks, and both sides write a different one; hello2 is a new program linked at the same address as hello and ksh, so the only evidence exec worked is that something else is running there. Sharing the lower half instead of copying it — one line — makes the child's exec free the parent's pages, and the parent then faults fetching its own .text. Five markers fail.

Also: ksh's `cmd &` refusal said "background jobs need fork". They do not — they need a way to start a program and not block, which spawn has provided since Phase 10. The refusal was written when it was true and never revisited.

44 boot markers and 31 console markers pass from a clean build.


Claude-Session: https://claude.ai/code/session_01P1GdpYMiKP5Gj1Jmub59gw