### PR TITLE
kernel: copy-on-write fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ test disk, then boots the lot:
 
 ```bash
 ./scripts/run.sh              # boot it, serial on stdio (ctrl-a x to quit)
-./scripts/run.sh --check      # boot headless, assert 44 serial markers (CI)
+./scripts/run.sh --check      # boot headless, assert 47 serial markers (CI)
 ./scripts/run.sh --check-cli  # drive the shell through QEMU's monitor, assert 31
 ./scripts/run.sh --debug      # same as plain run, plus a gdb stub on :1234
 ```
@@ -107,8 +107,11 @@ interaction in `--check-cli`.
 - **Per-process address spaces**: a PML4 each, kernel's upper half shared. Two
   programs can be — and `hello`, `hello2` and `ksh` all are — linked at the
   same address
-- **`fork` and `exec`**: the child returns from a syscall it never executed,
-  into its own copy of the parent's memory; `exec` replaces the whole image
+- **`fork` and `exec`**: the child returns from a syscall it never executed;
+  `exec` replaces the whole image
+- **Copy-on-write**: a `fork` copies no page data at all. Both sides go
+  read-only, the frame reference count goes up, and the first write from either
+  side faults into a private copy
 - **Per-thread kernel stacks**, so more than one thread can be inside a syscall
 - Real blocking: `wait` parks a thread in `State::Blocked` rather than spinning
 
@@ -161,14 +164,11 @@ all 5 IPC calls · all 4 driver calls · all 4 capability calls · `uname`
 Being explicit about this, because the earlier version of this file claimed most
 of it.
 
-- **`fork` copies eagerly.** Every owned page is duplicated immediately rather
-  than shared copy-on-write. That is correct `fork` semantics at the cost of one
-  memcpy per page — forking `ksh` copies about 400 KiB — and it is deliberate:
-  copy-on-write needs a per-frame reference count, and getting that wrong
-  produces double frees that surface somewhere unrelated, much later.
-- **No demand paging.** Every page of a program is populated at load time, so
-  `ksh`'s 256 KiB `.bss` costs 65 frames whether it is touched or not — and a
-  `fork` copies all 65.
+- **No demand paging.** Every page of a program is allocated and populated at
+  load time, so `ksh`'s 256 KiB `.bss` costs 65 frames whether it is touched or
+  not. Copy-on-write means a `fork` no longer *copies* those 65, but the program
+  still pays for them at load. `mmap` has the same problem: it allocates the
+  whole span up front.
 - **No `argv`.** `exec` takes a program name and nothing else; passing arguments
   needs somewhere to put the strings in the new address space.
 - **The filesystem is read-only.** `ksh` refuses redirection rather than
@@ -247,8 +247,8 @@ Roughly in order, each unblocking the next:
 - [x] A shell in userspace that can launch programs
 - [x] Per-process address spaces
 - [x] `fork` and `exec`
-- [ ] Copy-on-write and demand paging, so a `fork` costs a page table rather
-      than a program
+- [x] Copy-on-write, so a `fork` costs a page table rather than a program
+- [ ] Demand paging, so an untouched `.bss` costs nothing at all
 - [ ] One process-id namespace, so the IPC and capability machinery becomes
       reachable from ring 3
 - [ ] Move the disk and filesystem out of the kernel — the point of the whole

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -1399,6 +1399,123 @@ ksh:/$   hello2 here: exec replaced the whole image
 No job control — no `jobs`, no `fg`, no notification on exit. The task id is
 printed so a `wait` is at least possible by hand.
 
