### PR TITLE
kernel: one process-id namespace, and IPC that carries bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,8 @@ test disk, then boots the lot:
 
 ```bash
 ./scripts/run.sh              # boot it, serial on stdio (ctrl-a x to quit)
-./scripts/run.sh --check      # boot headless, assert 49 serial markers (CI)
-./scripts/run.sh --check-cli  # drive the shell through QEMU's monitor, assert 31
+./scripts/run.sh --check      # boot headless, assert 52 serial markers (CI)
+./scripts/run.sh --check-cli  # drive the shell through QEMU's monitor, assert 32
 ./scripts/run.sh --debug      # same as plain run, plus a gdb stub on :1234
 ```
 
@@ -141,27 +141,36 @@ interaction in `--check-cli`.
 - `ksh` can launch programs: unknown commands become `spawn` + `wait`, and
   `cmd &` starts one in the background
 
+**Processes and IPC**
+- A process *is* a ring-3 thread with an address space, registered in the
+  process table at the same id — one namespace, not two
+- `send_message`/`receive_message` carry real bytes, with a blocking receive
+  that parks the thread rather than spinning
+- **Capabilities that can refuse**: `fork` and `spawn` open a channel between a
+  process and its parent, and nothing else. A message to any other process is
+  `PermissionDenied`, and the test checks it
+
 **In-kernel console**
 - A fallback shell on the same keyboard, which takes over when `ksh` exits — so
   there is a prompt on a system whose userspace has died
 
 ## The syscall surface
 
-44 numbers are defined; **20 do the work** and the other 24 return an error
+44 numbers are defined; **23 do the work** and the other 21 return an error
 saying so. Nothing returns success for work it did not do.
 
