### PR TITLE
kernel: demand paging

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ test disk, then boots the lot:
 
 ```bash
 ./scripts/run.sh              # boot it, serial on stdio (ctrl-a x to quit)
-./scripts/run.sh --check      # boot headless, assert 47 serial markers (CI)
+./scripts/run.sh --check      # boot headless, assert 49 serial markers (CI)
 ./scripts/run.sh --check-cli  # drive the shell through QEMU's monitor, assert 31
 ./scripts/run.sh --debug      # same as plain run, plus a gdb stub on :1234
 ```
@@ -112,6 +112,10 @@ interaction in `--check-cli`.
 - **Copy-on-write**: a `fork` copies no page data at all. Both sides go
   read-only, the frame reference count goes up, and the first write from either
   side faults into a private copy
+- **Demand paging**: `.bss`, user stacks and anonymous `mmap` are *reserved*
+  rather than allocated — a page table entry with no frame behind it until the
+  program touches it. A boot that runs five programs reserves 322 pages and
+  touches 38
 - **Per-thread kernel stacks**, so more than one thread can be inside a syscall
 - Real blocking: `wait` parks a thread in `State::Blocked` rather than spinning
 
@@ -164,11 +168,11 @@ all 5 IPC calls · all 4 driver calls · all 4 capability calls · `uname`
 Being explicit about this, because the earlier version of this file claimed most
 of it.
 
-- **No demand paging.** Every page of a program is allocated and populated at
-  load time, so `ksh`'s 256 KiB `.bss` costs 65 frames whether it is touched or
-  not. Copy-on-write means a `fork` no longer *copies* those 65, but the program
-  still pays for them at load. `mmap` has the same problem: it allocates the
-  whole span up front.
+- **Demand paging is anonymous-only.** A reserved page is always filled with
+  zeros. File-backed mappings would need the fault handler to read through the
+  VFS, so `mmap` still refuses anything but `MAP_ANONYMOUS`. There is also no
+  reclaim: nothing ever takes a page *back*, so the only pressure valve is a
+  process exiting.
 - **No `argv`.** `exec` takes a program name and nothing else; passing arguments
   needs somewhere to put the strings in the new address space.
 - **The filesystem is read-only.** `ksh` refuses redirection rather than
@@ -248,7 +252,7 @@ Roughly in order, each unblocking the next:
 - [x] Per-process address spaces
 - [x] `fork` and `exec`
 - [x] Copy-on-write, so a `fork` costs a page table rather than a program
-- [ ] Demand paging, so an untouched `.bss` costs nothing at all
+- [x] Demand paging, so an untouched `.bss` costs nothing at all
 - [ ] One process-id namespace, so the IPC and capability machinery becomes
       reachable from ring 3
 - [ ] Move the disk and filesystem out of the kernel — the point of the whole

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -1516,6 +1516,94 @@ Placing the table found two bugs in the same afternoon, both of the same shape �
 Two consecutive `hello` runs from `ksh` — each a fork, an exec, and two
 teardowns — both end at 1613 used pages.
 