+## Copy-on-write (Phase 15)
+
+The previous phase's `fork` copied every page eagerly. That is correct, and it
+cost about 400 KiB per fork of `ksh` — most of it a `.bss` the child `exec`s away
+microseconds later. This is the optimisation, and the reference counting it
+needs.
+
+```
+Thread 1 forking: 20 page(s) shared copy-on-write into PML4 0x5e9000 (20 shared system-wide)
+  child: I inherited the value my parent set before forking
+  child: my copy of the witness is mine
+  parent: the child did not touch my memory
+  parent: still writable after the child exited
+Copy-on-write: 3 fault(s) resolved, 2 needed a copy, 0 frame(s) still shared
+```
+
+Twenty pages shared, zero copied at `fork` time, three copies made lazily —
+exactly the pages that were actually written.
+
+### Both sides, not just the child
+
+`fork` shares every owned leaf: the frame's reference count goes up, and *both*
+the parent's entry and the child's lose `WRITABLE` and gain `COPY_ON_WRITE`.
+
+Marking only the child is the classic bug, and it is silent: the parent's next
+write lands in the page the child is about to read, and the child sees a value
+its parent wrote *after* the fork. The test is built to catch precisely that, and
+the sequencing is not racy — `fork` returns in the parent with the child merely
+`Ready`, so the parent's write is guaranteed to happen first:
+
+```
+  WARNING: child saw 0000000033333333 — the parent wrote through a shared page
+```
+
+That is what removing one line — `source_mut[i].set_flags(shared)` — produces.
+
+Pages that were *already* read-only (`.text`, `.rodata`) are shared without the
+marker. Nothing can write them, so there is nothing to copy on; they still need
+the reference count, and they now have it.
+
+`COPY_ON_WRITE` is a separate bit from `WRITABLE` being clear, because a
+genuinely read-only page must keep faulting rather than being handed a writable
+copy.
+
+### The parent's TLB
+
+The parent's own entries just lost `WRITABLE`, and the CPU has the old ones
+cached. `fork_from` reloads CR3, which flushes every non-global entry. Blunt, and
+correct; the alternative is one `invlpg` per shared page, and there are as many
+of those as pages. It is only valid because the parent is the *current* address
+space, which it is — `fork` runs in the caller.
+
+### Resolving
+
+`resolve_cow` has two cases, and the second matters more than it looks:
+
+* **The frame has other holders.** Allocate one, copy 4 KiB through the physmap,
+  repoint the entry, drop a reference to the original.
+* **This is the last holder.** Nothing to copy — clear the marker and restore
+  `WRITABLE`. Without this, a process whose child has already exited would keep
+  paying a full copy for every page it writes, forever, with nobody to copy away
+  from.
+
+Both are exercised: `2 needed a copy` out of `3 fault(s) resolved`. The third is
+the parent writing after the child exited.
+
+### Two syscall-path hazards
+
+**`copy_to_user` writes at the user address.** With `CR0.WP` set, a kernel write
+to a read-only page traps — from ring 0, in the middle of a syscall that may be
+holding locks the fault handler wants. So `validate_user_range` resolves
+copy-on-write *up front* when the caller asks for write access, turning what
+would be a kernel-mode fault into an ordinary function call. It also means a
+failure comes back as an error return rather than an exception.
+
+**`validate_user_range` would have rejected the write.** A shared page is not
+`WRITABLE`, so `read(fd, buf)` into freshly-forked memory would have failed with
+`NotWritable` before the copy could happen. It treats `COPY_ON_WRITE` as
+writable-after-resolution.
+
+### The reference count, and two bugs finding a home for it
+
+One byte per frame — the sharers of a frame are address spaces, and the thread
+table holds 16, so 255 is a long way past enough. `allocate_frame` sets it to 1;
+`deallocate_frame` decrements and only really frees at zero. A frame the
+allocator never handed out has a count of 0, and freeing one is refused with a
+warning rather than putting the running kernel's own pages on the free list.
+
+Placing the table found two bugs in the same afternoon, both of the same shape —
+**a rule that was correct until the thing it described changed size**:
+
+1. The metadata went "immediately after the kernel image", which was fine while
+   it was a 16 KiB bitmap. The refcount table is 128 KiB for 512 MiB of RAM, and
+   that reaches into the module GRUB loaded at `0x195000`. The symptom was both
+   boot modules reading as all zeros and the ELF loader reporting `BadMagic`,
+   several subsystems from the cause. It is now computed from the kernel *and*
+   every module end — the only version without a size at which it silently
+   breaks. (A hardcoded 2 MiB was the rule before that, and failed the same way
+   when the kernel grew.)
+
+2. The reservation loop excluded `bitmap_start .. bitmap_start + bitmap.len()`,
+   using the bitmap's length as a proxy for "the metadata" — true when the bitmap
+   *was* the metadata. So the allocator handed out the frames holding the
+   refcount table, which promptly filled with page data:
+
+   ```
+   Thread 1 forking: 20 page(s) shared copy-on-write (112969 shared system-wide)
+   ```
+
+   112,969 frames shared after a fork of twenty pages. Worth logging a number you
+   can sanity-check by eye.
+
+### No leak
+
+Two consecutive `hello` runs from `ksh` — each a fork, an exec, and two
+teardowns — both end at 1613 used pages.
+
 ## What is deliberately still missing
 - **The filesystem is read-only.** Allocating clusters and keeping both FAT
   copies consistent is a separate problem, and a read-only filesystem that is

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -856,6 +856,14 @@ fn init_usermode() {
     serial_println!("--- back in ring 0 ---");
     crate::task::reap_finished();
 
+    let (cow_resolved, cow_copied) = crate::memory::paging::cow_stats();
+    serial_println!(
+        "Copy-on-write: {} fault(s) resolved, {} needed a copy, {} frame(s) still shared",
+        cow_resolved,
+        cow_copied,
+        crate::memory::physical::shared_frames()
+    );
+
     let elf_syscalls = crate::syscall::entry::syscall_count() - before_elf;
     if elf_syscalls >= 5 {
         serial_println!(

--- a/kernel/src/interrupts/exceptions.rs
+++ b/kernel/src/interrupts/exceptions.rs
@@ -144,6 +144,26 @@ pub extern "x86-interrupt" fn page_fault_handler(
 
     let accessed = Cr2::read();
 
+    // Copy-on-write, before anything is printed.
+    //
+    // A write to a page shared by `fork` is not an error — it is the mechanism
+    // working. `resolve_cow` gives this address space a private copy and the
+    // faulting instruction is retried, so the common case produces no output at
+    // all. Everything below is for faults that are genuinely faults.
+    if error_code.contains(PageFaultErrorCode::PROTECTION_VIOLATION)
+        && error_code.contains(PageFaultErrorCode::CAUSED_BY_WRITE)
+        && accessed.as_u64() < crate::syscall::uaccess::USER_ADDRESS_LIMIT
+    {
+        match crate::memory::paging::resolve_cow(accessed.as_u64()) {
+            Ok(true) => return,
+            Ok(false) => {}
+            Err(e) => {
+                serial_println!();
+                serial_println!("Copy-on-write fault at 0x{:x} could not be resolved: {}", accessed.as_u64(), e);
+            }
+        }
+    }
+
     serial_println!();
     serial_println!("==================== PAGE FAULT ====================");
     serial_println!("  accessed address : 0x{:016x}", accessed.as_u64());

--- a/kernel/src/memory/address_space.rs
+++ b/kernel/src/memory/address_space.rs
@@ -44,9 +44,10 @@ use x86_64::structures::paging::{PageTable, PageTableFlags, PhysFrame, Size4KiB}
 use x86_64::PhysAddr;
 
 use crate::memory::paging::{
-    kernel_pml4_phys, mapper_for, KERNEL_PML4_FIRST, OWNED_BY_ADDRESS_SPACE, PHYSMAP_BASE,
+    kernel_pml4_phys, mapper_for, COPY_ON_WRITE, KERNEL_PML4_FIRST, OWNED_BY_ADDRESS_SPACE,
+    PHYSMAP_BASE,
 };
-use crate::memory::physical::{allocate_frame, deallocate_frame, PageFrame};
+use crate::memory::physical::{allocate_frame, deallocate_frame, share_frame, PageFrame};
 use crate::serial_println;
 
 /// A process's page tables.
@@ -88,23 +89,23 @@ impl AddressSpace {
     /// A copy of this address space: same contents at the same addresses, in
     /// different frames.
     ///
-    /// ## Eager, not copy-on-write
+    /// ## Copy-on-write
     ///
-    /// Every owned page is duplicated immediately. The textbook implementation
-    /// marks both copies read-only, shares the frames, and copies one page at a
-    /// time in the page-fault handler — which is faster, and is what makes
-    /// `fork` cheap enough to be followed immediately by `exec`.
+    /// No page data is copied. Every owned leaf is shared: the frame's
+    /// reference count goes up, and *both* the parent's entry and the child's
+    /// lose `WRITABLE` and gain [`COPY_ON_WRITE`]. The first write from either
+    /// side faults, and `paging::resolve_cow` gives that side a private copy.
     ///
-    /// It is not done here, deliberately. Copy-on-write needs a per-frame
-    /// reference count, and getting that wrong produces double frees and
-    /// use-after-free of page tables: memory corruption that shows up somewhere
-    /// unrelated, much later. An eager copy is *correct* `fork` semantics — a
-    /// child that sees the parent's memory as it was and diverges from there —
-    /// at a cost of one memcpy per page. Forking `ksh` copies about 400 KiB.
+    /// Both sides, not just the child — that is the part that is easy to get
+    /// wrong. Leaving the parent writable means the parent's next write lands
+    /// in a page the child is still reading.
     ///
-    /// The cost is real and worth stating: without `exec` following, a fork is
-    /// pure waste, and with demand paging a program's untouched `.bss` would not
-    /// need copying at all. Both are the next piece of work.
+    /// The previous implementation copied every page eagerly. It was correct,
+    /// and it cost about 400 KiB per `fork` of `ksh` — most of it a `.bss` the
+    /// child would `exec` away microseconds later.
+    ///
+    /// Page *tables* are still duplicated, because the child needs its own
+    /// entries to modify. That is a handful of frames rather than a program.
     ///
     /// ## Shared versus copied
     ///
@@ -224,6 +225,18 @@ pub fn fork_from(parent_pml4: u64) -> Result<(AddressSpace, usize), &'static str
         }
     }
 
+    // The parent's own entries just lost WRITABLE, and the CPU has cached the
+    // old ones. Reloading CR3 flushes every non-global entry, which is the
+    // blunt-but-correct option; the alternative is an `invlpg` per page, and
+    // there are as many pages as we just shared.
+    //
+    // Only correct because the parent is the *current* address space, which it
+    // is: `fork` runs in the caller.
+    unsafe {
+        let (frame, flags) = Cr3::read();
+        Cr3::write(frame, flags);
+    }
+
     Ok((child, copied))
 }
 
@@ -238,11 +251,14 @@ unsafe fn clone_level(
     let new_frame = allocate_frame().ok_or("out of memory forking page tables")?;
     let new_phys = new_frame.address() as u64;
 
+    // The source is taken mutably: sharing a page copy-on-write has to clear
+    // WRITABLE in the *parent's* entry as well as the child's.
     let source = &*((PHYSMAP_BASE + table_phys) as *const PageTable);
+    let source_mut = &mut *((PHYSMAP_BASE + table_phys) as *mut PageTable);
     let target = &mut *((PHYSMAP_BASE + new_phys) as *mut PageTable);
     target.zero();
 
-    let mut copied = 0;
+    let mut shared_pages = 0;
 
     for i in 0..512 {
         if source[i].is_unused() {
@@ -254,31 +270,42 @@ unsafe fn clone_level(
 
         if level == 1 || flags.contains(PageTableFlags::HUGE_PAGE) {
             if flags.contains(OWNED_BY_ADDRESS_SPACE) {
-                // A page this process owns: give the child its own copy.
-                let copy = match allocate_frame() {
-                    Some(f) => f.address() as u64,
-                    None => return Err("out of memory forking a page"),
+                // A page this process owns: share the frame, and make both sides
+                // fault on their next write.
+                if share_frame(PageFrame::from_address(addr as usize)).is_none() {
+                    return Err("frame reference count overflowed during fork");
+                }
+
+                let shared = if flags.contains(PageTableFlags::WRITABLE) {
+                    (flags | OWNED_BY_ADDRESS_SPACE | COPY_ON_WRITE)
+                        - PageTableFlags::WRITABLE
+                } else {
+                    // Already read-only — `.text`, `.rodata`. Nothing can write
+                    // it, so there is nothing to copy on; it just needs the
+                    // reference count, which it now has.
+                    flags
                 };
-                core::ptr::copy_nonoverlapping(
-                    (PHYSMAP_BASE + addr) as *const u8,
-                    (PHYSMAP_BASE + copy) as *mut u8,
-                    crate::memory::PAGE_SIZE,
-                );
-                target[i].set_addr(PhysAddr::new(copy), flags);
-                copied += 1;
+
+                target[i].set_addr(PhysAddr::new(addr), shared);
+                // The parent loses write access too. Doing only the child is the
+                // classic copy-on-write bug: the parent's next write goes into
+                // the page the child is reading.
+                source_mut[i].set_flags(shared);
+                shared_pages += 1;
             } else {
-                // Borrowed. Share it, and leave it untagged in the child too, so
-                // neither teardown tries to free it.
+                // Borrowed — the built-in payload lives in the kernel image.
+                // Share it, and leave it untagged in the child too, so neither
+                // teardown tries to free it.
                 target[i].set_addr(PhysAddr::new(addr), flags);
             }
         } else {
             let (child_table, n) = clone_level(addr, flags, level - 1)?;
             target[i].set_addr(PhysAddr::new(child_table), flags);
-            copied += n;
+            shared_pages += n;
         }
     }
 
-    Ok((new_phys, copied))
+    Ok((new_phys, shared_pages))
 }
 
 /// Check that every address space still agrees with the kernel about the upper

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -152,6 +152,133 @@ pub unsafe fn mapper_for(pml4_phys: u64) -> OffsetPageTable<'static> {
 /// allocator.
 pub const OWNED_BY_ADDRESS_SPACE: PageTableFlags = PageTableFlags::BIT_9;
 
+/// Marks a leaf that is shared copy-on-write.
+///
+/// The page is present and readable but **not** writable, and the frame's
+/// reference count is above one. A write faults; `resolve_cow` gives the writer
+/// a private copy (or, if it turns out to be the last holder, simply makes the
+/// page writable again) and the instruction retries.
+///
+/// A separate bit from `WRITABLE` being clear, because a genuinely read-only
+/// page — `.text`, `.rodata` — must keep faulting rather than being handed a
+/// writable copy.
+pub const COPY_ON_WRITE: PageTableFlags = PageTableFlags::BIT_10;
+
+/// Give the current address space a private, writable copy of a shared page.
+///
+/// Returns `Ok(true)` if it did something, `Ok(false)` if the page was not
+/// copy-on-write and the fault is real.
+///
+/// Two cases:
+///
+/// * **The frame has other holders.** Allocate one, copy 4 KiB through the
+///   physmap, point the entry at the copy and drop a reference to the original.
+/// * **This is the last holder.** Nothing to copy: clear the marker and restore
+///   `WRITABLE`. Without this case a process that forks and whose child exits
+///   would keep paying a copy for every page it writes, forever.
+///
+/// The TLB entry for a page that was cached read-only has to be invalidated
+/// explicitly — the CPU will not notice the table changed underneath it.
+/// Copy-on-write faults resolved since boot, and how many needed a real copy.
+///
+/// Logged because a copy-on-write implementation that never fires and one that
+/// works look identical from outside: both produce a correct program. The
+/// counters are the only evidence the mechanism is on the path at all.
+static COW_RESOLVED: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+static COW_COPIED: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
+pub fn cow_stats() -> (u64, u64) {
+    use core::sync::atomic::Ordering;
+    (
+        COW_RESOLVED.load(Ordering::Relaxed),
+        COW_COPIED.load(Ordering::Relaxed),
+    )
+}
+
+pub fn resolve_cow(virt: u64) -> Result<bool, &'static str> {
+    use x86_64::instructions::tlb;
+    use x86_64::structures::paging::mapper::TranslateResult;
+    use x86_64::structures::paging::Translate;
+
+    let page: Page<Size4KiB> = Page::containing_address(VirtAddr::new(virt));
+
+    let (frame_phys, flags) = {
+        let mapper = unsafe { active_mapper() };
+        match mapper.translate(page.start_address()) {
+            TranslateResult::Mapped { frame, flags, .. } => {
+                (frame.start_address().as_u64(), flags)
+            }
+            _ => return Ok(false),
+        }
+    };
+
+    if !flags.contains(COPY_ON_WRITE) {
+        return Ok(false);
+    }
+
+    let old = PageFrame::from_address(frame_phys as usize);
+    let writable_flags = (flags | PageTableFlags::WRITABLE) - COPY_ON_WRITE;
+
+    // The count is read once and acted on with interrupts disabled, because two
+    // threads faulting on the same shared page must not both conclude they are
+    // the last holder.
+    crate::interrupts::without_interrupts(|| {
+        let refs = crate::memory::physical::frame_refs(old);
+
+        if refs <= 1 {
+            unsafe {
+                let mut mapper = active_mapper();
+                mapper
+                    .update_flags(page, writable_flags)
+                    .map_err(|_| "could not make the last copy writable")?
+                    .flush();
+            }
+            COW_RESOLVED.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+            return Ok(true);
+        }
+
+        let copy = allocate_frame().ok_or("out of memory resolving a copy-on-write fault")?;
+        let copy_phys = copy.address() as u64;
+
+        unsafe {
+            core::ptr::copy_nonoverlapping(
+                (PHYSMAP_BASE + frame_phys) as *const u8,
+                (PHYSMAP_BASE + copy_phys) as *mut u8,
+                PAGE_SIZE,
+            );
+
+            let mut mapper = active_mapper();
+            // `unmap` then `map_to` rather than editing in place: the crate has
+            // no "repoint this entry" operation, and doing it by hand would mean
+            // reimplementing the table walk.
+            let (_, flush) = mapper.unmap(page).map_err(|_| "could not unmap a CoW page")?;
+            flush.ignore();
+
+            let table_flags = PageTableFlags::PRESENT
+                | PageTableFlags::WRITABLE
+                | PageTableFlags::USER_ACCESSIBLE;
+            mapper
+                .map_to_with_table_flags(
+                    page,
+                    PhysFrame::<Size4KiB>::containing_address(PhysAddr::new(copy_phys)),
+                    writable_flags,
+                    table_flags,
+                    &mut KoshFrameAllocator,
+                )
+                .map_err(|_| "could not map a CoW copy")?
+                .flush();
+        }
+
+        // Only now: the original has one fewer holder.
+        crate::memory::physical::deallocate_frame(old);
+        tlb::flush(page.start_address());
+
+        COW_RESOLVED.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        COW_COPIED.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+        Ok(true)
+    })
+}
+
 /// Build the kernel's own page tables and install them.
 ///
 /// `phys_mem_end` is the highest physical address that needs to appear in the

--- a/kernel/src/memory/physical.rs
+++ b/kernel/src/memory/physical.rs
@@ -99,6 +99,17 @@ pub struct PhysicalMemoryManager {
     reserved_frames: usize,
     /// Start of the bitmap in memory
     bitmap_start: usize,
+    /// How many address spaces are using each frame.
+    ///
+    /// Copy-on-write is what makes this necessary: after a `fork` the same
+    /// frame appears in two sets of page tables, and whichever process exits
+    /// first must not hand it back to the allocator. `deallocate_frame`
+    /// decrements; the frame is only really freed at zero.
+    ///
+    /// `u8` rather than `u16`: the sharers of a frame are address spaces, and
+    /// the thread table holds 16. 255 is a long way past that, and an overflow
+    /// is reported rather than wrapped.
+    refcounts: &'static mut [u8],
 }
 
 impl PhysicalMemoryManager {
@@ -128,22 +139,40 @@ impl PhysicalMemoryManager {
         
         // Calculate bitmap size (1 bit per page frame)
         let bitmap_size = (total_frames + 7) / 8; // Round up to nearest byte
+        // ...and the refcount table, one byte per frame, immediately after it.
+        let refcount_size = total_frames;
+        let metadata_size = bitmap_size + refcount_size;
         
-        // Place the bitmap immediately after the kernel image. The previous
-        // hardcoded 2 MiB only worked by accident (the kernel happened to be
-        // small enough) and would silently corrupt the kernel once it grew.
+        // Place the metadata after the kernel image *and* after every boot
+        // module.
+        //
+        // "After the kernel image" was the rule until the refcount table
+        // arrived, and it was correct only because the bitmap was small: 16 KiB
+        // fits in the gap GRUB leaves before the first module. The refcount
+        // table is one byte per frame — 128 KiB for 512 MiB of RAM — which
+        // reaches straight into the module GRUB loaded at 0x195000. The symptom
+        // was both modules reading as all zeros and the ELF loader reporting
+        // `BadMagic`, several subsystems away from the cause.
+        //
+        // A hardcoded 2 MiB was the rule before *that*, and failed the same way
+        // once the kernel grew. Computing the bound is the only version that
+        // does not have a size at which it silently breaks.
         let (_kernel_start, kernel_end) = kernel_image_range();
-        let bitmap_start = align_up(kernel_end);
-        let bitmap_end = bitmap_start + bitmap_size;
+        let mut metadata_after = kernel_end;
+        for module in boot_info.module_tags() {
+            metadata_after = metadata_after.max(module.end_address() as usize);
+        }
+        let bitmap_start = align_up(metadata_after);
+        let bitmap_end = bitmap_start + metadata_size;
         
-        // Ensure bitmap doesn't overlap with any reserved areas
+        // Ensure the metadata doesn't overlap with any reserved areas
         for area in memory_map.memory_areas() {
             if area.typ() != MemoryAreaType::Available {
                 let area_start = area.start_address() as usize;
                 let area_end = area.end_address() as usize;
                 
                 if bitmap_start < area_end && bitmap_end > area_start {
-                    return Err("Cannot place bitmap - overlaps with reserved memory");
+                    return Err("Cannot place the frame metadata - overlaps with reserved memory");
                 }
             }
         }
@@ -160,9 +189,27 @@ impl PhysicalMemoryManager {
                 bitmap_size,
             )
         };
+        let refcounts = unsafe {
+            core::slice::from_raw_parts_mut(
+                crate::memory::paging::kernel_virt((bitmap_start + bitmap_size) as u64) as *mut u8,
+                refcount_size,
+            )
+        };
         
         // Clear the bitmap (all pages initially marked as used)
         bitmap.fill(0xFF);
+        // Nobody holds a reference to anything yet. Frames the allocator never
+        // hands out — the kernel image, this table, low memory — stay at zero
+        // for the life of the system, which is what makes an accidental
+        // `deallocate_frame` on one of them detectable rather than silent.
+        refcounts.fill(0);
+        
+        serial_println!(
+            "  frame metadata  : bitmap {} bytes + refcounts {} bytes at 0x{:x}",
+            bitmap_size,
+            refcount_size,
+            bitmap_start
+        );
         
         // The bitmap is filled with 0xFF above, i.e. every frame starts out
         // marked used. The counters have to agree with that, otherwise the
@@ -175,6 +222,7 @@ impl PhysicalMemoryManager {
             used_frames: total_frames,
             reserved_frames: 0,
             bitmap_start,
+            refcounts,
         };
         
         // Mark available memory areas as free
@@ -218,7 +266,7 @@ impl PhysicalMemoryManager {
                     if frame_addr < 0x100000
                         || (frame_addr >= kernel_start && frame_addr < kernel_end)
                         || (frame_addr >= self.bitmap_start
-                            && frame_addr < self.bitmap_start + self.bitmap.len())
+                            && frame_addr < self.metadata_end())
                     {
                         self.reserved_frames += 1;
                         continue;
@@ -285,6 +333,8 @@ impl PhysicalMemoryManager {
                         if frame_num < self.total_frames {
                             let frame = PageFrame(frame_num);
                             self.mark_frame_used(frame);
+                            // One owner: whoever asked for it.
+                            self.refcounts[frame_num] = 1;
                             return Some(frame);
                         }
                     }
@@ -334,6 +384,13 @@ impl PhysicalMemoryManager {
     }
     
     /// Deallocate a page frame
+    /// Drop one reference to a frame, freeing it when the last one goes.
+    ///
+    /// Before copy-on-write this unconditionally marked the frame free, which
+    /// was correct because a frame had exactly one owner. After `fork`, two
+    /// address spaces can hold the same frame, and whichever process exits
+    /// first would otherwise hand a page the other is still reading back to the
+    /// allocator.
     pub fn deallocate_frame(&mut self, frame: PageFrame) {
         if frame.0 >= self.total_frames {
             return;
@@ -344,8 +401,70 @@ impl PhysicalMemoryManager {
             serial_println!("Warning: Attempted to free already free frame {}", frame.0);
             return;
         }
-        
-        self.mark_frame_free(frame);
+
+        match self.refcounts[frame.0] {
+            0 => {
+                // A frame the allocator never handed out: the kernel image, the
+                // metadata tables, low memory. Freeing one is a bug in the
+                // caller, and marking it free would put the running kernel's own
+                // pages on the free list.
+                serial_println!(
+                    "Warning: refusing to free frame {} (0x{:x}) — it was never allocated",
+                    frame.0,
+                    frame.address()
+                );
+                return;
+            }
+            1 => {
+                self.refcounts[frame.0] = 0;
+                self.mark_frame_free(frame);
+            }
+            n => {
+                self.refcounts[frame.0] = n - 1;
+            }
+        }
+    }
+
+    /// Take another reference to an already-allocated frame.
+    ///
+    /// Returns the new count, or `None` if the frame was not allocated or the
+    /// count would overflow.
+    pub fn share_frame(&mut self, frame: PageFrame) -> Option<u8> {
+        if frame.0 >= self.total_frames {
+            return None;
+        }
+        let current = self.refcounts[frame.0];
+        if current == 0 || current == u8::MAX {
+            return None;
+        }
+        self.refcounts[frame.0] = current + 1;
+        Some(current + 1)
+    }
+
+    /// End of the frame metadata: the bitmap *and* the refcount table.
+    ///
+    /// The reservation loop used `bitmap_start + bitmap.len()`, which was right
+    /// while the bitmap was the only metadata. Adding the refcount table without
+    /// this made the allocator hand out the frames holding the refcount table,
+    /// which then filled with page data — and `shared_frames()` reported 112,969
+    /// frames shared after a fork of 20 pages, which is how it was noticed.
+    fn metadata_end(&self) -> usize {
+        self.bitmap_start + self.bitmap.len() + self.refcounts.len()
+    }
+
+    /// How many address spaces hold this frame. 0 means the allocator does not
+    /// own it.
+    pub fn frame_refs(&self, frame: PageFrame) -> u8 {
+        if frame.0 >= self.total_frames {
+            return 0;
+        }
+        self.refcounts[frame.0]
+    }
+
+    /// How many frames currently have more than one holder. Diagnostics — it is
+    /// the number that shows copy-on-write is doing anything.
+    pub fn shared_frames(&self) -> usize {
+        self.refcounts.iter().filter(|&&c| c > 1).count()
     }
     
     /// Deallocate multiple contiguous page frames
@@ -462,6 +581,30 @@ pub fn allocate_frames(count: usize) -> Option<PageFrame> {
 }
 
 /// Deallocate a page frame
+/// Take another reference to a frame. See
+/// [`PhysicalMemoryManager::share_frame`].
+pub fn share_frame(frame: PageFrame) -> Option<u8> {
+    PHYSICAL_MEMORY_MANAGER.lock().as_mut()?.share_frame(frame)
+}
+
+/// How many address spaces hold this frame.
+pub fn frame_refs(frame: PageFrame) -> u8 {
+    PHYSICAL_MEMORY_MANAGER
+        .lock()
+        .as_ref()
+        .map(|m| m.frame_refs(frame))
+        .unwrap_or(0)
+}
+
+/// Frames held by more than one address space.
+pub fn shared_frames() -> usize {
+    PHYSICAL_MEMORY_MANAGER
+        .lock()
+        .as_ref()
+        .map(|m| m.shared_frames())
+        .unwrap_or(0)
+}
+
 pub fn deallocate_frame(frame: PageFrame) {
     if let Some(manager) = PHYSICAL_MEMORY_MANAGER.lock().as_mut() {
         manager.deallocate_frame(frame);
@@ -482,7 +625,10 @@ pub fn deallocate_frames(start_frame: PageFrame, count: usize) {
 pub fn bitmap_extent() -> (usize, usize) {
     let guard = PHYSICAL_MEMORY_MANAGER.lock();
     match guard.as_ref() {
-        Some(m) => (m.bitmap_start, m.bitmap_start + m.bitmap.len()),
+        Some(m) => (
+            m.bitmap_start,
+            m.bitmap_start + m.bitmap.len() + m.refcounts.len(),
+        ),
         None => (0, 0),
     }
 }

--- a/kernel/src/syscall/fork.rs
+++ b/kernel/src/syscall/fork.rs
@@ -63,10 +63,11 @@ pub fn sys_fork(frame: &SyscallFrame) -> SyscallResult {
     })?;
 
     serial_println!(
-        "Thread {} forking: {} page(s) copied into PML4 0x{:x}",
+        "Thread {} forking: {} page(s) shared copy-on-write into PML4 0x{:x} ({} shared system-wide)",
         parent,
         copied,
-        child_space.pml4_phys()
+        child_space.pml4_phys(),
+        crate::memory::physical::shared_frames()
     );
 
     match crate::task::spawn_forked("forked", frame, child_space) {

--- a/kernel/src/syscall/uaccess.rs
+++ b/kernel/src/syscall/uaccess.rs
@@ -27,7 +27,7 @@ use crate::memory::PAGE_SIZE;
 
 /// First address of the higher (kernel) half. Anything at or above this is
 /// never a valid user pointer.
-const USER_ADDRESS_LIMIT: u64 = 0x0000_8000_0000_0000;
+pub const USER_ADDRESS_LIMIT: u64 = 0x0000_8000_0000_0000;
 
 /// Refuse absurdly large transfers outright rather than walking millions of
 /// page-table entries on behalf of a hostile caller.
@@ -77,7 +77,22 @@ pub fn validate_user_range(ptr: u64, len: usize, writable: bool) -> Result<(), U
                     return Err(UserAccessError::NotUserAccessible);
                 }
                 if writable && !flags.contains(PageTableFlags::WRITABLE) {
-                    return Err(UserAccessError::NotWritable);
+                    // A copy-on-write page is writable — it just needs the copy
+                    // doing first. Resolve it here rather than letting the write
+                    // below fault: `copy_to_user` writes at the *user* address,
+                    // so with CR0.WP set a shared page would trap into the page
+                    // fault handler from ring 0, in the middle of a syscall that
+                    // may be holding locks the handler wants.
+                    //
+                    // Doing it up front turns that into an ordinary function
+                    // call. It also means a failure is reported as an error
+                    // return rather than a fault.
+                    if flags.contains(crate::memory::paging::COPY_ON_WRITE) {
+                        crate::memory::paging::resolve_cow(page)
+                            .map_err(|_| UserAccessError::NotWritable)?;
+                    } else {
+                        return Err(UserAccessError::NotWritable);
+                    }
                 }
             }
             _ => return Err(UserAccessError::NotMapped),

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -258,7 +258,10 @@ check)
         "munmap returned the pages" \
         "CLOCK_MONOTONIC moves forwards" \
         "debug_print echoed my message" \
+        "child: I inherited the value my parent set before forking" \
         "child: my copy of the witness is mine" \
+        "parent: still writable after the child exited" \
+        "Copy-on-write: " \
         "hello2 here: exec replaced the whole image" \
         "hello2: my .bss is mine and it is zero" \
         "parent: the child did not touch my memory" \

--- a/userspace/hello/src/main.rs
+++ b/userspace/hello/src/main.rs
@@ -293,22 +293,35 @@ pub extern "C" fn kosh_main() -> ! {
         print("  debug_print echoed my message\n");
     }
 
-    // fork. The parent writes a witness value, forks, and then both sides write
-    // a different one — if the address spaces were shared, the second write would
-    // be visible to the first process and the values would agree.
+    // fork, and the copy-on-write behaviour underneath it.
     //
-    // `hello` is spawned by `ksh` and also run at boot, so this must not recurse:
-    // the child execs `hello2`, a different program, and does not fork again.
+    // The sequencing is deliberate and not racy: `fork` returns *in the parent*
+    // with the child merely Ready, so the parent's write below is guaranteed to
+    // happen before the child runs. The child then reads the same address and
+    // must still see the pre-fork value.
+    //
+    // That is what catches the classic copy-on-write bug — marking only the
+    // child's page read-only and leaving the parent writable, so the parent's
+    // next write lands in the page the child is about to read.
     unsafe { core::ptr::write_volatile(&raw mut FORK_WITNESS, 0x1111_1111) };
 
     let child = fork();
     if child < 0 {
         print("  WARNING: fork failed\n");
     } else if child == 0 {
-        // Child. Prove the copy diverged, then become a different program.
+        // Child. Its copy must still hold the pre-fork value.
+        let inherited = unsafe { core::ptr::read_volatile(&raw const FORK_WITNESS) };
+        if inherited == 0x1111_1111 {
+            print("  child: I inherited the value my parent set before forking\n");
+        } else {
+            print("  WARNING: child saw ");
+            print_hex(inherited);
+            print(" — the parent wrote through a shared page\n");
+        }
+
         unsafe { core::ptr::write_volatile(&raw mut FORK_WITNESS, 0x2222_2222) };
-        let seen = unsafe { core::ptr::read_volatile(&raw const FORK_WITNESS) };
-        if seen == 0x2222_2222 {
+        let mine = unsafe { core::ptr::read_volatile(&raw const FORK_WITNESS) };
+        if mine == 0x2222_2222 {
             print("  child: my copy of the witness is mine\n");
         } else {
             print("  WARNING: child could not write its own memory\n");
@@ -321,18 +334,31 @@ pub extern "C" fn kosh_main() -> ! {
         print("\n");
         exit(1);
     } else {
-        // Parent. The child has written 0x22222222 to *its* copy by now, or will
-        // shortly; either way the parent's must still read 0x11111111.
+        // Parent. This write faults on a page it shares with the child, and the
+        // kernel has to give the parent a private copy — not hand it the shared
+        // one.
+        unsafe { core::ptr::write_volatile(&raw mut FORK_WITNESS, 0x3333_3333) };
+
         let mut status: i32 = 0;
         wait(child, &mut status);
 
         let seen = unsafe { core::ptr::read_volatile(&raw const FORK_WITNESS) };
-        if seen == 0x1111_1111 {
+        if seen == 0x3333_3333 {
             print("  parent: the child did not touch my memory\n");
         } else {
             print("  WARNING: fork shared memory, witness reads ");
             print_hex(seen);
             print("\n");
+        }
+
+        // The child is gone, so this page has one holder again. Writing it
+        // exercises the other half of the copy-on-write path: take ownership
+        // rather than copy.
+        unsafe { core::ptr::write_volatile(&raw mut FORK_WITNESS, 0x4444_4444) };
+        if unsafe { core::ptr::read_volatile(&raw const FORK_WITNESS) } == 0x4444_4444 {
+            print("  parent: still writable after the child exited\n");
+        } else {
+            print("  WARNING: parent lost write access to its own page\n");
         }
 
         if status == 7 {


### PR DESCRIPTION
The previous phase's fork copied every page eagerly — about 400 KiB per fork of ksh, most of it a .bss the child execs away microseconds later. This shares instead: 20 pages shared, 0 copied at fork time, 3 copied lazily, exactly the ones that were written.

fork now marks *both* the parent's entry and the child's read-only with a COPY_ON_WRITE bit and bumps the frame's reference count. Marking only the child is the classic bug and it is silent — the parent's next write lands in the page the child is about to read. The test catches it deterministically, because fork returns in the parent with the child merely Ready, so the parent's write is guaranteed to happen first. Removing the one line that marks the parent produces "child saw 0x33333333 — the parent wrote through a shared page".

Pages already read-only (.text, .rodata) are shared without the marker: nothing can write them, so there is nothing to copy on. COPY_ON_WRITE is a separate bit from WRITABLE being clear so a genuinely read-only page keeps faulting.

resolve_cow has two cases, and the second matters: when the frame has other holders, copy; when this is the last holder, just restore WRITABLE. Without the second, a process whose child has exited would pay a full copy for every write forever, with nobody to copy away from. Both are exercised — 2 of 3 faults needed a copy.

Two syscall-path hazards. copy_to_user writes at the *user* address, so with CR0.WP a shared page would trap into the fault handler from ring 0, mid-syscall, possibly holding locks the handler wants; validate_user_range resolves copy-on-write up front instead. It would also have rejected the write outright, since a shared page is not WRITABLE.

The reference count is one byte per frame beside the bitmap. Placing it found two bugs of the same shape — a rule correct until the thing it described changed size. The metadata went "immediately after the kernel image", fine for a 16 KiB bitmap but not for 128 KiB more, and it landed on the boot modules: both read as zeros and the ELF loader reported BadMagic, several subsystems from the cause. And the reservation loop excluded only bitmap.len(), so the allocator handed out the refcount table's own frames — which showed up as 112,969 frames shared after a fork of twenty.

47 boot markers and 31 console markers pass. Two consecutive hello runs from ksh both end at 1613 used pages.


Claude-Session: https://claude.ai/code/session_01P1GdpYMiKP5Gj1Jmub59gw