-**Working** (all 20 exercised from ring 3, not just by the kernel checking
+**Working** (all 23 exercised from ring 3, not just by the kernel checking
 itself):
 
-`exit` `fork` `exec` `wait` `getpid` `yield` `spawn` · `mmap` `munmap` · `open`
-`close` `read` `write` `lseek` `stat` `getdents` · `time` `clock_gettime` ·
-`debug_print` `debug_dump`
+`exit` `fork` `exec` `wait` `getpid` `getppid` `yield` `spawn` · `mmap`
+`munmap` · `open` `close` `read` `write` `lseek` `stat` `getdents` · `time`
+`clock_gettime` · `send_message` `receive_message` · `debug_print` `debug_dump`
 
 **Refuses with `NotSupported`, honestly:**
 
-`kill` `getppid` · `mprotect` `brk` `sbrk` · `fstat` `mkdir` `rmdir` `unlink` ·
-all 5 IPC calls · all 4 driver calls · all 4 capability calls · `uname`
-`sysinfo`
+`kill` · `mprotect` `brk` `sbrk` · `fstat` `mkdir` `rmdir` `unlink` ·
+`reply_message` `create_channel` `destroy_channel` · all 4 driver calls · all 4
+capability calls · `uname` `sysinfo`
 
 ## What does not work
 
@@ -177,13 +186,13 @@ of it.
   needs somewhere to put the strings in the new address space.
 - **The filesystem is read-only.** `ksh` refuses redirection rather than
   pretending; there is no `mkdir`, `unlink` or write path.
-- **No IPC from userspace.** `kernel/src/ipc/` is ~85 KB of real queueing and
-  capability machinery, and it is unreachable: `syscall/entry.rs` passes a
-  *thread* id where the IPC layer expects a `ProcessTable` entry, and those two
-  namespaces are unrelated. Reconciling them is the next IPC job.
-- **Capability-based security is not enforced.** Same story: the machinery exists
-  in-kernel, all four capability syscalls return `NotSupported`, and no code path
-  checks a capability on behalf of a user process.
+- **IPC is send/receive only.** `reply_message`, `create_channel` and
+  `destroy_channel` still refuse, and there is no timeout on a blocking receive:
+  a process waiting for a message that never comes waits forever.
+- **Capabilities are not exposed to userspace.** They are enforced on the IPC
+  path — a process may message its parent and its children, and nothing else —
+  but the four capability syscalls still return `NotSupported`, so a program
+  cannot inspect or delegate what it holds.
 - **Not actually a microkernel yet.** The ATA driver, the filesystem and the
   keyboard driver are all *in* the kernel. That is the opposite of the intended
   design and is where the IPC work above leads.
@@ -253,8 +262,7 @@ Roughly in order, each unblocking the next:
 - [x] `fork` and `exec`
 - [x] Copy-on-write, so a `fork` costs a page table rather than a program
 - [x] Demand paging, so an untouched `.bss` costs nothing at all
-- [ ] One process-id namespace, so the IPC and capability machinery becomes
-      reachable from ring 3
+- [x] One process-id namespace, so IPC and capabilities became reachable
 - [ ] Move the disk and filesystem out of the kernel — the point of the whole
       exercise
 - [ ] FAT32 writes

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -1604,6 +1604,130 @@ then as *"a syscall must not read an argument the ABI does not require the calle
 to set"* — and the validator, ten lines away, kept it. Writing the lesson down
 did not find the second instance. Grepping for `args[4]` would have.
 
+## One process-id namespace, and IPC that carries bytes (Phase 17)
+
+`kernel/src/ipc/` has been ~85 KB of implemented message queues, capability sets
+and security policy since long before anything could reach it. What kept it
+unreachable was not missing code but a **name collision**.
+
+`syscall/entry.rs` passed the calling *thread's* id as a `ProcessId`.
+`ipc::message::send_message` looked that id up in `process::ProcessTable`, whose
+only entries were three processes a boot self-test created — `init`, `shell` and
+`background_task`, at pids 1, 2 and 3, because the table's allocator is a
+monotonic counter starting at 1.
+
+Thread ids run 0..15. So the behaviour depended on which slot a program happened
+to land in:
+
+| thread | what `send_message` did |
+|---|---|
+| 0 | `SenderNotFound` — pid 0 can never exist, the counter starts at 1 |
+| 1, 2, 3 | **passed**, attributed to `init`/`shell`/`background_task` |
+| 4..15 | `SenderNotFound` |
+
+Worse, the self-test granted pid 1 `(SendMessage, ResourceId::Any)`, so a ring-3
+thread that landed in slot 1 also passed the capability check — as "init". A bug
+that depends on a scheduler slot is a bug that looks intermittent.
+
+### A process is a thread with an address space
+
+There is no second abstraction, and pretending there was is what left the table
+holding synthetic rows while every real program ran outside it. So the pid *is*
+the thread id, and `usermode::register_process` is the one place a process comes
+into existence.
+
+`ProcessTable` needed `create_process_with_pid`, because its own allocator is a
+counter and a caller-chosen id was impossible. Two allocators would have been two
+namespaces again.
+
+Registration sets up three things together, because a process missing any of them
+fails somewhere unhelpful:
+
+- the **table entry**, without which `send_message` reports `SenderNotFound`;
+- a **message queue**, without which a `receive` before the first `send` reports
+  `ReceiverNotFound` rather than "no message" — `enqueue_message` creates a queue
+  on demand but `dequeue_message` does not, an asymmetry worth knowing about;
+- a **capability** to exchange messages with its parent.
+
+### Capabilities that can refuse
+
+`security::grant_system_process_capabilities` hands out `(SendMessage,
+ResourceId::Any)`, which makes the check unable to say no to anything. It is not
+used. `create_secure_ipc_channel(child, parent)` grants each side `SendMessage`
+scoped to the *other specifically*, and that is the whole policy: **a process may
+message its parent and its children.**
+
+That is narrow, and it is narrow on purpose — a capability system that grants
+everything is decoration. The test reaches it:
+
+```
+  child: messaging my grandparent was refused
+```
+
+The grandparent is the shell that started this program. It exists, so the
+receiver-existence check passes and the *capability* check is what refuses.
+Swapping the scoped grant for `SendMessage/Any` turns that line into
+`WARNING: messaged a process I have no capability for`.
+
+Worth separating from a weaker check in the same test: sending to pid 999 is also
+refused, but by the existence check, which runs first. That one proves nothing
+about capabilities, and the test says so.
+
+### The payload
+
+```
+  parent: got the child's message, bytes and all
+```
+
+`send_message` copies the caller's buffer with `copy_from_user` and enqueues
+`MessageData::Bytes`. What it replaces substituted
+`MessageData::Text(format!("Message from process {} (len={})", pid, len))` — a
+*description* of the message, delivered instead of the message, with `Ok(0)`
+returned to the sender. `receive_message` used to dequeue for real and return
+only the message id, dropping the payload.
+
+Copying was never the hard part; `copy_from_user` had existed for phases. The
+namespace was.
+
+`receive_message` returns `(sender << 32) | length`, because a syscall has one
+return value and the receiver needs both.
+
+### Blocking, and lock order
+
+`State::Blocked { on: usize }` became `State::Blocked(BlockedOn)` with two
+reasons — a thread finishing, or a message arriving. They need different wake
+paths: collapsing them would mean waking every blocked thread on either event and
+letting each work out whether it was meant.
+
+The wake happens **after** every IPC lock is dropped. `wake_for_message` takes
+the scheduler lock; the send path takes the process table, the capability manager
+and the queue manager. Taking the scheduler lock while holding a queue lock on
+one path and the reverse on another is how a kernel stops.
+
+The receive loop re-checks the queue after waking rather than trusting the
+wake-up. A spurious wake is harmless; a missed re-check is a hang.
+
+### What was deleted
+
+`test_process_management`, `test_ipc_system` and `test_scheduler` — 234 lines of
+boot-time output — are gone.
+
+They created the three synthetic processes that caused the aliasing above. The
+IPC test then sent a message between pids 1 and 2 that failed with
+`PermissionDenied`, because capabilities were granted sixty lines *after* the
+send. And `test_scheduler` drove `process::scheduler`, which schedules nothing:
+it picks a pid and writes it into a field. The real scheduler is `task`.
+
+What replaces all three is two ring-3 processes exchanging a message, which
+exercises the same queueing and capability code with real senders and real bytes.
+
+### `getppid` finally means something
+
+It returned `Ok(0)` under a TODO for a long time — indistinguishable from a
+genuine "no parent", which is what 0 means — then `NotSupported` once that was
+noticed. There is a hierarchy now, and it is the same relation the capability
+policy uses.
+
 ## What is deliberately still missing
 - **The filesystem is read-only.** Allocating clusters and keeping both FAT
   copies consistent is a separate problem, and a read-only filesystem that is

--- a/kernel/src/boot.rs
+++ b/kernel/src/boot.rs
@@ -1281,73 +1281,34 @@ fn test_page_swapping_algorithms() {
 }
 
 /// Initialize process management
+/// Bring up the process table.
+///
+/// This used to run `test_process_management()`, which created three processes
+/// called `init`, `shell` and `background_task` — at pids 1, 2 and 3, because
+/// the table's allocator is a monotonic counter starting at 1.
+///
+/// Those pids are *thread* ids. A ring-3 thread landing in slot 1, 2 or 3 was
+/// attributed to one of them: `send_message`'s existence check passed, and
+/// "init" had been granted `(SendMessage, Any)`, so the capability check passed
+/// too. A thread in slot 4 or above got `SenderNotFound`. The failure was
+/// id-dependent, which is another way of saying it looked intermittent.
+///
+/// The test also drove `process::scheduler`, which schedules nothing: it picks a
+/// pid and writes it into a field. The real scheduler is `task`. Both tests are
+/// gone; what replaces them is two ring-3 processes exchanging a message, which
+/// exercises the same queueing and capability code with real senders.
 fn init_process_management() {
     serial_println!("Initializing process management...");
     
     match crate::process::init_process_management() {
         Ok(()) => {
             serial_println!("Process management initialized successfully");
-            
-            // Test process management functionality
-            test_process_management();
         }
         Err(e) => {
             serial_println!("Failed to initialize process management: {}", e);
             panic!("Process management initialization failed");
         }
     }
-}
-
-/// Test process management functionality
-fn test_process_management() {
-    serial_println!("Testing process management...");
-    
-    // Test process creation
-    {
-        extern crate alloc;
-        use alloc::string::String;
-        use crate::process::{create_process, ProcessPriority, ProcessId, print_process_table};
-        
-        // Create a few test processes
-        let init_pid = create_process(
-            None,
-            String::from("init"),
-            ProcessPriority::System,
-        );
-        
-        if let Ok(init_pid) = init_pid {
-            serial_println!("Created init process with PID {}", init_pid.0);
-            
-            // Create child processes
-            let shell_pid = create_process(
-                Some(init_pid),
-                String::from("shell"),
-                ProcessPriority::Interactive,
-            );
-            
-            let background_pid = create_process(
-                Some(init_pid),
-                String::from("background_task"),
-                ProcessPriority::Background,
-            );
-            
-            if let (Ok(shell_pid), Ok(bg_pid)) = (shell_pid, background_pid) {
-                serial_println!("Created shell process with PID {}", shell_pid.0);
-                serial_println!("Created background process with PID {}", bg_pid.0);
-                
-                // Print process table
-                print_process_table();
-                
-                // Test scheduler
-                test_scheduler();
-                
-                // Test context switching
-                test_context_switching_functionality();
-            }
-        }
-    }
-    
-    serial_println!("Process management test complete");
 }
 
 /// Initialize IPC system
@@ -1357,165 +1318,12 @@ fn init_ipc_system() {
     match crate::ipc::init_ipc_system() {
         Ok(()) => {
             serial_println!("IPC system initialized successfully");
-            
-            // Test IPC functionality
-            test_ipc_system();
         }
         Err(e) => {
             serial_println!("Failed to initialize IPC system: {}", e);
             panic!("IPC system initialization failed");
         }
     }
-}
-
-/// Test IPC system functionality
-fn test_ipc_system() {
-    serial_println!("Testing IPC system...");
-    
-    // Test message passing
-    {
-        extern crate alloc;
-        use alloc::string::String;
-        use crate::process::ProcessId;
-        use crate::ipc::{
-            create_message, send_message, receive_message,
-            MessageType, MessageData, create_capability, check_capability,
-            CapabilityType, grant_system_process_capabilities, grant_user_process_capabilities,
-            create_secure_ipc_channel, is_restricted_operation, validate_capability_request
-        };
-        use crate::ipc::capability::ResourceId;
-        
-        let sender_pid = ProcessId::new(1);
-        let receiver_pid = ProcessId::new(2);
-        
-        // Test basic message creation and sending
-        let message = create_message(
-            sender_pid,
-            receiver_pid,
-            MessageType::ServiceRequest,
-            MessageData::Text(String::from("Hello, IPC!")),
-        );
-        
-        serial_println!("Created test message: {}", message);
-        
-        // Test message sending
-        match send_message(message) {
-            Ok(()) => {
-                serial_println!("Message sent successfully");
-                
-                // Test message receiving
-                match receive_message(receiver_pid) {
-                    Ok(received_msg) => {
-                        serial_println!("Message received: {}", received_msg);
-                        
-                        if let MessageData::Text(text) = &received_msg.data {
-                            serial_println!("Message content: '{}'", text);
-                        }
-                    }
-                    Err(e) => {
-                        serial_println!("Failed to receive message: {}", e);
-                    }
-                }
-            }
-            Err(e) => {
-                serial_println!("Failed to send message: {}", e);
-            }
-        }
-        
-        // Test capability system
-        serial_println!("Testing capability system...");
-        
-        // Grant a capability to a process
-        let file_resource = ResourceId::File(String::from("/test/file.txt"));
-        match create_capability(
-            sender_pid,
-            CapabilityType::Read,
-            file_resource.clone(),
-            None, // System-granted
-        ) {
-            Ok(cap_id) => {
-                serial_println!("Created capability {} for process {}", cap_id.0, sender_pid.0);
-                
-                // Test capability checking
-                if check_capability(sender_pid, CapabilityType::Read, &file_resource) {
-                    serial_println!("Capability check passed for read access");
-                } else {
-                    serial_println!("Capability check failed for read access");
-                }
-                
-                // Test capability check for different permission
-                if check_capability(sender_pid, CapabilityType::Write, &file_resource) {
-                    serial_println!("Capability check passed for write access");
-                } else {
-                    serial_println!("Capability check failed for write access (expected)");
-                }
-            }
-            Err(e) => {
-                serial_println!("Failed to create capability: {}", e);
-            }
-        }
-        
-        // Test security policy system
-        serial_println!("Testing security policy system...");
-        
-        // Test granting system capabilities
-        match grant_system_process_capabilities(sender_pid) {
-            Ok(capabilities) => {
-                serial_println!("Granted {} system capabilities to process {}", 
-                               capabilities.len(), sender_pid.0);
-            }
-            Err(e) => {
-                serial_println!("Failed to grant system capabilities: {}", e);
-            }
-        }
-        
-        // Test granting user capabilities
-        match grant_user_process_capabilities(receiver_pid) {
-            Ok(capabilities) => {
-                serial_println!("Granted {} user capabilities to process {}", 
-                               capabilities.len(), receiver_pid.0);
-            }
-            Err(e) => {
-                serial_println!("Failed to grant user capabilities: {}", e);
-            }
-        }
-        
-        // Test secure IPC channel creation
-        match create_secure_ipc_channel(sender_pid, receiver_pid) {
-            Ok(()) => {
-                serial_println!("Created secure IPC channel between processes {} and {}", 
-                               sender_pid.0, receiver_pid.0);
-            }
-            Err(e) => {
-                serial_println!("Failed to create secure IPC channel: {}", e);
-            }
-        }
-        
-        // Test restricted operation validation
-        if is_restricted_operation(CapabilityType::Admin) {
-            serial_println!("Admin operation correctly identified as restricted");
-        }
-        
-        if !is_restricted_operation(CapabilityType::Read) {
-            serial_println!("Read operation correctly identified as non-restricted");
-        }
-        
-        // Test capability request validation
-        if validate_capability_request(
-            sender_pid,
-            CapabilityType::SendMessage,
-            &ResourceId::Process(receiver_pid),
-        ) {
-            serial_println!("SendMessage capability request validated successfully");
-        } else {
-            serial_println!("SendMessage capability request validation failed");
-        }
-    }
-    
-    // Print IPC statistics
-    crate::ipc::print_ipc_info();
-    
-    serial_println!("IPC system test complete");
 }
 
 /// Initialize system call interface
@@ -1595,38 +1403,6 @@ fn test_syscall_interface() {
     }
     
     serial_println!("System call interface test complete");
-}
-
-/// Test scheduler functionality
-fn test_scheduler() {
-    serial_println!("Testing scheduler...");
-    
-    use crate::process::{schedule_next_process, print_scheduler_info, set_scheduling_algorithm, SchedulingAlgorithm};
-    
-    // Test round-robin scheduling
-    serial_println!("Testing round-robin scheduling...");
-    if let Ok(scheduled_pid) = schedule_next_process() {
-        if let Some(pid) = scheduled_pid {
-            serial_println!("Scheduled process: {}", pid.0);
-        } else {
-            serial_println!("No process scheduled");
-        }
-    }
-    
-    // Test priority scheduling
-    serial_println!("Testing priority scheduling...");
-    if set_scheduling_algorithm(SchedulingAlgorithm::Priority).is_ok() {
-        if let Ok(scheduled_pid) = schedule_next_process() {
-            if let Some(pid) = scheduled_pid {
-                serial_println!("Priority scheduled process: {}", pid.0);
-            }
-        }
-    }
-    
-    // Print scheduler information
-    print_scheduler_info();
-    
-    serial_println!("Scheduler test complete");
 }
 
 /// Test context switching functionality