+## Demand paging (Phase 16)
+
+Copy-on-write saved the *copy*. This saves the allocation.
+
+```
+  segment: vaddr 0x80d000 filesz 0 memsz 262200 [rw-] -> 0 page(s), 65 reserved
+  mmap gave me a usable megabyte at 0x0000000010000000 (2 pages touched)
+  recycled pages came back zeroed
+Demand paging: 322 page(s) reserved, 38 touched (284 never allocated)
+```
+
+`ksh` declares a 256 KiB heap in `.bss`. Every one of those 65 frames used to be
+allocated and zeroed at load time; now none of them are, and the shell reaches
+its first prompt having touched a handful.
+
+### A page table entry with nothing behind it
+
+A reservation is a **non-present** entry carrying the flags the page should have
+once it exists, plus a `DEMAND_ZERO` marker. Any access faults; the handler
+allocates a zeroed frame, sets `PRESENT`, clears the marker, and the instruction
+retries.
+
+The CPU ignores every bit of a non-present entry except the present bit itself,
+which is what makes the entry usable as somewhere to keep the intended
+permissions until they are needed.
+
+The `x86_64` crate's mapper deals in *mappings*, and a reservation is not one, so
+`leaf_entry` walks the four levels by hand — creating intermediate tables when
+asked, and refusing to walk *into* a huge page, because reinterpreting 2 MiB of
+somebody's data as page table entries is not a failure mode worth having.
+
+### Three places it applies
+
+| | before | after |
+|---|---|---|
+| the ELF `.bss` tail | every page of `p_memsz` allocated and zeroed | only pages holding file bytes; the rest reserved |
+| the user stack | 16 pages per program | 16 reservations |
+| anonymous `mmap` | the whole span | the whole span, reserved |
+
+The stack is the clearest case of the old cost: sixteen pages exist because
+`ksh`'s recursive-descent parser occasionally needs them, not because anything
+uses them on the way to the first prompt.
+
+### What had to learn about absent pages
+
+- **`fork`** copies the reservation rather than sharing a frame — there is no
+  frame. Whichever side touches the page first gets its own zeroed one, which is
+  exactly the semantics `fork` wants for untouched memory.
+- **Teardown** must not free a reservation. `entry.addr()` on one returns zero,
+  so the previous code would have handed physical frame 0 to the allocator once
+  per untouched page.
+- **`uaccess`** materialises before checking. `copy_to_user` writes at the *user*
+  address, so a reserved destination would fault from ring 0 mid-syscall — the
+  same hazard copy-on-write has, with the same fix.
+- **`mmap`'s free-region scan** had to learn that a reservation occupies an
+  address. `translate` only reports mappings, so the scan would happily pick a
+  range that already had a promise attached.
+
+### Proving it, and a test that was not a test
+
+The obvious check — "a fresh `mmap` reads as zero" — proves nothing on a mostly
+idle system, where the allocator hands back frames nothing has ever written. It
+passed with the zeroing deliberately removed.
+
+The version that works recycles: dirty a region with a pattern, `munmap` it,
+`mmap` again — those are the same frames — and look.
+
+```
+  WARNING: 16 recycled page(s) still held the old contents
+```
+
+That is what removing the `write_bytes` produces. All sixteen, every time.
+
+### The same bug, twice, in two files
+
+The second `mmap` in a program failed with `EBADF`, and the first worked.
+
+`validate_mmap_args` checked `args[4]` — the file descriptor — whenever
+`MAP_ANONYMOUS` was absent, using the mask `0x01`. `MAP_ANONYMOUS` is `0x20`, so
+the check ran on every call; `fd` arrives in R8, which a four-argument syscall
+wrapper never sets; and by the second `mmap` R8 happened to hold something above
+1024.
+
+This is the identical bug fixed in `sys_mmap` itself one phase ago, written up
+then as *"a syscall must not read an argument the ABI does not require the caller
+to set"* — and the validator, ten lines away, kept it. Writing the lesson down
+did not find the second instance. Grepping for `args[4]` would have.
+
 ## What is deliberately still missing
 - **The filesystem is read-only.** Allocating clusters and keeping both FAT
   copies consistent is a separate problem, and a read-only filesystem that is

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -856,6 +856,14 @@ fn init_usermode() {
     serial_println!("--- back in ring 0 ---");
     crate::task::reap_finished();
 
+    let (demand_faults, reserved) = crate::memory::paging::demand_stats();
+    serial_println!(
+        "Demand paging: {} page(s) reserved, {} touched ({} never allocated)",
+        reserved,
+        demand_faults,
+        reserved.saturating_sub(demand_faults)
+    );
+
     let (cow_resolved, cow_copied) = crate::memory::paging::cow_stats();
     serial_println!(
         "Copy-on-write: {} fault(s) resolved, {} needed a copy, {} frame(s) still shared",

--- a/kernel/src/elf.rs
+++ b/kernel/src/elf.rs
@@ -231,25 +231,55 @@ unsafe fn load_segment(
         flags |= PageTableFlags::NO_EXECUTE;
     }
 
+    // Only the pages that actually hold file bytes are allocated. The tail —
+    // the part of `p_memsz` past `p_filesz`, which is `.bss` — is *reserved*:
+    // recorded in the page tables as a promise, with no frame behind it until
+    // the program touches the page.
+    //
+    // For `ksh` that is most of what it declares, because its 256 KiB heap lives
+    // in `.bss` and most of it is never used. Before this, every page was
+    // allocated and zeroed at load time.
+    let file_end = if ph.filesz == 0 {
+        start
+    } else {
+        (ph.vaddr + ph.filesz + PAGE_SIZE as u64 - 1) & !(PAGE_SIZE as u64 - 1)
+    };
+    let eager_pages = (((file_end.max(start) - start) / PAGE_SIZE as u64) as usize).min(pages);
+    let reserved_pages = pages - eager_pages;
+
+    if eager_pages > 0 {
+        paging::map_user_pages_in(paging::mapper_for(pml4_phys), start, eager_pages, flags)
+            .map_err(ElfError::MappingFailed)?;
+    }
+    if reserved_pages > 0 {
+        paging::reserve_user_pages_in(
+            pml4_phys,
+            start + (eager_pages * PAGE_SIZE) as u64,
+            reserved_pages,
+            flags,
+        )
+        .map_err(ElfError::MappingFailed)?;
+        paging::note_reserved(reserved_pages);
+    }
+
     serial_println!(
-        "  segment: vaddr 0x{:x} filesz {} memsz {} [{}{}{}] -> {} page(s)",
+        "  segment: vaddr 0x{:x} filesz {} memsz {} [{}{}{}] -> {} page(s), {} reserved",
         ph.vaddr,
         ph.filesz,
         ph.memsz,
         if ph.flags & PF_R != 0 { "r" } else { "-" },
         if ph.flags & PF_W != 0 { "w" } else { "-" },
         if ph.flags & PF_X != 0 { "x" } else { "-" },
-        pages
+        eager_pages,
+        reserved_pages
     );
 
-    // Allocate and map the whole span with its final permissions, in the target
-    // address space rather than the one this code happens to be running in.
-    paging::map_user_pages_in(paging::mapper_for(pml4_phys), start, pages, flags)
-        .map_err(ElfError::MappingFailed)?;
-
-    // Fill it in through the physmap. `map_user_pages` already zeroed every
-    // frame, which is what makes the .bss tail correct without extra work: we
-    // only have to write the `p_filesz` bytes that come from the file.
+    // Fill in the file bytes through the physmap.
+    //
+    // The `.bss` tail is still zero without extra work here, for two reasons
+    // now: the pages that hold file bytes were zeroed by `map_user_pages_in`
+    // before anything was written to them, and the reserved pages beyond them
+    // are zeroed when the fault handler materialises each one.
     for i in 0..ph.filesz as usize {
         let vaddr = ph.vaddr + i as u64;
         let phys = paging::translate_in(pml4_phys, vaddr)

--- a/kernel/src/interrupts/exceptions.rs
+++ b/kernel/src/interrupts/exceptions.rs
@@ -164,6 +164,26 @@ pub extern "x86-interrupt" fn page_fault_handler(
         }
     }
 
+    // Demand-zero, likewise before anything is printed. A first touch of a
+    // reserved page — a program's `.bss`, its stack, an anonymous `mmap` — is
+    // the mechanism working, not an error.
+    if !error_code.contains(PageFaultErrorCode::PROTECTION_VIOLATION)
+        && accessed.as_u64() < crate::syscall::uaccess::USER_ADDRESS_LIMIT
+    {
+        match crate::memory::paging::resolve_demand(accessed.as_u64()) {
+            Ok(true) => return,
+            Ok(false) => {}
+            Err(e) => {
+                serial_println!();
+                serial_println!(
+                    "Demand-zero fault at 0x{:x} could not be serviced: {}",
+                    accessed.as_u64(),
+                    e
+                );
+            }
+        }
+    }
+
     serial_println!();
     serial_println!("==================== PAGE FAULT ====================");
     serial_println!("  accessed address : 0x{:016x}", accessed.as_u64());

--- a/kernel/src/memory/address_space.rs
+++ b/kernel/src/memory/address_space.rs
@@ -175,9 +175,14 @@ unsafe fn free_level(table_phys: u64, level: u8) -> usize {
         let addr = entry.addr().as_u64();
 
         if level == 1 || flags.contains(PageTableFlags::HUGE_PAGE) {
-            // A leaf. Free the frame only if this space owns it — the built-in
-            // ring-3 payload is mapped straight out of the kernel image.
-            if flags.contains(OWNED_BY_ADDRESS_SPACE) {
+            // A leaf. Free the frame only if this space owns it *and* one exists
+            // — the built-in ring-3 payload is mapped straight out of the kernel
+            // image, and a reservation has no frame at all. Freeing a
+            // reservation would hand physical frame 0 to the allocator, once per
+            // untouched page.
+            if flags.contains(PageTableFlags::PRESENT)
+                && flags.contains(OWNED_BY_ADDRESS_SPACE)
+            {
                 deallocate_frame(PageFrame::from_address(addr as usize));
                 freed += 1;
             }
@@ -269,6 +274,15 @@ unsafe fn clone_level(
         let addr = source[i].addr().as_u64();
 
         if level == 1 || flags.contains(PageTableFlags::HUGE_PAGE) {
+            if !flags.contains(PageTableFlags::PRESENT) {
+                // A reservation: no frame yet, so there is nothing to share and
+                // nothing to count. The child inherits the promise, and whichever
+                // side touches the page first gets its own zeroed frame — which
+                // is exactly the semantics `fork` wants for untouched memory.
+                target[i].set_addr(PhysAddr::new(0), flags);
+                continue;
+            }
+
             if flags.contains(OWNED_BY_ADDRESS_SPACE) {
                 // A page this process owns: share the frame, and make both sides
                 // fault on their next write.

--- a/kernel/src/memory/paging.rs
+++ b/kernel/src/memory/paging.rs
@@ -164,6 +164,174 @@ pub const OWNED_BY_ADDRESS_SPACE: PageTableFlags = PageTableFlags::BIT_9;
 /// writable copy.
 pub const COPY_ON_WRITE: PageTableFlags = PageTableFlags::BIT_10;
 
+/// Marks a page that has been *reserved* but never allocated.
+///
+/// The entry is **not present**, so any access faults; the rest of the entry
+/// carries the flags the page should have once it exists. `resolve_demand`
+/// allocates a zeroed frame on first touch.
+///
+/// This is what makes a program's `.bss`, its stack and an anonymous `mmap`
+/// cost nothing until they are used. `ksh` declares a 256 KiB heap in `.bss`;
+/// before this, all 65 frames were allocated and zeroed at load time whether the
+/// program touched them or not.
+///
+/// A non-present entry's other bits are ignored by the CPU, which is what makes
+/// it usable as somewhere to keep the intended permissions.
+pub const DEMAND_ZERO: PageTableFlags = PageTableFlags::BIT_11;
+
+/// Walk to a leaf entry, creating the intermediate tables if asked.
+///
+/// The `x86_64` crate's mapper deals in *mappings*; a reservation is not a
+/// mapping, so the table walk has to be done by hand. Returns `None` if a level
+/// is missing and `create` is false.
+///
+/// # Safety
+/// `pml4_phys` must be a live PML4 and the caller must not hold another
+/// reference into the same tables.
+unsafe fn leaf_entry(
+    pml4_phys: u64,
+    virt: u64,
+    create: bool,
+) -> Option<&'static mut x86_64::structures::paging::page_table::PageTableEntry> {
+    let indices = [
+        ((virt >> 39) & 0x1FF) as usize,
+        ((virt >> 30) & 0x1FF) as usize,
+        ((virt >> 21) & 0x1FF) as usize,
+        ((virt >> 12) & 0x1FF) as usize,
+    ];
+
+    // Intermediate entries are permissive; the leaf's own flags decide access.
+    // The same reasoning as `map_user_range_in`: the CPU takes the *most*
+    // restrictive of the path, so a supervisor-only parent would make every leaf
+    // under it supervisor-only.
+    let table_flags = PageTableFlags::PRESENT
+        | PageTableFlags::WRITABLE
+        | PageTableFlags::USER_ACCESSIBLE;
+
+    let mut table = &mut *((PHYSMAP_BASE + pml4_phys) as *mut PageTable);
+
+    for level in 0..3 {
+        let entry = &mut table[indices[level]];
+
+        if entry.is_unused() {
+            if !create {
+                return None;
+            }
+            let frame = allocate_frame()?;
+            let phys = frame.address() as u64;
+            core::ptr::write_bytes((PHYSMAP_BASE + phys) as *mut u8, 0, PAGE_SIZE);
+            entry.set_addr(PhysAddr::new(phys), table_flags);
+        } else if entry.flags().contains(PageTableFlags::HUGE_PAGE) {
+            // A huge page where a table was expected. Nothing in the lower half
+            // creates one, but walking into it as if it were a table would
+            // reinterpret 2 MiB of somebody's data as page table entries.
+            return None;
+        }
+
+        let next = entry.addr().as_u64();
+        table = &mut *((PHYSMAP_BASE + next) as *mut PageTable);
+    }
+
+    Some(&mut table[indices[3]])
+}
+
+/// Reserve `pages` at `virt` without allocating a single frame.
+///
+/// The counterpart to [`map_user_pages_in`]: same result from the program's
+/// point of view, at the cost of one page fault per page actually used instead
+/// of one allocation per page declared.
+pub fn reserve_user_pages_in(
+    pml4_phys: u64,
+    virt: u64,
+    pages: usize,
+    flags: PageTableFlags,
+) -> Result<(), &'static str> {
+    // Not present, so the CPU faults; OWNED so teardown knows the frame belongs
+    // to this address space once it exists.
+    let reserved = (flags | DEMAND_ZERO | OWNED_BY_ADDRESS_SPACE) - PageTableFlags::PRESENT;
+
+    for i in 0..pages {
+        let addr = virt + (i * PAGE_SIZE) as u64;
+        let entry = unsafe { leaf_entry(pml4_phys, addr, true) }
+            .ok_or("out of memory reserving user pages")?;
+
+        if !entry.is_unused() {
+            return Err("reserving a page that is already mapped");
+        }
+
+        // Address zero: there is no frame yet, and `resolve_demand` uses the
+        // absent PRESENT bit rather than the address to tell reserved from
+        // mapped.
+        entry.set_addr(PhysAddr::new(0), reserved);
+    }
+
+    Ok(())
+}
+
+/// Does this address have a reservation waiting on it?
+pub fn is_reserved(pml4_phys: u64, virt: u64) -> bool {
+    match unsafe { leaf_entry(pml4_phys, virt, false) } {
+        Some(entry) => entry.flags().contains(DEMAND_ZERO),
+        None => false,
+    }
+}
+
+/// Demand-zero faults serviced since boot, and pages still reserved.
+static DEMAND_FAULTS: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+static PAGES_RESERVED: core::sync::atomic::AtomicU64 = core::sync::atomic::AtomicU64::new(0);
+
+pub fn demand_stats() -> (u64, u64) {
+    use core::sync::atomic::Ordering;
+    (
+        DEMAND_FAULTS.load(Ordering::Relaxed),
+        PAGES_RESERVED.load(Ordering::Relaxed),
+    )
+}
+
+pub fn note_reserved(pages: usize) {
+    PAGES_RESERVED.fetch_add(pages as u64, core::sync::atomic::Ordering::Relaxed);
+}
+
+/// Give a reserved page a real, zeroed frame.
+///
+/// Returns `Ok(true)` if it did something, `Ok(false)` if the address was not
+/// reserved and the fault is real.
+pub fn resolve_demand(virt: u64) -> Result<bool, &'static str> {
+    use x86_64::instructions::tlb;
+
+    let pml4 = Cr3::read().0.start_address().as_u64();
+
+    let entry = match unsafe { leaf_entry(pml4, virt, false) } {
+        Some(e) => e,
+        None => return Ok(false),
+    };
+
+    let flags = entry.flags();
+    if flags.contains(PageTableFlags::PRESENT) || !flags.contains(DEMAND_ZERO) {
+        return Ok(false);
+    }
+
+    let frame = allocate_frame().ok_or("out of memory servicing a demand-zero fault")?;
+    let phys = frame.address() as u64;
+
+    unsafe {
+        // Zero before it is reachable from ring 3. Handing a process a page of
+        // somebody else's data is the classic information leak, and a reserved
+        // page is *promised* to read as zero.
+        core::ptr::write_bytes((PHYSMAP_BASE + phys) as *mut u8, 0, PAGE_SIZE);
+    }
+
+    entry.set_addr(
+        PhysAddr::new(phys),
+        (flags | PageTableFlags::PRESENT) - DEMAND_ZERO,
+    );
+
+    tlb::flush(VirtAddr::new(virt));
+    DEMAND_FAULTS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
+
+    Ok(true)
+}
+
 /// Give the current address space a private, writable copy of a shared page.
 ///
 /// Returns `Ok(true)` if it did something, `Ok(false)` if the page was not

--- a/kernel/src/syscall/dispatcher.rs
+++ b/kernel/src/syscall/dispatcher.rs
@@ -458,11 +458,20 @@ fn sys_mmap(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
         find_free_region(pages).ok_or(SyscallError::OutOfMemory)?
     };
 
-    crate::memory::paging::map_user_pages(base, pages, page_flags)
-        .map_err(|e| {
+    // Reserved rather than allocated: `mmap` is the syscall most likely to be
+    // asked for more than the caller will touch, and a reservation costs a page
+    // table entry. The pages still read as zero — the fault handler zeroes each
+    // frame before it is reachable — so nothing about the contract changes.
+    let pml4 = crate::memory::paging::kernel_pml4_phys();
+    let target = crate::task::current_address_space_pml4().unwrap_or(pml4);
+
+    crate::memory::paging::reserve_user_pages_in(target, base, pages, page_flags).map_err(
+        |e| {
             serial_println!("Process {} mmap failed: {}", process_id.0, e);
             SyscallError::OutOfMemory
-        })?;
+        },
+    )?;
+    crate::memory::paging::note_reserved(pages);
 
     if syscall_trace_enabled() {
         serial_println!(
@@ -483,11 +492,22 @@ fn sys_mmap(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
     Err(SyscallError::NotSupported)
 }
 
-/// Is every page of this span currently unmapped in the calling process?
+/// Is every page of this span free — neither mapped nor reserved?
+///
+/// `translate` only sees *mappings*, and a reserved page is not one, so asking
+/// it alone would happily hand out an address that already has a promise
+/// attached. `reserve_user_pages_in` would then refuse, but only after the
+/// scan had picked the address.
 #[cfg(target_arch = "x86_64")]
 fn region_free(base: u64, pages: usize) -> bool {
+    let pml4 = match crate::task::current_address_space_pml4() {
+        Some(p) => p,
+        None => return false,
+    };
     (0..pages).all(|i| {
-        crate::memory::paging::translate(base + (i * crate::memory::PAGE_SIZE) as u64).is_none()
+        let addr = base + (i * crate::memory::PAGE_SIZE) as u64;
+        crate::memory::paging::translate(addr).is_none()
+            && !crate::memory::paging::is_reserved(pml4, addr)
     })
 }
 

--- a/kernel/src/syscall/uaccess.rs
+++ b/kernel/src/syscall/uaccess.rs
@@ -71,6 +71,15 @@ pub fn validate_user_range(ptr: u64, len: usize, writable: bool) -> Result<(), U
     let mut page = first_page;
 
     while page < end {
+        // A reserved page is not mapped *yet*. The kernel is about to read or
+        // write it at the user address, which would fault from ring 0 in the
+        // middle of a syscall — the same hazard copy-on-write has — so
+        // materialise it before the check rather than after.
+        //
+        // Unconditional and idempotent: `resolve_demand` returns `Ok(false)`
+        // immediately for anything that is not a reservation.
+        let _ = crate::memory::paging::resolve_demand(page);
+
         match mapper.translate(VirtAddr::new(page)) {
             TranslateResult::Mapped { flags, .. } => {
                 if !flags.contains(PageTableFlags::USER_ACCESSIBLE) {

--- a/kernel/src/syscall/validation.rs
+++ b/kernel/src/syscall/validation.rs
@@ -186,28 +186,43 @@ fn validate_kill_args(args: &[u64; 6]) -> Result<(), SyscallError> {
 }
 
 // Memory management syscall validations
+/// `mmap(addr, length, prot, flags, fd, offset)`.
+///
+/// **`fd` is only read when `MAP_ANONYMOUS` is absent**, and that is not a
+/// nicety. `fd` arrives in R8, and a caller using a four-argument syscall
+/// wrapper — which is every caller here, because anonymous mappings need no more
+/// — never sets R8. Reading it means reading a stale register.
+///
+/// This bug was found once already, in `sys_mmap` itself, and fixed there. The
+/// validator kept it, and the symptom was worth the reminder: the *first*
+/// `mmap` in a program worked and a later one failed with `EBADF`, because by
+/// then R8 happened to hold something above 1024. The lesson from last time was
+/// written down and the second instance still shipped, which is an argument for
+/// grepping rather than remembering.
+///
+/// The mask is also corrected: `MAP_ANONYMOUS` is `0x20`, not `0x01`.
 fn validate_mmap_args(args: &[u64; 6]) -> Result<(), SyscallError> {
-    let addr = args[0];
+    const MAP_ANONYMOUS: u64 = 0x20;
+
     let length = args[1];
     let prot = args[2];
     let flags = args[3];
-    let fd = args[4];
-    let offset = args[5];
-    
+
     if length == 0 {
         return Err(SyscallError::InvalidArgument);
     }
-    
-    // Validate protection flags
-    if prot > 7 {  // PROT_READ | PROT_WRITE | PROT_EXEC
+
+    // PROT_READ | PROT_WRITE | PROT_EXEC
+    if prot > 7 {
         return Err(SyscallError::InvalidArgument);
     }
-    
-    // If mapping a file, validate file descriptor
-    if (flags & 0x01) == 0 && fd != u64::MAX {  // Not MAP_ANONYMOUS
-        validate_file_descriptor(fd)?;
+
+    if flags & MAP_ANONYMOUS == 0 {
+        // A file mapping, which the handler refuses anyway — but the caller has
+        // told us it set `fd`, so checking it is meaningful.
+        validate_file_descriptor(args[4])?;
     }
-    
+
     Ok(())
 }
 

--- a/kernel/src/usermode.rs
+++ b/kernel/src/usermode.rs
@@ -352,8 +352,12 @@ fn prepare_program(image: &[u8]) -> Result<(AddressSpace, u64), SpawnError> {
         | PageTableFlags::USER_ACCESSIBLE
         | PageTableFlags::NO_EXECUTE;
 
-    let mapped = paging::map_user_pages_in(
-        unsafe { paging::mapper_for(space.pml4_phys()) },
+    // Reserved, not allocated. A program that uses one page of stack should not
+    // pay for sixteen — and the sixteen exist precisely because `ksh`'s parser
+    // occasionally needs them, not because anything uses them on the way to the
+    // first prompt.
+    let mapped = paging::reserve_user_pages_in(
+        space.pml4_phys(),
         stack_bottom,
         USER_STACK_PAGES_MAX,
         stack_flags,
@@ -363,6 +367,7 @@ fn prepare_program(image: &[u8]) -> Result<(AddressSpace, u64), SpawnError> {
         unsafe { space.free() };
         return Err(SpawnError::Map(e));
     }
+    paging::note_reserved(USER_STACK_PAGES_MAX);
 
     serial_println!(
         "  loaded {} segment(s), {} bytes, entry 0x{:x}, stack 0x{:x}..0x{:x}",

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -254,8 +254,10 @@ check)
         "hello from a loaded ELF binary" \
         ".bss was zeroed correctly" \
         "stack is writable and readable" \
-        "mmap gave me 8192 usable bytes" \
+        "mmap gave me a usable megabyte" \
+        "Demand paging: " \
         "munmap returned the pages" \
+        "recycled pages came back zeroed" \
         "CLOCK_MONOTONIC moves forwards" \
         "debug_print echoed my message" \
         "child: I inherited the value my parent set before forking" \

--- a/userspace/hello/src/main.rs
+++ b/userspace/hello/src/main.rs
@@ -233,31 +233,93 @@ pub extern "C" fn kosh_main() -> ! {
     // mmap: memory the program was not given at load time. Until this release
     // `mmap` returned the constant 0x40000000 and reported success, so writing
     // to the result faulted.
-    let mapped = mmap(8192, PROT_READ | PROT_WRITE);
+    // A megabyte, of which this touches two pages. Under eager allocation that
+    // is 256 frames for 8 KiB of use; reserved, it is 256 page table entries.
+    const BIG: u64 = 1024 * 1024;
+    let mapped = mmap(BIG, PROT_READ | PROT_WRITE);
     if mapped < 0 {
         print("  WARNING: mmap failed\n");
     } else {
         let p = mapped as u64 as *mut u64;
+
+        // A page near the far end, which nothing has touched. It must read as
+        // zero — a reserved page is *promised* to, and handing over a frame with
+        // somebody else's data in it is the classic information leak.
+        let far = unsafe { p.byte_add((BIG - 4096) as usize) };
+        let far_before = unsafe { core::ptr::read_volatile(far) };
+
         unsafe {
             core::ptr::write_volatile(p, 0x1234_5678_9abc_def0);
-            core::ptr::write_volatile(p.add(1023), 0x0fed_cba9_8765_4321);
+            core::ptr::write_volatile(far, 0x0fed_cba9_8765_4321);
         }
         let ok = unsafe {
             core::ptr::read_volatile(p) == 0x1234_5678_9abc_def0
-                && core::ptr::read_volatile(p.add(1023)) == 0x0fed_cba9_8765_4321
+                && core::ptr::read_volatile(far) == 0x0fed_cba9_8765_4321
         };
-        if ok {
-            print("  mmap gave me 8192 usable bytes at 0x");
+
+        if far_before != 0 {
+            print("  WARNING: an untouched page came back non-zero\n");
+        } else if ok {
+            print("  mmap gave me a usable megabyte at 0x");
             print_hex(mapped as u64);
-            print("\n");
+            print(" (2 pages touched)\n");
         } else {
             print("  WARNING: mmap memory did not hold its contents\n");
         }
 
-        if munmap(mapped as u64, 8192) < 0 {
+        if munmap(mapped as u64, BIG) < 0 {
             print("  WARNING: munmap failed\n");
         } else {
             print("  munmap returned the pages\n");
+        }
+
+        // Recycled memory must not carry the last tenant's data.
+        //
+        // Checking that a *fresh* mapping reads zero proves nothing on a mostly
+        // idle system, where the allocator hands back frames that were never
+        // written. So: dirty a region, give it back, take it again, and look.
+        // Those are the same frames.
+        const SMALL: u64 = 64 * 1024;
+        const PATTERN: u64 = 0xDEAD_BEEF_CAFE_F00D;
+
+        let first = mmap(SMALL, PROT_READ | PROT_WRITE);
+        if first <= 0 {
+            print("  WARNING: second mmap failed with ");
+            print_i64(first);
+            print("\n");
+        } else {
+            let q = first as u64 as *mut u64;
+            let mut page = 0u64;
+            while page < SMALL {
+                unsafe { core::ptr::write_volatile(q.byte_add(page as usize), PATTERN) };
+                page += 4096;
+            }
+            munmap(first as u64, SMALL);
+
+            let second = mmap(SMALL, PROT_READ | PROT_WRITE);
+            if second <= 0 {
+                print("  WARNING: third mmap failed with ");
+                print_i64(second);
+                print("\n");
+            } else {
+                let r = second as u64 as *mut u64;
+                let mut leaked = 0;
+                let mut page = 0u64;
+                while page < SMALL {
+                    if unsafe { core::ptr::read_volatile(r.byte_add(page as usize)) } == PATTERN {
+                        leaked += 1;
+                    }
+                    page += 4096;
+                }
+                if leaked == 0 {
+                    print("  recycled pages came back zeroed\n");
+                } else {
+                    print("  WARNING: ");
+                    print_i64(leaked);
+                    print(" recycled page(s) still held the old contents\n");
+                }
+                munmap(second as u64, SMALL);
+            }
         }
     }
 


### PR DESCRIPTION
Copy-on-write saved the copy; this saves the allocation. A reservation is a non-present page table entry carrying the flags the page should have, plus a DEMAND_ZERO marker. The first access faults, the handler allocates a zeroed frame, and the instruction retries.

Applied to the three places that allocate memory a program may never touch: the ELF loader's .bss tail, the user stack, and anonymous mmap. ksh declares a 256 KiB heap in .bss — 65 frames allocated and zeroed at load time before, none now. A boot running five programs reserves 322 pages and touches 38.

The x86_64 crate's mapper deals in mappings and a reservation is not one, so leaf_entry walks the four levels by hand — creating intermediate tables on request and refusing to walk into a huge page.

Four things had to learn about absent pages. fork copies the reservation rather than sharing a frame, since there is no frame; teardown must skip it, or entry.addr() hands physical frame 0 to the allocator once per untouched page; uaccess materialises before checking, because copy_to_user writes at the user address and would otherwise fault from ring 0 mid-syscall; and mmap's free-region scan had to stop treating a reservation as free address space, because translate only reports mappings.

The obvious test — "a fresh mmap reads zero" — proves nothing on an idle system where the allocator returns frames nothing ever wrote, and it passed with the zeroing deliberately removed. The version that works recycles: dirty a region, munmap, mmap again, look. Removing the write_bytes then reports all 16 pages still holding the old pattern.

Also fixes the same bug twice over: validate_mmap_args checked args[4] whenever MAP_ANONYMOUS was absent, using the mask 0x01 where MAP_ANONYMOUS is 0x20 — so it checked on every call, reading R8, which a four-argument syscall wrapper never sets. The first mmap in a program worked and the second failed with EBADF. This is the identical bug fixed in sys_mmap one phase ago and written up as "a syscall must not read an argument the ABI does not require the caller to set". The validator ten lines away kept it.

49 boot markers and 31 console markers pass. Two hello runs from ksh both end at 1523 used pages.


Claude-Session: https://claude.ai/code/session_01P1GdpYMiKP5Gj1Jmub59gw