--- a/kernel/src/console/commands.rs
+++ b/kernel/src/console/commands.rs
@@ -133,7 +133,8 @@ fn threads() {
             crate::task::State::Running => "running",
             crate::task::State::Ready => "ready",
             crate::task::State::Finished => "finished",
-            crate::task::State::Blocked { on } => {
+            crate::task::State::Blocked(crate::task::BlockedOn::Message(_)) => "msg-wait",
+            crate::task::State::Blocked(crate::task::BlockedOn::Thread(on)) => {
                 let text = alloc::format!("wait({})", on);
                 let bytes = text.as_bytes();
                 let take = core::cmp::min(bytes.len(), blocked.len());

--- a/kernel/src/ipc/message.rs
+++ b/kernel/src/ipc/message.rs
@@ -310,12 +310,12 @@ pub fn send_message(message: Message) -> Result<(), MessageError> {
                    message.header.receiver.0);
     
     // Validate sender exists
-    if crate::process::get_process(message.header.sender).is_none() {
+    if !crate::process::process_exists(message.header.sender) {
         return Err(MessageError::SenderNotFound);
     }
     
     // Validate receiver exists
-    if crate::process::get_process(message.header.receiver).is_none() {
+    if !crate::process::process_exists(message.header.receiver) {
         return Err(MessageError::ReceiverNotFound);
     }
     
@@ -341,7 +341,7 @@ pub fn receive_message(receiver: ProcessId) -> Result<Message, MessageError> {
     serial_println!("Process {} attempting to receive message", receiver.0);
     
     // Validate receiver exists
-    if crate::process::get_process(receiver).is_none() {
+    if !crate::process::process_exists(receiver) {
         return Err(MessageError::ReceiverNotFound);
     }
     

--- a/kernel/src/process/mod.rs
+++ b/kernel/src/process/mod.rs
@@ -9,7 +9,7 @@ pub use process::{
     Process, ProcessId, ProcessState, ProcessTable, ProcessError, ProcessPriority, ProcessInfo,
     create_process, get_process, remove_process, set_current_process, get_current_process,
     get_runnable_processes, get_process_statistics, print_process_table, cleanup_zombie_processes,
-    init_process_table
+    init_process_table, create_process_with_pid, process_exists, parent_of
 };
 pub use scheduler::{
     Scheduler, SchedulerError, SchedulingAlgorithm,

--- a/kernel/src/process/process.rs
+++ b/kernel/src/process/process.rs
@@ -278,6 +278,60 @@ impl ProcessTable {
         Ok(pid)
     }
     
+    /// Create a process with a caller-chosen PID.
+    ///
+    /// The table's own PID allocator is a monotonic counter, which is fine for a
+    /// system where processes are created by the table. Here they are not: a
+    /// process *is* a ring-3 thread, and the thread table already assigned it an
+    /// id. Two allocators would mean two namespaces, which is exactly the split
+    /// this phase exists to remove — `syscall/entry.rs` passed a thread id where
+    /// the IPC layer expected a table entry, so every send failed or, worse,
+    /// aliased one of the three synthetic processes at pids 1-3.
+    pub fn create_process_with_pid(
+        &mut self,
+        pid: ProcessId,
+        parent_pid: Option<ProcessId>,
+        name: String,
+        priority: ProcessPriority,
+    ) -> Result<ProcessId, ProcessError> {
+        if self.processes.len() >= self.max_processes {
+            return Err(ProcessError::ProcessTableFull);
+        }
+        if self.get_process(pid).is_some() {
+            return Err(ProcessError::InvalidPid);
+        }
+
+        let mut process = Process::new(pid, parent_pid, name, priority);
+        process.set_state(ProcessState::Ready);
+
+        if let Some(parent_pid) = parent_pid {
+            if let Some(parent) = self.get_process_mut(parent_pid) {
+                parent.add_child(pid);
+            }
+        }
+
+        self.processes.push(Some(process));
+
+        // Keep the counter clear of hand-picked ids, so a later
+        // `create_process` cannot collide with one.
+        if pid.0 >= self.next_pid {
+            self.next_pid = pid.0 + 1;
+        }
+
+        Ok(pid)
+    }
+
+    /// Does this PID name a live process?
+    ///
+    /// Cheaper than [`Self::get_process`] on the IPC path, and much cheaper than
+    /// the module-level `get_process`, which clones the process's name into a
+    /// fresh `String` just to answer this question — twice per `send_message`.
+    pub fn exists(&self, pid: ProcessId) -> bool {
+        self.processes
+            .iter()
+            .any(|p| p.as_ref().map_or(false, |proc| proc.pid == pid))
+    }
+
     /// Get a process by PID (immutable reference)
     pub fn get_process(&self, pid: ProcessId) -> Option<&Process> {
         self.processes.iter()
@@ -556,6 +610,38 @@ pub fn get_current_process() -> Option<ProcessId> {
 }
 
 /// Get all runnable processes
+/// Register a process at a caller-chosen PID.
+pub fn create_process_with_pid(
+    pid: ProcessId,
+    parent_pid: Option<ProcessId>,
+    name: String,
+    priority: ProcessPriority,
+) -> Result<ProcessId, ProcessError> {
+    let mut guard = PROCESS_TABLE.lock();
+    match guard.as_mut() {
+        Some(table) => table.create_process_with_pid(pid, parent_pid, name, priority),
+        None => Err(ProcessError::ProcessNotFound),
+    }
+}
+
+/// Does this PID name a live process?
+pub fn process_exists(pid: ProcessId) -> bool {
+    PROCESS_TABLE
+        .lock()
+        .as_ref()
+        .map(|table| table.exists(pid))
+        .unwrap_or(false)
+}
+
+/// Parent of a process, if it has one.
+pub fn parent_of(pid: ProcessId) -> Option<ProcessId> {
+    PROCESS_TABLE
+        .lock()
+        .as_ref()
+        .and_then(|table| table.get_process(pid))
+        .and_then(|p| p.parent_pid)
+}
+
 pub fn get_runnable_processes() -> Vec<ProcessId> {
     let table = PROCESS_TABLE.lock();
     if let Some(table) = table.as_ref() {

--- a/kernel/src/syscall/dispatcher.rs
+++ b/kernel/src/syscall/dispatcher.rs
@@ -332,15 +332,20 @@ fn sys_getpid(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
     Ok(process_id.0 as u64)
 }
 
-/// Not implemented, and no longer pretending otherwise.
+/// `getppid()` -> parent's pid
 ///
-/// This returned `Ok(0)` under a TODO, which userspace cannot tell apart from a
-/// genuine "no parent" — and 0 is what a real `getppid` returns for the process
-/// that has none. There is no parent to report: `spawn` hands back a task id and
-/// records nothing about who called it, so a process hierarchy does not exist
-/// yet. Refusing says that; returning 0 says the opposite.
-fn sys_getppid(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
-    Err(SyscallError::NotSupported)
+/// Real now that a process hierarchy exists: `spawn` and `fork` record the
+/// creating process as the parent, which is also what decides who may send whom
+/// a message.
+///
+/// It returned `Ok(0)` under a TODO for a long time — indistinguishable from a
+/// genuine "no parent", which is what 0 means — and then `NotSupported` once
+/// that was noticed. A program started by the kernel rather than by another
+/// program genuinely has no parent, and gets 0.
+fn sys_getppid(process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
+    Ok(crate::process::parent_of(process_id)
+        .map(|p| p.0 as u64)
+        .unwrap_or(0))
 }
 
 fn sys_kill(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
@@ -700,59 +705,137 @@ fn sys_unlink(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
 }
 
 // IPC system calls
-/// `send_message(receiver, ptr, len)`
+/// Largest message a process can send. The queue caps a *process* at 64 KiB
+/// total, so a single message has to be well under that or one send fills it.
+const MAX_MESSAGE_BYTES: usize = 4096;
+
+/// `send_message(receiver_pid, ptr, len)`
 ///
-/// Not implemented, and it now says so instead of delivering something else.
+/// Copies the caller's bytes into a message and enqueues it on the receiver.
 ///
-/// What it used to do is the most subtle fabrication in this kernel, because
-/// most of it was real. It reached `ipc::message::send_message`, which genuinely
-/// validates the sender and receiver, checks a `SendMessage` capability and
-/// enqueues — but `args[1]`, the caller's buffer, was bound to `_message_ptr`
-/// and never read. In its place went:
+/// What this replaces is the subtlest fabrication this kernel had, because most
+/// of it was real: it reached `ipc::message::send_message`, which genuinely
+/// validates sender and receiver, checks a capability and enqueues — but
+/// `args[1]`, the caller's buffer, was bound to `_message_ptr` and never read.
+/// In its place went a synthetic `MessageData::Text(format!("Message from
+/// process {} (len={})", pid, len))`, so the receiver got a *description* of the
+/// message instead of the message, and the sender got `Ok(0)`.
 ///
-/// ```text
-/// MessageData::Text(format!("Message from process {} (len={})", pid, len))
-/// ```
-///
-/// so the receiver got a synthetic string describing the message instead of the
-/// message, and the sender got `Ok(0)`.
-///
-/// Copying the payload is the easy part — `uaccess::copy_from_user` already
-/// exists. What blocks this is that there are **two unrelated id namespaces**:
-/// `syscall/entry.rs` passes the calling *thread's* id as the `ProcessId`, while
-/// `ipc::message::send_message` looks the sender up in `process::ProcessTable`,
-/// whose only entries are the three synthetic ones the boot self-test creates.
-/// A ring-3 caller is not in that table, so every send would fail
-/// `SenderNotFound` even with a real payload.
-///
-/// Reconciling those namespaces — one process table that `spawn` registers into,
-/// with the thread as a member of a process rather than a synonym for one — is
-/// the work. `kernel/src/ipc/` is ~85 KB of implemented queueing and capability
-/// machinery waiting on it.
+/// Copying the payload was never the hard part; `uaccess::copy_from_user` has
+/// existed for phases. The blocker was that `syscall/entry.rs` passed a *thread*
+/// id where the IPC layer expected a `ProcessTable` entry, so every send would
+/// have failed `SenderNotFound` even with real bytes. Those namespaces are one
+/// now — a process *is* a ring-3 thread, registered at the same id — which is
+/// what makes this implementable rather than a different fabrication.
+#[cfg(target_arch = "x86_64")]
 fn sys_send_message(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
-    serial_println!(
-        "Process {} called send_message({}, 0x{:x}, {}): IPC needs one process-id namespace first",
-        process_id.0,
-        args[0],
-        args[1],
-        args[2]
+    use alloc::vec;
+
+    let receiver = ProcessId::new(args[0] as u32);
+    let ptr = args[1];
+    let len = args[2] as usize;
+
+    if len == 0 || len > MAX_MESSAGE_BYTES {
+        return Err(SyscallError::InvalidArgument);
+    }
+
+    let mut buf = vec![0u8; len];
+    crate::syscall::uaccess::copy_from_user(ptr, &mut buf)
+        .map_err(|_| SyscallError::InvalidArgument)?;
+
+    let message = crate::ipc::message::create_message(
+        process_id,
+        receiver,
+        crate::ipc::message::MessageType::ServiceRequest,
+        crate::ipc::message::MessageData::Bytes(buf),
     );
+
+    crate::ipc::message::send_message(message)?;
+
+    // Wake the receiver *after* every IPC lock has been dropped. `wake_for_message`
+    // takes the scheduler lock, and holding that and a queue lock in opposite
+    // orders on two paths is how a kernel stops.
+    crate::task::wake_for_message(receiver.0 as usize);
+
+    if syscall_trace_enabled() {
+        serial_println!(
+            "Process {} sent {} byte(s) to {}",
+            process_id.0,
+            len,
+            receiver.0
+        );
+    }
+
+    Ok(len as u64)
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn sys_send_message(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
     Err(SyscallError::NotSupported)
 }
 
-/// `receive_message(timeout_ms)`
+/// `receive_message(buf_ptr, buf_len, blocking)` -> (sender << 32) | length
 ///
-/// Not implemented, for the same reason as [`sys_send_message`]. This one did
-/// dequeue for real — and then returned only `message_id`, dropping the payload
-/// on the floor under a `// In a real implementation, we would copy the message
-/// data to user space`. A caller that got a message id had no way to read the
-/// message.
+/// Copies the next message's payload to the caller and reports who sent it and
+/// how long it was, packed into one return value because a syscall has one.
+///
+/// This used to dequeue for real and then return only the message id, dropping
+/// the payload under a `// In a real implementation, we would copy the message
+/// data to user space`. A caller that got an id had no way to read the message.
+///
+/// `blocking` non-zero parks the thread in `State::Blocked(BlockedOn::Message)`
+/// until someone sends, rather than spinning on `yield`. The loop around the
+/// block is not paranoia: a wake-up is a hint, and re-checking the queue is what
+/// makes a spurious one harmless.
+#[cfg(target_arch = "x86_64")]
 fn sys_receive_message(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
-    serial_println!(
-        "Process {} called receive_message({}): IPC needs one process-id namespace first",
-        process_id.0,
-        args[0]
-    );
+    let out = args[0];
+    let capacity = args[1] as usize;
+    let blocking = args[2] != 0;
+
+    if capacity == 0 || capacity > MAX_MESSAGE_BYTES {
+        return Err(SyscallError::InvalidArgument);
+    }
+
+    let message = loop {
+        match crate::ipc::message::receive_message(process_id) {
+            Ok(m) => break m,
+            Err(crate::ipc::MessageError::NoMessage) if blocking => {
+                crate::task::block_for_message();
+            }
+            Err(e) => return Err(e.into()),
+        }
+    };
+
+    let payload: &[u8] = match &message.data {
+        crate::ipc::message::MessageData::Bytes(b) => b,
+        crate::ipc::message::MessageData::Text(t) => t.as_bytes(),
+        // The other variants exist for kernel-internal senders. Userspace only
+        // ever produces `Bytes`, and a message it cannot represent is better
+        // refused than silently truncated to nothing.
+        _ => return Err(SyscallError::NotSupported),
+    };
+
+    let n = core::cmp::min(payload.len(), capacity);
+    crate::syscall::uaccess::copy_to_user(out, &payload[..n])
+        .map_err(|_| SyscallError::InvalidArgument)?;
+
+    if syscall_trace_enabled() {
+        serial_println!(
+            "Process {} received {} byte(s) from {}",
+            process_id.0,
+            n,
+            message.header.sender.0
+        );
+    }
+
+    // Sender in the high half, length in the low half. Both fit: pids are u32
+    // and a message is capped at 4 KiB.
+    Ok(((message.header.sender.0 as u64) << 32) | n as u64)
+}
+
+#[cfg(not(target_arch = "x86_64"))]
+fn sys_receive_message(_process_id: ProcessId, _args: [u64; 6]) -> SyscallResult {
     Err(SyscallError::NotSupported)
 }
 

--- a/kernel/src/syscall/validation.rs
+++ b/kernel/src/syscall/validation.rs
@@ -40,7 +40,7 @@ pub fn validate_syscall_args(
         SYS_RMDIR | SYS_UNLINK => validate_unlink_args(process_id, args),
         
         SYS_SEND_MESSAGE => validate_send_message_args(process_id, args),
-        SYS_RECEIVE_MESSAGE => validate_receive_message_args(args),
+        SYS_RECEIVE_MESSAGE => validate_receive_message_args(process_id, args),
         SYS_REPLY_MESSAGE => validate_reply_message_args(process_id, args),
         SYS_CREATE_CHANNEL => validate_create_channel_args(args),
         SYS_DESTROY_CHANNEL => validate_destroy_channel_args(args),
@@ -378,25 +378,41 @@ fn validate_unlink_args(process_id: ProcessId, args: &[u64; 6]) -> Result<(), Sy
 }
 
 // IPC syscall validations
-fn validate_send_message_args(process_id: ProcessId, args: &[u64; 6]) -> Result<(), SyscallError> {
-    let receiver_pid = args[0];
-    let message_ptr = args[1];
-    let message_len = args[2];
-    
-    if receiver_pid == 0 {
+/// `send_message(receiver_pid, ptr, len)`.
+fn validate_send_message_args(
+    process_id: ProcessId,
+    args: &[u64; 6],
+) -> Result<(), SyscallError> {
+    let receiver = args[0];
+    let ptr = args[1];
+    let len = args[2];
+
+    // Pid 0 is the kernel's own thread, which has no queue and nothing to say.
+    if receiver == 0 {
         return Err(SyscallError::InvalidArgument);
     }
-    
-    if message_len > 0 {
-        validate_user_pointer(process_id, message_ptr, message_len as usize, false)?;
+    if len == 0 || len > 4096 {
+        return Err(SyscallError::InvalidArgument);
     }
-    
-    Ok(())
+    validate_user_pointer(process_id, ptr, len as usize, false)
 }
 
-fn validate_receive_message_args(args: &[u64; 6]) -> Result<(), SyscallError> {
-    // Receive message takes optional timeout
-    Ok(())
+/// `receive_message(buf_ptr, buf_len, blocking)`.
+///
+/// The destination is checked here rather than in the handler because a receive
+/// that blocks and *then* discovers it has nowhere to put the answer has already
+/// consumed the message.
+fn validate_receive_message_args(
+    process_id: ProcessId,
+    args: &[u64; 6],
+) -> Result<(), SyscallError> {
+    let buf = args[0];
+    let len = args[1];
+
+    if len == 0 || len > 4096 {
+        return Err(SyscallError::InvalidArgument);
+    }
+    validate_user_pointer(process_id, buf, len as usize, true)
 }
 
 fn validate_reply_message_args(process_id: ProcessId, args: &[u64; 6]) -> Result<(), SyscallError> {

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -59,12 +59,28 @@ const TIME_SLICE_TICKS: u32 = 2;
 pub enum State {
     Ready,
     Running,
-    /// Waiting for the thread with this id to finish. Skipped by the scheduler,
-    /// so a `wait` costs nothing while it blocks — as opposed to spinning on
-    /// `yield_now`, which is what the first version of this did and which meant
-    /// a shell waiting for a child consumed half the CPU.
-    Blocked { on: usize },
+    /// Not runnable, for one of the reasons below. Skipped by the scheduler, so
+    /// blocking costs nothing — as opposed to spinning on `yield_now`, which is
+    /// what the first version of `wait` did and which meant a shell waiting for
+    /// a child consumed half the CPU.
+    Blocked(BlockedOn),
     Finished,
+}
+
+/// Why a thread is not runnable.
+///
+/// Two reasons, and they need different wake paths: a thread waiting for a child
+/// is woken by that child exiting, a thread waiting for a message by anyone
+/// sending it one. Collapsing them into a single "blocked" would mean waking
+/// every blocked thread on either event and letting each work out whether it was
+/// meant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BlockedOn {
+    /// The thread with this id finishing.
+    Thread(usize),
+    /// A message arriving in this process's queue. The id is the thread's own,
+    /// because a process and its thread share one id.
+    Message(usize),
 }
 
 pub struct Thread {
@@ -675,10 +691,47 @@ pub fn exit_current() -> ! {
     }
 }
 
+/// Park the running thread until a message arrives for it.
+///
+/// Returns once something has called [`wake_for_message`] with this thread's id.
+/// The caller re-checks its queue afterwards rather than trusting the wake-up:
+/// a spurious wake is harmless, a missed re-check is a hang.
+pub fn block_for_message() {
+    let id = current_id();
+
+    without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+        let current = sched.current;
+        if let Some(t) = sched.threads[current].as_mut() {
+            t.state = State::Blocked(BlockedOn::Message(id));
+        }
+    });
+
+    schedule();
+}
+
+/// Make a thread waiting for a message runnable again.
+///
+/// Called from the send path, *after* every IPC lock has been released: this
+/// takes the scheduler lock, and holding two of those in the wrong order is how
+/// a kernel stops.
+pub fn wake_for_message(thread: usize) {
+    without_interrupts(|| {
+        let mut sched = SCHEDULER.lock();
+        for slot in sched.threads.iter_mut() {
+            if let Some(t) = slot {
+                if t.state == State::Blocked(BlockedOn::Message(thread)) {
+                    t.state = State::Ready;
+                }
+            }
+        }
+    });
+}
+
 fn wake_waiters_locked(sched: &mut Scheduler, finished: usize) {
     for slot in sched.threads.iter_mut() {
         if let Some(t) = slot {
-            if t.state == (State::Blocked { on: finished }) {
+            if t.state == State::Blocked(BlockedOn::Thread(finished)) {
                 t.state = State::Ready;
             }
         }
@@ -726,7 +779,7 @@ pub fn wait_for(id: usize) -> Result<i32, &'static str> {
                 );
                 if !finished {
                     if let Some(t) = sched.threads[current].as_mut() {
-                        t.state = State::Blocked { on: id };
+                        t.state = State::Blocked(BlockedOn::Thread(id));
                     }
                 }
                 finished

--- a/kernel/src/usermode.rs
+++ b/kernel/src/usermode.rs
@@ -413,7 +413,8 @@ pub fn spawn_program(name: &str) -> Result<usize, SpawnError> {
 
     match crate::task::spawn("spawned", enter_spawned, slot) {
         Ok(thread) => {
-            serial_println!("spawn '{}': thread {}, entry 0x{:x}", name, thread, entry);
+            register_process(thread, Some(crate::task::current_id()), name);
+            serial_println!("spawn '{}': thread {} (pid {}), entry 0x{:x}", name, thread, thread, entry);
             Ok(thread)
         }
         Err(e) => {
@@ -443,12 +444,72 @@ pub fn prepare_named_program(
     })
 }
 
+/// Register a ring-3 thread as a process, and give it what IPC needs.
+///
+/// A process here *is* a thread with an address space — there is no separate
+/// abstraction, and pretending otherwise is what left the process table holding
+/// three synthetic rows while every real program ran outside it. So the pid is
+/// the thread id, and this is the one place a process comes into existence.
+///
+/// Three things are set up together, because a process missing any of them
+/// fails somewhere unhelpful:
+///
+/// * the process table entry, without which `send_message` reports
+///   `SenderNotFound`;
+/// * a message queue, without which a `receive` before the first `send` reports
+///   `ReceiverNotFound` rather than "no message";
+/// * a capability to exchange messages with its parent, and the parent's to
+///   reply — which is the whole of the security policy, and is deliberately
+///   narrow. A process can talk to its parent and its children. Anything else
+///   is `PermissionDenied`, and that is testable rather than assumed.
+pub fn register_process(thread: usize, parent: Option<usize>, name: &str) {
+    use crate::process::{ProcessId, ProcessPriority};
+
+    let pid = ProcessId::new(thread as u32);
+    let parent_pid = parent.map(|p| ProcessId::new(p as u32));
+
+    if let Err(e) = crate::process::create_process_with_pid(
+        pid,
+        parent_pid,
+        alloc::string::String::from(name),
+        ProcessPriority::Normal,
+    ) {
+        serial_println!("  could not register process {}: {:?}", thread, e);
+        return;
+    }
+
+    if let Err(e) = crate::ipc::queue::create_message_queue(pid) {
+        serial_println!("  could not create a message queue for {}: {:?}", thread, e);
+    }
+
+    // A channel with the parent, in both directions. `create_secure_ipc_channel`
+    // grants each side `SendMessage` scoped to the other specifically — not
+    // `ResourceId::Any`, which is what `grant_system_process_capabilities` hands
+    // out and which would make the capability check unable to refuse anything.
+    if let Some(parent_pid) = parent_pid {
+        if let Err(e) = crate::ipc::security::create_secure_ipc_channel(pid, parent_pid) {
+            serial_println!("  could not open an IPC channel {}<->{}: {:?}", thread, parent_pid.0, e);
+        }
+    }
+}
+
+/// Retire a process when its thread exits.
+fn deregister_process(thread: usize) {
+    use crate::process::ProcessId;
+    let pid = ProcessId::new(thread as u32);
+
+    let _ = crate::ipc::queue::remove_message_queue(pid);
+    let _ = crate::process::remove_process(pid);
+}
+
 /// Record a forked child in the program table, inheriting its parent's name.
 ///
 /// Not a new program — a second thread running the same one — so it gets the
 /// parent's name with a marker, which is what makes a `fork` visible in the log
 /// without pretending a new image was loaded.
 pub fn register_forked(child: usize, parent: usize) {
+    register_process(child, Some(parent), "forked");
+
     let mut table = PROGRAMS.lock();
 
     let parent_name = table
@@ -547,6 +608,8 @@ fn release_slot(slot: usize) {
 /// function did the unmapping too, walking a recorded list of ranges; that list
 /// existed because there was nothing else that knew what a program had mapped.
 pub fn on_thread_exit(thread: usize) {
+    deregister_process(thread);
+
     let taken = {
         let mut table = PROGRAMS.lock();
         let found = table.iter().position(|s| matches!(s, Some(p) if p.thread == thread));
@@ -702,6 +765,10 @@ fn run_module(name: &str) {
     }
 
     register_running(name);
+    // A program the kernel started for itself has no parent process, so no IPC
+    // channel: nothing has a capability to message it and it has none to
+    // message anything. `ksh` gets one the moment it spawns a child.
+    register_process(crate::task::current_id(), None, name);
     crate::task::adopt_address_space(space);
 
     serial_println!("Entering loaded ELF in ring 3...");

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -263,11 +263,14 @@ check)
         "child: I inherited the value my parent set before forking" \
         "child: my copy of the witness is mine" \
         "parent: still writable after the child exited" \
+        "message, bytes and all" \
+        "sending to a pid that does not exist was refused" \
         "Copy-on-write: " \
         "hello2 here: exec replaced the whole image" \
         "hello2: my .bss is mine and it is zero" \
         "parent: the child did not touch my memory" \
         "and exited 7" \
+        "capability check not exercised" \
         "seconds since the epoch" \
         "ELF loader: PASS" \
         "Storage: PASS" \
@@ -432,6 +435,7 @@ check-cli)
         "redirect out" \
         "background" \
         "hello2 here: exec replaced the whole image" \
+        "child: messaging my grandparent was refused" \
         "ksh: exiting" \
         "ksh exited with code 0, falling back to the kernel console" \
         "Kosh console" \

--- a/userspace/hello/src/main.rs
+++ b/userspace/hello/src/main.rs
@@ -22,6 +22,9 @@ const SYS_EXIT: u64 = 1;
 const SYS_FORK: u64 = 2;
 const SYS_EXEC: u64 = 3;
 const SYS_WAIT: u64 = 4;
+const SYS_GETPPID: u64 = 6;
+const SYS_SEND_MESSAGE: u64 = 30;
+const SYS_RECEIVE_MESSAGE: u64 = 31;
 const SYS_GETPID: u64 = 5;
 const SYS_MMAP: u64 = 10;
 const SYS_MUNMAP: u64 = 11;
@@ -45,6 +48,10 @@ const CLOCK_MONOTONIC: u64 = 1;
 /// variable because it lives in `.bss` — the part of the address space the
 /// eager copy has to duplicate.
 static mut FORK_WITNESS: u64 = 0;
+
+/// The process that started this one, recorded before forking so the child
+/// inherits it.
+static mut GRANDPARENT: u64 = 0;
 
 /// Zero-initialised, so it occupies no space in the file. If the loader forgets
 /// to zero the gap between `p_filesz` and `p_memsz`, this reads as garbage.
@@ -123,6 +130,33 @@ fn fork() -> i64 {
 
 fn wait(task: i64, status: &mut i32) -> i64 {
     unsafe { syscall3(SYS_WAIT, task as u64, status as *mut i32 as u64, 0) }
+}
+
+fn getppid() -> i64 {
+    unsafe { syscall3(SYS_GETPPID, 0, 0, 0) }
+}
+
+fn send_message(to: i64, bytes: &[u8]) -> i64 {
+    unsafe {
+        syscall3(
+            SYS_SEND_MESSAGE,
+            to as u64,
+            bytes.as_ptr() as u64,
+            bytes.len() as u64,
+        )
+    }
+}
+
+/// Returns `(sender << 32) | length`, or negative on failure.
+fn receive_message(buf: &mut [u8], blocking: bool) -> i64 {
+    unsafe {
+        syscall3(
+            SYS_RECEIVE_MESSAGE,
+            buf.as_mut_ptr() as u64,
+            buf.len() as u64,
+            if blocking { 1 } else { 0 },
+        )
+    }
 }
 
 fn exec(name: &str) -> i64 {
@@ -367,6 +401,14 @@ pub extern "C" fn kosh_main() -> ! {
     // next write lands in the page the child is about to read.
     unsafe { core::ptr::write_volatile(&raw mut FORK_WITNESS, 0x1111_1111) };
 
+    // Recorded before the fork so the child inherits it: the process that
+    // started *this* one. When `ksh` runs this program that is the shell; when
+    // the kernel runs it at boot there is nobody, and it is 0.
+    //
+    // The child uses it to try something it must not be allowed to do.
+    let grandparent = getppid();
+    unsafe { core::ptr::write_volatile(&raw mut GRANDPARENT, grandparent as u64) };
+
     let child = fork();
     if child < 0 {
         print("  WARNING: fork failed\n");
@@ -389,6 +431,33 @@ pub extern "C" fn kosh_main() -> ! {
             print("  WARNING: child could not write its own memory\n");
         }
 
+        // Message the parent, which is blocked in a receive waiting for it.
+        //
+        // The capability that permits this was granted by `fork`: a process may
+        // message its parent and its children, and nothing else. The parent
+        // checks below that a send to an unrelated pid is refused.
+        let parent = getppid();
+        let sent = send_message(parent, b"child reporting for duty");
+        if sent < 0 {
+            print("  WARNING: child could not message its parent\n");
+        }
+
+        // ...and one it must not be allowed to send. The grandparent exists —
+        // it is the shell that started this program — but it is neither this
+        // process's parent nor its child, so there is no capability for it.
+        //
+        // Refusing a pid that does not exist proves nothing about capabilities;
+        // `send_message` checks the receiver exists first. This is the test that
+        // reaches the capability check.
+        let gp = unsafe { core::ptr::read_volatile(&raw const GRANDPARENT) } as i64;
+        if gp == 0 {
+            print("  child: no grandparent here, capability check not exercised\n");
+        } else if send_message(gp, b"you should not see this") < 0 {
+            print("  child: messaging my grandparent was refused\n");
+        } else {
+            print("  WARNING: messaged a process I have no capability for\n");
+        }
+
         // exec never returns. If it does, it failed.
         let err = exec("hello2");
         print("  WARNING: exec returned ");
@@ -400,6 +469,32 @@ pub extern "C" fn kosh_main() -> ! {
         // kernel has to give the parent a private copy — not hand it the shared
         // one.
         unsafe { core::ptr::write_volatile(&raw mut FORK_WITNESS, 0x3333_3333) };
+
+        // Block until the child sends. Not a yield loop — the kernel parks this
+        // thread and the send wakes it.
+        let mut inbox = [0u8; 64];
+        let got = receive_message(&mut inbox, true);
+        if got < 0 {
+            print("  WARNING: parent's receive failed\n");
+        } else {
+            let sender = (got >> 32) as i64;
+            let len = (got & 0xFFFF_FFFF) as usize;
+            if sender == child && &inbox[..len] == b"child reporting for duty" {
+                print("  parent: got the child's message, bytes and all\n");
+            } else {
+                print("  WARNING: parent got the wrong message\n");
+            }
+        }
+
+        // A pid that does not exist. Cheap to check and worth checking, but note
+        // what it does *not* prove: `send_message` tests that the receiver
+        // exists before it tests capabilities, so this never reaches the
+        // capability code. The child's attempt above is the one that does.
+        if send_message(999, b"nobody is listening") < 0 {
+            print("  parent: sending to a pid that does not exist was refused\n");
+        } else {
+            print("  WARNING: sent a message to a process that does not exist\n");
+        }
 
         let mut status: i32 = 0;
         wait(child, &mut status);


### PR DESCRIPTION
kernel/src/ipc/ has been ~85 KB of implemented queues, capability sets and security policy since long before anything could reach it. What kept it unreachable was a name collision, not missing code.

syscall/entry.rs passed the calling *thread's* id as a ProcessId, and send_message looked it up in ProcessTable, whose only entries were three processes a boot self-test created at pids 1, 2 and 3. Thread ids run 0..15, so the behaviour depended on which slot a program landed in: thread 0 got SenderNotFound, threads 1-3 passed and were attributed to init/shell/ background_task, threads 4+ got SenderNotFound. The self-test had granted pid 1 (SendMessage, Any), so a thread in slot 1 passed the capability check too — as "init". A bug that depends on a scheduler slot looks intermittent.

A process here is a thread with an address space; there is no second abstraction. So the pid is the thread id, ProcessTable gained create_process_with_pid because its own allocator is a counter, and usermode::register_process is the one place a process comes into existence. It sets up the table entry, a message queue (enqueue creates one on demand but dequeue does not — a receive before the first send would otherwise report ReceiverNotFound rather than "no message"), and a capability.

The capability is scoped: create_secure_ipc_channel grants each side SendMessage for the other specifically, so a process may message its parent and its children and nothing else. grant_system_process_capabilities, which hands out (SendMessage, Any), is deliberately not used — a capability system that grants everything is decoration. The test has a child message its grandparent, which exists, so the receiver-existence check passes and the capability check is what refuses. Granting Any instead turns that marker into a WARNING.

send_message now copies the caller's buffer instead of substituting MessageData::Text(format!("Message from process {} (len={})", ...)) — a description of the message delivered in its place, with Ok(0) returned. receive_message copies the payload out instead of returning only a message id, and blocks in State::Blocked(BlockedOn::Message) rather than spinning. The wake happens after every IPC lock is dropped, because it takes the scheduler lock.

getppid is real, and it is the same relation the capability policy uses.

Deleted: test_process_management, test_ipc_system and test_scheduler, 234 lines. They created the aliasing processes; the IPC test's own send failed with PermissionDenied because capabilities were granted sixty lines after it; and test_scheduler drove process::scheduler, which picks a pid and writes it into a field. Two ring-3 processes exchanging a message replaces all three.

52 boot markers and 32 console markers pass.


Claude-Session: https://claude.ai/code/session_01P1GdpYMiKP5Gj1Jmub59gw