### PR TITLE
kernel: a disk driver in ring 3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ members = [
     "userspace/init",
     "userspace/hello",
     "userspace/hello2",
+    "userspace/ata-driver",
     "userspace/fs-service",
     "userspace/driver-manager",
     "userspace/shell",

--- a/README.md
+++ b/README.md
@@ -53,19 +53,19 @@ be accurate about what runs and blunt about what doesn't. If something is listed
 under **Works**, there is a marker in `scripts/run.sh` that fails if it stops
 working.
 
-`docs/BOOT.md` is the long version: 1,100 lines on how the boot chain, paging,
-scheduling, ring 3, the filesystem and the address-space work actually function,
-including the bugs found along the way and how each was caught.
+`docs/BOOT.md` is the long version: how the boot chain, paging, scheduling,
+ring 3, the filesystem, the address-space work and the driver interface actually
+function, including the bugs found along the way and how each was caught.
 
 ## Running it
 
-One command builds the kernel, both userspace programs, a GRUB ISO and a FAT32
+One command builds the kernel, the four userspace programs, a GRUB ISO and a FAT32
 test disk, then boots the lot:
 
 ```bash
 ./scripts/run.sh              # boot it, serial on stdio (ctrl-a x to quit)
-./scripts/run.sh --check      # boot headless, assert 52 serial markers (CI)
-./scripts/run.sh --check-cli  # drive the shell through QEMU's monitor, assert 32
+./scripts/run.sh --check      # boot headless, assert 62 serial markers (CI)
+./scripts/run.sh --check-cli  # drive the shell through QEMU's monitor, assert 35
 ./scripts/run.sh --debug      # same as plain run, plus a gdb stub on :1234
 ```
 
@@ -123,13 +123,25 @@ interaction in `--check-cli`.
 - `SYSCALL`/`SYSRET` with a `swapgs`-free per-CPU block reached through `gs:`
 - User-pointer validation that checks range *and* page permissions, tested from
   the user side by a payload that deliberately passes a kernel address
-- A ring-3 fault kills the process and the kernel carries on
+- A ring-3 fault of *any* kind kills the process and the kernel carries on —
+  not just a page fault, which is all it used to be
 - A static ELF64 loader: `PT_LOAD` segments mapped at their `p_vaddr` with
   per-segment permissions and a zeroed `.bss` tail
 
 **Devices and storage**
 - 8259 PIC remap, PIT timer, PS/2 keyboard on IRQ1
 - ATA PIO driver on the legacy IDE ports — IDENTIFY, LBA28 reads
+- **A disk driver in ring 3.** `userspace/ata-driver` reads the same disk from
+  an unprivileged process, using `in` and `out` directly — no syscall per port.
+  Its ports come from the TSS I/O permission bitmap, 9 bits granted to that
+  thread and denied to every other; a process without the grant that touches
+  0x1F7 is killed and the system carries on
+- Devices are named, not addressed: `request_device("ata0")` is checked against a
+  `DeviceAccess` capability, and the kernel decides which ports the name means —
+  so a disk driver cannot ask for the interrupt controller
+- One driver per device at a time: while a ring-3 driver holds `ata0`, the
+  kernel's own block layer refuses that channel, and the claim is released even
+  if the driver crashes
 - Read-only FAT32: BPB validation, cluster-chain walking, long filenames
 - CMOS RTC, so `date` prints the real date
 
@@ -140,6 +152,8 @@ interaction in `--check-cli`.
   recursive-descent parser, and `ls`/`cat`/`cd`/`stat`/`date`/`getpid`
 - `ksh` can launch programs: unknown commands become `spawn` + `wait`, and
   `cmd &` starts one in the background
+- `ata-driver` — the ATA driver as an ordinary ring-3 process, driving a real
+  disk with `in` and `out` and answering block reads over IPC
 
 **Processes and IPC**
 - A process *is* a ring-3 thread with an address space, registered in the
@@ -156,15 +170,16 @@ interaction in `--check-cli`.
 
 ## The syscall surface
 
-44 numbers are defined; **23 do the work** and the other 21 return an error
+46 numbers are defined; **25 do the work** and the other 21 return an error
 saying so. Nothing returns success for work it did not do.
 
-**Working** (all 23 exercised from ring 3, not just by the kernel checking
+**Working** (all 25 exercised from ring 3, not just by the kernel checking
 itself):
 
 `exit` `fork` `exec` `wait` `getpid` `getppid` `yield` `spawn` · `mmap`
 `munmap` · `open` `close` `read` `write` `lseek` `stat` `getdents` · `time`
-`clock_gettime` · `send_message` `receive_message` · `debug_print` `debug_dump`
+`clock_gettime` · `send_message` `receive_message` · `request_device`
+`release_device` · `debug_print` `debug_dump`
 
 **Refuses with `NotSupported`, honestly:**
 
@@ -193,9 +208,17 @@ of it.
   path — a process may message its parent and its children, and nothing else —
   but the four capability syscalls still return `NotSupported`, so a program
   cannot inspect or delegate what it holds.
-- **Not actually a microkernel yet.** The ATA driver, the filesystem and the
-  keyboard driver are all *in* the kernel. That is the opposite of the intended
-  design and is where the IPC work above leads.
+- **Only the disk driver is out of the kernel, and there are two of it.** The
+  filesystem and the keyboard driver are still in-kernel, and `block/ata.rs` is
+  still there too — it stands aside while the ring-3 driver holds the channel
+  rather than being gone. It can be deleted once `fat32` moves out and stops
+  needing it, which is the next piece of work.
+- **Drivers are trusted by boot-module name.** `DRIVER_IMAGES` in `usermode.rs`
+  maps `ata-driver` to `ata0`, so the trust root is "GRUB loaded it from the
+  ISO". A real capability system delegates from `init`; this is a two-entry table
+  standing in for one.
+- **Ring 3 cannot receive interrupts.** The userspace driver polls, exactly as
+  the in-kernel one does. Turning IRQ14 into a message is not implemented.
 - **`userspace/init`, `fs-service`, `driver-manager` do not run.** They are not
   built, not on the ISO, have no linker scripts, and depend on `fork`/`exec`.
 - **`drivers/*` are not drivers.** `storage` and `network` are trait skeletons
@@ -232,13 +255,15 @@ kernel/src/
   task/            preemptive kernel threads and the context switch
   syscall/         SYSCALL entry, dispatcher, user-pointer checks, files
   elf.rs           static ELF64 loader
-  block/ata.rs     ATA PIO driver
+  block/ata.rs     ATA PIO driver (stands aside for the ring-3 one)
   fs/fat32.rs      read-only FAT32
   console/         the in-kernel fallback shell
-  platform/rtc.rs  CMOS real-time clock
+  platform/rtc.rs      CMOS real-time clock
+  platform/devports.rs which ports a named device is, and who holds it
 userspace/
   hello/           static ELF that proves the loader and the newer syscalls
   hello2/          what hello execs into — a different image at the same address
+  ata-driver/      the ATA driver, in ring 3, talking to the disk over IPC
   shell/           ksh
 docs/BOOT.md       how all of the above actually works
 scripts/run.sh     build, ISO, disk image, boot, and the two CI gates
@@ -263,8 +288,9 @@ Roughly in order, each unblocking the next:
 - [x] Copy-on-write, so a `fork` costs a page table rather than a program
 - [x] Demand paging, so an untouched `.bss` costs nothing at all
 - [x] One process-id namespace, so IPC and capabilities became reachable
-- [ ] Move the disk and filesystem out of the kernel — the point of the whole
-      exercise
+- [x] The disk driver out of the kernel, with port permissions to make it possible
+- [ ] The filesystem out of the kernel, so `block/ata.rs` can be deleted
+- [ ] `argv` for `exec`, so a driver can be told what to serve
 - [ ] FAT32 writes
 - [ ] `userspace/init` doing its job
 

--- a/docs/BOOT.md
+++ b/docs/BOOT.md
@@ -1728,6 +1728,192 @@ genuine "no parent", which is what 0 means — then `NotSupported` once that was
 noticed. There is a hierarchy now, and it is the same relation the capability
 policy uses.
 
+## A driver outside the kernel (Phase 18)
+
+`kernel/src/block/ata.rs` is 334 lines that drive an IDE disk. Nothing in it
+needs to be in the kernel — it reads and writes eight I/O ports and polls a
+status register — and every phase up to here has said the point of a microkernel
+is that such things run in ring 3. This is the phase that moves one.
+
+`userspace/ata-driver` is the same driver as an ordinary unprivileged process. It
+IDENTIFYs the primary master, serves block reads over IPC, and exits. It is
+linked at 8 MiB like `hello` and `ksh`, has its own address space, and is loaded
+by the same ELF loader. The only thing it has that they do not is nine bits.
+
+### Why the I/O permission bitmap and not the other two options
+
+A ring-3 driver has to execute `in` and `out`. There are three ways to allow it:
+
+* **A port-I/O system call.** Safe and unusable: a 512-byte sector is 256 16-bit
+  port reads, so one sector becomes 256 round trips through the syscall stub.
+* **`IOPL = 3` in the thread's RFLAGS.** One bit, and it grants *every* port. A
+  disk driver that can reprogram the PIC at 0x20, stop the PIT at 0x40 or reset
+  the machine through the keyboard controller at 0x64 is not isolated from the
+  kernel in any sense that matters.
+* **The TSS I/O permission bitmap.** With `IOPL = 0`, the CPU consults one bit
+  per port on every `in`/`out`. A granted port costs nothing at run time; a
+  denied one raises #GP.
+
+The third is the only one that is both fast and narrow, so that is what `gdt.rs`
+now carries: a 128-byte bitmap covering ports 0..1023, all ones — deny — by
+default.
+
+Two things had to change to get one. `TaskStateSegment` from the `x86_64` crate
+has an `iomap_base` field and no room after it, and `Descriptor::tss_segment`
+hard-codes the segment limit to `size_of::<TaskStateSegment>() - 1`. A bitmap
+that starts past the limit reads as all ones, which is a perfectly good default
+and not a bitmap. So the TSS is wrapped in a `#[repr(C, packed(4))]` struct with
+the bitmap and its mandatory 0xFF terminator after it, and the descriptor is
+built by hand with a limit that covers the whole thing.
+
+The bitmap is per-*task* in the hardware's sense, and since Kosh does not use
+hardware task switching there is one of it. So it is rewritten on context switch
+from the incoming thread's grant, in `publish_kernel_stack`'s neighbourhood and
+for the same reason `RSP0` is: forget `set_kernel_stack` and a thread lands on
+another's kernel stack; forget `set_io_grant` and a thread inherits another's
+hardware. The installed grant is cached, so the common switch — between threads
+that hold no ports, which is all of them but the driver — writes nothing.
+
+### A name, not a port range
+
+`SYS_REQUEST_DEVICE` takes a device *name*. `platform/devports.rs` decides what
+the name means:
+
+```rust
+Device { name: "ata0", ranges: [Some((0x1F0, 8)), Some((0x3F6, 1))], .. }
+```
+
+Two entries in the table, `ata0` and `ata1`. Deliberately absent: the PIC, the
+PIT, the keyboard controller, the CMOS/NMI gate and COM1. A driver cannot ask
+for them because there is no name for them, and there is no name for them because
+handing any of them to an unprivileged process is not survivable.
+
+The capability check is the existing one — `DeviceAccess` scoped to
+`ResourceId::Device("ata0")`, refused with `PermissionDenied` when absent.
+
+### The part that is a placeholder, and why it is written as a table
+
+Something has to grant that capability first. What does it today is
+`DRIVER_IMAGES` in `usermode.rs`: the kernel recognises a boot module by the name
+on its `module2` line and grants it its device. The trust root is "GRUB loaded it
+from the ISO", which is the same root that already decides what code the kernel
+runs at all — defensible for a boot-time driver and useless for anything loaded
+later.
+
+A capability system wants a delegation story: `init` holds the hardware, grants
+each driver exactly its device, and the kernel makes no policy decision about
+which program is trusted. That is why this is a two-entry table rather than a
+rule. `userspace/init` taking it over is what makes it a chain.
+
+### One driver at a time
+
+The kernel still contains an ATA driver, and `fs/fat32.rs` reads through it. Two
+drivers polling one set of registers do not race loudly: one writes the LBA
+registers, the other writes its own, and the command that follows reads whichever
+sector the last writer named. It returns the wrong bytes, intermittently.
+
+So `devports` keeps a claim per device. While a ring-3 process holds `ata0`,
+`AtaDisk::probe`, `read_blocks` and `write_blocks` all return
+`BlockError::ClaimedByUserspace` — checked on every entry point, not once at
+probe time, because a driver can start and exit while `fat32` holds an `AtaDisk`
+across all of it. `SYS_REQUEST_DEVICE` verifies this at the moment it takes the
+claim rather than trusting it:
+
+```
+  process 2 now drives 'ata0' (primary IDE channel) — ports in ring 3
+  the kernel's own ATA driver now refuses ata0
+```
+
+The claim is released when the driver exits — from `deregister_process`, before
+the message queue and the process table entry, because a driver that *crashes*
+must not take its disk with it. Surviving a driver crash is most of the argument
+for running drivers in ring 3 at all.
+
+### What the test actually proves
+
+`hello` spawns the driver, and checks bytes nobody in this program chose: the
+0xEB jump opcode at 0, the `mkfs.fat` OEM name at 3, `FAT32` at 82 and the 0x55AA
+signature at 510 — the boot sector `mkfs.vfat` wrote into `build/disk.img`. Then
+a second sector, so "the driver returns one canned buffer" is not an explanation
+that survives, and a read past the end of the disk, which has to be refused
+rather than spin on a status register that never becomes ready.
+
+Then the negative control, in a forked child because the expected outcome is
+death: a process with no `ata0` grant executes `in` on 0x1F7, the exact port the
+driver just read hundreds of times.
+
+```
+  the ring-3 driver identified a disk of 131072 sectors
+  read LBA 0 in ring 3: a FAT32 boot sector, signature and all
+  a second sector read back different bytes
+  the driver refused a read past the end of the disk
+  the driver exited and gave ata0 back
+  a process without the ata0 grant was killed for touching its ports
+```
+
+Removing `task::grant_io_device` from `sys_request_device` — keeping the
+capability and the claim, dropping only the bitmap bits — turns the driver's very
+first `in` into a #GP at `rip 0x800073`, kills it, and releases `ata0`. So the
+ports come from the bitmap and not from ambient permission, and the crash-recovery
+path is exercised by the control that proves it.
+
+### Ring-3 faults stop being fatal to the machine
+
+The page-fault handler has killed ring-3 threads rather than halting since Phase
+5. Every other handler halted, which meant the argument — a userspace bug must
+not take down the system — applied only to the one exception a program was
+expected to cause. A `ud2`, a division by zero, or an `in` on an ungranted port
+stopped the machine.
+
+`fault()` now decides from the saved CS's RPL, for every vector. Faults in ring 0
+still halt: a kernel that cannot trust its own state has nothing useful to do
+next. #DF and #MC halt regardless of ring — a double fault means the CPU could
+not deliver the first exception, so the machinery that would kill the process is
+the machinery that has already failed once.
+
+### The bug that was waiting underneath
+
+Killing a *registered* process from an exception handler double-faulted the
+system. The second fault was a #GP inside `BTreeMap::remove`, on a `movaps` in
+code that is entirely correct.
+
+An exception that pushes an error code pushes six quadwords onto a stack the CPU
+has already aligned to 16, so the handler starts with `RSP % 16 == 0`. The System
+V ABI says a function starts with `RSP % 16 == 8` — the state a `call` leaves.
+LLVM's `x86-interrupt` convention does not reconcile the two: every frame below
+the handler is eight bytes off, and the first `movaps` to a 16-aligned stack slot
+anywhere in that subtree faults.
+
+This had been true of every error-code handler since Phase 5. It never fired
+because the only handler that did real work was the page-fault handler, and the
+only process it ever killed was a demo with no message queue to tear down. Adding
+a second way to kill a process — one that kills a *real* one — is what reached
+`BTreeMap::remove`, which spills SSE registers to aligned slots.
+
+The measurement is worth recording because the first two attempts at a diagnosis
+were wrong. Instrumenting the handlers showed both #PF and #GP at the same
+alignment, which proves nothing without a baseline. Instrumenting
+`on_thread_exit` — one function, reached on both the normal exit path and the
+kill path — showed `rsp mod 16 = 0` from a normal exit and `8` from a kill.
+
+The fix is `kosh_call_aligned`: the handlers keep only frame decoding and hand
+the work to a body function called with the stack put back the way the ABI
+expects. Two things about it are load-bearing:
+
+* It is `global_asm!`, not inline `asm!`. An inline block containing a `call`
+  must declare `clobber_abi("C")`, and in an `x86-interrupt` function that is a
+  statement that the handler clobbers xmm0-15. LLVM then preserves them — with
+  `movaps` into aligned slots, in the handler's *own prologue*, before any of the
+  realigning code runs. The handler re-faults on entry, forever, and it surfaces
+  as a double fault from stack exhaustion in a prologue.
+* The old `rsp` is parked in a stack slot, not a callee-saved register. The
+  register version compiles: `clobber_abi("C")` covers only the caller-saved set,
+  so the allocator is free to hand the arguments `r15`, and `mov r15, rsp` then
+  passes the stack pointer as the context argument.
+
+Reverting the shim and calling the body directly reproduces the original double
+#GP inside `BTreeMap::remove`, which is the control for all of it.
+
 ## What is deliberately still missing
 - **The filesystem is read-only.** Allocating clusters and keeping both FAT
   copies consistent is a separate problem, and a read-only filesystem that is
@@ -1737,24 +1923,24 @@ policy uses.
 - **The VFS is still unwired.** `userspace/fs-service/src/vfs.rs` has a mount
   table; it has never had a real filesystem underneath it, and connecting the
   two is separate work from making FAT32 correct.
-- **No `fork`/`exec`.** `spawn` loads a *second* program rather than duplicating
-  the caller, so there is still no way for a program to replace its own image or
-  to inherit one. `userspace/init` cannot do its job until `fork` exists.
-- **No `fork`.** Every process starts from an ELF. Duplicating a *running*
-  address space needs the page tables copied and every writable page marked
-  copy-on-write, plus a `#PF` handler that does the copying — none of which
-  exists. The address space is now the right shape for it.
-- **No demand paging.** Every page of a program is allocated and populated at
-  load time, so a 256 KiB `.bss` costs 65 frames whether or not it is touched.
+- **The filesystem is still in the kernel.** The disk driver is out; `fat32` is
+  not, and until it is, "microkernel" describes the disk and nothing above it.
+  That is the next phase, and it is what lets `kernel/src/block/ata.rs` be
+  deleted rather than merely stood aside from.
+- **`exec` takes no `argv`.** A driver cannot be told which device to serve, which
+  is part of why `DRIVER_IMAGES` maps an image name to a device rather than the
+  program deciding.
+- **Drivers are trusted by boot-module name.** See Phase 18: the delegation chain
+  from `init` is what would make the capability grant mean something.
+- **Interrupts are not delivered to ring 3.** The ring-3 driver polls, exactly as
+  the in-kernel one does. A driver that wants IRQ14 needs the kernel to turn an
+  interrupt into a message, which nothing does yet.
 - **The descriptor table is still global.** One table for the system, because
   `Program` has nowhere to hang a per-process one yet. `sys_exit` works around
   it by only closing everything when it is the last program running.
-- **No IPC or capabilities from ring 3.** Both subsystems are implemented
-  in-kernel and unreachable, waiting on a single process-id namespace — see
-  Phase 13 above.
-- **No pipes or background jobs.** `ksh` parses them; running them needs two
-  programs connected by a shared descriptor, which needs per-process descriptor
-  tables. The table is currently global — see the note in `sys_exit`.
+- **No pipes.** `ksh` parses them; running them needs two programs connected by a
+  shared descriptor, which needs per-process descriptor tables. The table is
+  currently global — see the note in `sys_exit`.
 - **Swap and power management are disabled** in `init_kernel`. Both were
   simulated, and swap tried to allocate 8 MiB from a 1 MiB heap.
 - **Only IRQ0 and IRQ1 are unmasked.** Everything else on the PIC has a

--- a/kernel/src/block/ata.rs
+++ b/kernel/src/block/ata.rs
@@ -83,9 +83,39 @@ pub struct AtaDisk {
     name: [u8; 8],
 }
 
+impl Channel {
+    /// The name this channel goes by in `platform::devports`.
+    const fn device_name(self) -> &'static str {
+        match self {
+            Channel::Primary => "ata0",
+            Channel::Secondary => "ata1",
+        }
+    }
+}
+
 impl AtaDisk {
+    /// Refuse if a ring-3 driver is currently driving this channel.
+    ///
+    /// The two drivers share one set of registers and neither can see the
+    /// other's half-issued command: this one writes the LBA registers, the
+    /// user-space one writes its own, and the command that follows reads
+    /// whichever sector the last writer named. It is not a race that fails
+    /// loudly — it silently returns the wrong sector's bytes.
+    ///
+    /// So the claim is checked on every entry point rather than once at probe
+    /// time. A driver can be started and can exit while the system runs, and
+    /// `fat32` holds an `AtaDisk` across all of it.
+    fn check_not_claimed(channel: Channel) -> Result<(), BlockError> {
+        if crate::platform::devports::is_claimed(channel.device_name()) {
+            Err(BlockError::ClaimedByUserspace)
+        } else {
+            Ok(())
+        }
+    }
+
     /// Look for a drive and read its parameters with IDENTIFY.
     pub fn probe(channel: Channel, drive: Drive) -> Result<Self, BlockError> {
+        Self::check_not_claimed(channel)?;
         let io = channel.io_base();
 
         unsafe {
@@ -272,6 +302,7 @@ impl BlockDevice for AtaDisk {
     }
 
     fn read_blocks(&self, lba: u64, buf: &mut [u8]) -> Result<(), BlockError> {
+        Self::check_not_claimed(self.channel)?;
         if buf.len() % BLOCK_SIZE != 0 {
             return Err(BlockError::BadBufferSize);
         }
@@ -302,6 +333,7 @@ impl BlockDevice for AtaDisk {
     }
 
     fn write_blocks(&self, lba: u64, buf: &[u8]) -> Result<(), BlockError> {
+        Self::check_not_claimed(self.channel)?;
         if buf.len() % BLOCK_SIZE != 0 {
             return Err(BlockError::BadBufferSize);
         }

--- a/kernel/src/block/mod.rs
+++ b/kernel/src/block/mod.rs
@@ -30,6 +30,9 @@ pub enum BlockError {
     BadBufferSize,
     /// The device is read-only.
     ReadOnly,
+    /// A ring-3 driver holds this device. The kernel's own driver stands aside
+    /// rather than interleaving register writes with it.
+    ClaimedByUserspace,
 }
 
 pub trait BlockDevice: Send + Sync {

--- a/kernel/src/gdt.rs
+++ b/kernel/src/gdt.rs
@@ -28,6 +28,34 @@
 //! to mutate it, which is why [`set_kernel_stack`] used to be
 //! `unimplemented!()`. The table and the TSS are now plain statics initialised
 //! imperatively, in a defined order.
+//!
+//! ## The I/O permission bitmap
+//!
+//! A driver in ring 3 has to execute `in` and `out`. There are three ways to let
+//! it, and only one of them is worth having:
+//!
+//! * **A port-I/O system call.** Safe, and unusably slow: a 512-byte ATA sector
+//!   is 256 16-bit port reads, so a one-sector read becomes 256 round trips
+//!   through the syscall stub.
+//! * **IOPL = 3 in the thread's RFLAGS.** One bit, and it grants *every* port —
+//!   the PIC at 0x20, the PIT at 0x40, the CMOS at 0x70, COM1 at 0x3F8. A disk
+//!   driver that can mask the timer interrupt is not isolated from the kernel in
+//!   any sense that matters.
+//! * **The TSS I/O permission bitmap**, which is what this does. With IOPL = 0,
+//!   the CPU consults one bit per port, in the TSS, on every `in`/`out`. A
+//!   granted port costs nothing at run time; a denied one raises #GP.
+//!
+//! The bitmap is per-*task* in the hardware's sense, which since we do not use
+//! hardware task switching means there is one of it. So it is rewritten on
+//! context switch from the incoming thread's grant — see [`set_io_grant`] — the
+//! same way `RSP0` is, and for the same reason.
+//!
+//! `TaskStateSegment` from the `x86_64` crate has an `iomap_base` field but no
+//! room after it, and `Descriptor::tss_segment` hard-codes the limit to
+//! `size_of::<TaskStateSegment>() - 1`. A bitmap that starts past the segment
+//! limit means "deny everything" — which is a perfectly good default and exactly
+//! what the stock descriptor gives you, but it is not a bitmap. Hence
+//! [`TssWithIoBitmap`] and a descriptor built by hand.
 
 use core::ptr::{addr_of, addr_of_mut};
 
@@ -54,7 +82,43 @@ static mut DOUBLE_FAULT_STACK: [u8; DOUBLE_FAULT_STACK_SIZE] = [0; DOUBLE_FAULT_
 /// first context switch, during which nothing runs in ring 3.
 static mut BOOT_KERNEL_STACK: [u8; BOOT_KERNEL_STACK_SIZE] = [0; BOOT_KERNEL_STACK_SIZE];
 
-static mut TSS: TaskStateSegment = TaskStateSegment::new();
+/// Ports the bitmap covers. Everything a PC's legacy hardware lives at is below
+/// 0x400: the PIC (0x20), the PIT (0x40), the keyboard controller (0x60), the
+/// CMOS (0x70), the ATA channels (0x1F0, 0x170, 0x3F6, 0x376), VGA (0x3C0) and
+/// the serial ports (0x3F8, 0x2F8).
+///
+/// A port whose bit lies past the segment limit is *denied*, so stopping at 1024
+/// rather than 65536 fails closed. 8 KiB of always-ones would be the alternative.
+pub const IO_PORT_LIMIT: u16 = 1024;
+const IO_BITMAP_BYTES: usize = (IO_PORT_LIMIT as usize) / 8;
+
+/// The TSS with the bitmap laid out immediately after it.
+///
+/// `packed(4)` matches `TaskStateSegment`'s own representation, so `bitmap`
+/// really does start at offset 104 — which is the value written into
+/// `iomap_base`, and the CPU will silently read the wrong bytes if the two
+/// disagree.
+#[repr(C, packed(4))]
+struct TssWithIoBitmap {
+    tss: TaskStateSegment,
+    bitmap: [u8; IO_BITMAP_BYTES],
+    /// The terminator byte.
+    ///
+    /// An `out dx, ax` at port 1023 asks the CPU about ports 1023 and 1024, and
+    /// it reads the *pair* of bytes containing them — one byte past the bitmap.
+    /// The manual requires that byte to be 0xFF and present within the limit;
+    /// without it the CPU would read whatever follows in memory and could allow
+    /// an access off the end of the table.
+    terminator: u8,
+}
+
+static mut TSS_IO: TssWithIoBitmap = TssWithIoBitmap {
+    tss: TaskStateSegment::new(),
+    // All ones: deny. A thread gets ports only by being handed a grant.
+    bitmap: [0xFF; IO_BITMAP_BYTES],
+    terminator: 0xFF,
+};
+
 static mut GDT: GlobalDescriptorTable = GlobalDescriptorTable::new();
 
 #[derive(Debug, Clone, Copy)]
@@ -77,7 +141,7 @@ pub fn init() {
     serial_println!("Setting up GDT and TSS...");
 
     unsafe {
-        let tss = &mut *addr_of_mut!(TSS);
+        let tss = &mut (*addr_of_mut!(TSS_IO)).tss;
 
         tss.interrupt_stack_table[DOUBLE_FAULT_IST_INDEX as usize] = {
             let start = VirtAddr::from_ptr(addr_of!(DOUBLE_FAULT_STACK));
@@ -89,6 +153,12 @@ pub fn init() {
             start + BOOT_KERNEL_STACK_SIZE
         };
 
+        // Offset of `bitmap` within the segment. `TaskStateSegment` is 104 bytes
+        // and `packed(4)` adds no padding, so this is 104 — computed rather than
+        // written out, because a hard-coded 104 that stops being true produces a
+        // bitmap the CPU reads from the wrong place and no diagnostic at all.
+        tss.iomap_base = core::mem::size_of::<TaskStateSegment>() as u16;
+
         let gdt = &mut *addr_of_mut!(GDT);
 
         // Order is load-bearing — see the module docs.
@@ -96,7 +166,7 @@ pub fn init() {
         let kernel_data = gdt.add_entry(Descriptor::kernel_data_segment());
         let user_data = gdt.add_entry(Descriptor::user_data_segment());
         let user_code = gdt.add_entry(Descriptor::user_code_segment());
-        let tss_sel = gdt.add_entry(Descriptor::tss_segment(&*addr_of!(TSS)));
+        let tss_sel = gdt.add_entry(tss_descriptor_with_bitmap());
 
         let selectors = Selectors {
             kernel_code,
@@ -130,7 +200,34 @@ pub fn init() {
             "  TSS.RSP0 = 0x{:x} (boot stack; per-thread from the first switch)",
             tss.privilege_stack_table[0].as_u64()
         );
+        serial_println!(
+            "  I/O bitmap at TSS+{}, {} bytes, ports 0..{} all denied",
+            tss.iomap_base,
+            IO_BITMAP_BYTES,
+            IO_PORT_LIMIT - 1
+        );
     }
+}
+
+/// The TSS descriptor, with the limit stretched over the bitmap.
+///
+/// `Descriptor::tss_segment` cannot be used: it computes the limit from
+/// `size_of::<TaskStateSegment>()`, which stops just before `iomap_base` points.
+/// The failure mode is not a crash — a bitmap outside the limit reads as all
+/// ones, so every port is denied and a driver simply never works.
+fn tss_descriptor_with_bitmap() -> Descriptor {
+    let ptr = addr_of!(TSS_IO) as u64;
+    // Inclusive bound, hence the -1.
+    let limit = (core::mem::size_of::<TssWithIoBitmap>() - 1) as u64;
+
+    let low = (1u64 << 47)                        // present
+        | (0b1001u64 << 40)                       // type: available 64-bit TSS
+        | ((ptr & 0x00FF_FFFF) << 16)             // base 0..24
+        | (((ptr >> 24) & 0xFF) << 56)            // base 24..32
+        | (limit & 0xFFFF);                       // limit 0..16
+    let high = ptr >> 32; // base 32..64
+
+    Descriptor::SystemSegment(low, high)
 }
 
 /// Point RSP0 at `top`.
@@ -145,13 +242,57 @@ pub fn init() {
 /// the stack it is already using, and the syscall frame is not at risk.
 pub fn set_kernel_stack(top: VirtAddr) {
     unsafe {
-        (*addr_of_mut!(TSS)).privilege_stack_table[0] = top;
+        (*addr_of_mut!(TSS_IO)).tss.privilege_stack_table[0] = top;
     }
 }
 
 /// Current RSP0, for diagnostics.
 pub fn kernel_stack() -> VirtAddr {
-    unsafe { (*addr_of!(TSS)).privilege_stack_table[0] }
+    unsafe { (*addr_of!(TSS_IO)).tss.privilege_stack_table[0] }
+}
+
+/// Grant currently installed in the bitmap.
+///
+/// Cached so the common switch — between threads that hold no ports, which is
+/// all of them but the driver — touches nothing. Rewriting 128 bytes on every
+/// tick would work and would be silly.
+static mut INSTALLED_IO_GRANT: u32 = 0;
+
+/// Write `grant`'s ports into the bitmap, denying everything else.
+///
+/// Called from the scheduler with the incoming thread's grant, alongside
+/// `set_kernel_stack`. The two failures are symmetrical: forget `set_kernel_stack`
+/// and a thread lands on another's kernel stack; forget this and a thread
+/// inherits another's hardware.
+///
+/// # Safety
+/// Must be called with interrupts disabled — it mutates a table the CPU reads.
+pub unsafe fn set_io_grant(grant: u32) {
+    if INSTALLED_IO_GRANT == grant {
+        return;
+    }
+
+    let tss_io = &mut *addr_of_mut!(TSS_IO);
+    tss_io.bitmap.fill(0xFF);
+
+    for (base, len) in crate::platform::devports::ports_for_grant(grant) {
+        for port in base..base.saturating_add(len) {
+            if port >= IO_PORT_LIMIT {
+                continue;
+            }
+            tss_io.bitmap[(port / 8) as usize] &= !(1u8 << (port % 8));
+        }
+    }
+
+    INSTALLED_IO_GRANT = grant;
+}
+
+/// Whether port `port` is currently permitted in ring 3. Diagnostics only.
+pub fn io_port_allowed(port: u16) -> bool {
+    if port >= IO_PORT_LIMIT {
+        return false;
+    }
+    unsafe { (*addr_of!(TSS_IO)).bitmap[(port / 8) as usize] & (1u8 << (port % 8)) == 0 }
 }
 
 /// Top of the stack `init` installed as RSP0.

--- a/kernel/src/interrupts/exceptions.rs
+++ b/kernel/src/interrupts/exceptions.rs
@@ -2,17 +2,140 @@
 //!
 //! Every handler prints a legible dump — vector, mnemonic, error code, faulting
 //! instruction pointer, stack pointer, flags and (for page faults) CR2 — and
-//! then halts. Halting rather than rebooting is deliberate: a frozen machine
-//! with a readable dump on the serial port is debuggable, a reboot loop is not.
+//! then either kills the offending process or halts. Halting rather than
+//! rebooting is deliberate: a frozen machine with a readable dump on the serial
+//! port is debuggable, a reboot loop is not.
+//!
+//! ## Whose fault it is
+//!
+//! The page-fault handler has terminated ring-3 threads rather than halting
+//! since Phase 5, on the grounds that a userspace bug taking down the machine is
+//! the exact thing a microkernel exists to avoid. Every *other* handler halted,
+//! which meant the argument only applied to the one exception a program was
+//! expected to cause. A `ud2` in a user program, a division by zero, or — since
+//! this phase — an `in` on a port the process was not granted, all stopped the
+//! system.
+//!
+//! [`fault`] now makes that decision for every vector, from CS's RPL. Faults in
+//! ring 0 still halt: a kernel that cannot trust its own state has nothing
+//! useful to do next.
+//!
+//! ## Why the handlers do their work through [`kosh_call_aligned`]
+//!
+//! An exception that pushes an error code pushes six quadwords onto a stack the
+//! CPU has already aligned to 16, so the handler starts with `RSP % 16 == 0`.
+//! The System V ABI says a function starts with `RSP % 16 == 8` — the state a
+//! `call` leaves, having pushed a return address. Those disagree by eight bytes,
+//! and LLVM's `x86-interrupt` convention does not reconcile them: everything the
+//! handler calls runs with its frames eight bytes off, and the first `movaps` to
+//! a 16-aligned stack slot anywhere in that subtree raises #GP.
+//!
+//! This was true of every error-code handler since Phase 5 and never fired,
+//! because the only one that did real work was the page-fault handler and the
+//! only process it ever killed was a demo with no message queue to tear down.
+//! Killing a *registered* process reaches `BTreeMap::remove`, which spills SSE
+//! registers to aligned slots, which faults — a second #GP, inside the handler
+//! for the first, from a `movaps` in code that is entirely correct.
+//!
+//! So the handlers keep only the frame decoding, and hand the work to a body
+//! function called with the stack put back the way the ABI expects.
 
 use x86_64::structures::idt::{InterruptStackFrame, PageFaultErrorCode};
 
 use crate::{println, serial_println};
 
-/// Print a uniform exception banner, then hang.
+/// Call `body(arg)` with the stack aligned as the System V ABI requires.
+///
+/// # Safety
+/// `arg` must be whatever `body` expects.
+extern "C" {
+    fn kosh_call_aligned(body: extern "C" fn(u64), arg: u64);
+}
+
+// Written as `global_asm!` rather than inline `asm!` for a reason worth
+// recording, because the inline version compiles and then breaks the machine.
+//
+// An inline `asm!` that contains a `call` has to declare `clobber_abi("C")`, and
+// for an `x86-interrupt` function that declaration is a statement that the
+// handler clobbers xmm0-15. LLVM then dutifully preserves them — with `movaps`
+// into 16-byte-aligned slots, in the handler's *own prologue*, before any of
+// this code runs. Those spills fault for exactly the reason this function
+// exists, so the handler re-faults on entry, forever, until the kernel stack is
+// gone and it comes out as a double fault in a prologue.
+//
+// A plain `extern "C"` call has no such effect: the handler saves what it
+// actually holds, which is what it did before any of this was here.
+core::arch::global_asm!(
+    r#"
+.section .text.kosh_call_aligned, "ax"
+.global kosh_call_aligned
+.type kosh_call_aligned, @function
+
+kosh_call_aligned:
+    /* rdi = body, rsi = arg. r10 and r11 are caller-saved scratch. */
+    movq    %rdi, %r11
+    movq    %rsi, %rdi
+
+    movq    %rsp, %r10
+    andq    $-16, %rsp          /* only ever moves down, so the caller's
+                                   locals - including the context struct -
+                                   stay where they are                      */
+    subq    $16, %rsp           /* still 16-aligned; room to park old rsp   */
+    movq    %r10, 8(%rsp)
+
+    call    *%r11               /* rsp % 16 == 0 here, so the callee starts
+                                   at 8, which is what the ABI defines      */
+
+    movq    8(%rsp), %rsp
+    ret
+"#,
+    options(att_syntax)
+);
+
+/// What [`fault_body`] needs, gathered so it can be passed as one pointer.
+#[repr(C)]
+struct FaultContext<'a> {
+    vector: u8,
+    name: &'a str,
+    error_code: Option<u64>,
+    frame: &'a InterruptStackFrame,
+}
+
+/// Print a uniform exception banner, then kill the process or hang.
 fn fault(vector: u8, name: &str, error_code: Option<u64>, frame: &InterruptStackFrame) -> ! {
-    dump(vector, name, error_code, frame);
+    let context = FaultContext {
+        vector,
+        name,
+        error_code,
+        frame,
+    };
+
+    unsafe { kosh_call_aligned(fault_body, &context as *const FaultContext as u64) };
+
+    // `fault_body` does not return. Reached only if it somehow did.
     halt()
+}
+
+extern "C" fn fault_body(context: u64) {
+    let context = unsafe { &*(context as *const FaultContext) };
+
+    dump(context.vector, context.name, context.error_code, context.frame);
+
+    if from_ring3(context.frame) {
+        serial_println!("  action      : ring 3 fault — terminating the process, not the system");
+        crate::task::kill_current(crate::task::EXIT_KILLED);
+    }
+
+    halt()
+}
+
+/// Whether the fault happened in ring 3.
+///
+/// From the saved CS's requested-privilege-level bits, which the CPU pushed as
+/// part of the exception frame. Reading the *current* CS would be wrong — by the
+/// time a handler runs, CS is the kernel's.
+fn from_ring3(frame: &InterruptStackFrame) -> bool {
+    frame.code_segment & 3 == 3
 }
 
 fn dump(vector: u8, name: &str, error_code: Option<u64>, frame: &InterruptStackFrame) {
@@ -53,8 +176,10 @@ pub extern "x86-interrupt" fn divide_error_handler(frame: InterruptStackFrame) {
 
 pub extern "x86-interrupt" fn nmi_handler(frame: InterruptStackFrame) {
     // An NMI is usually a hardware problem (parity error, watchdog). Report it
-    // but do not pretend we can recover.
-    fault(2, "NMI Non-Maskable Interrupt", None, &frame)
+    // but do not pretend we can recover — and unlike the rest, do not blame the
+    // running process for it, whichever ring it was in.
+    dump(2, "NMI Non-Maskable Interrupt", None, &frame);
+    halt()
 }
 
 pub extern "x86-interrupt" fn overflow_handler(frame: InterruptStackFrame) {
@@ -123,7 +248,10 @@ pub extern "x86-interrupt" fn alignment_check_handler(
 }
 
 pub extern "x86-interrupt" fn machine_check_handler(frame: InterruptStackFrame) -> ! {
-    fault(18, "#MC Machine Check", None, &frame)
+    // Hardware said something is wrong with the hardware. Not the process's
+    // doing, and not survivable by killing it.
+    dump(18, "#MC Machine Check", None, &frame);
+    halt()
 }
 
 pub extern "x86-interrupt" fn simd_handler(frame: InterruptStackFrame) {
@@ -140,7 +268,41 @@ pub extern "x86-interrupt" fn page_fault_handler(
     frame: InterruptStackFrame,
     error_code: PageFaultErrorCode,
 ) {
+    // Every page fault goes through the realigning shim, not just the ones that
+    // kill something: `resolve_cow` and `resolve_demand` run on the common path,
+    // several times per program, and they are ordinary kernel code entitled to
+    // an ABI-conformant stack.
+    let mut context = PageFaultContext {
+        frame: &frame,
+        error_code,
+        resolved: false,
+    };
+
+    unsafe {
+        kosh_call_aligned(
+            page_fault_body,
+            &mut context as *mut PageFaultContext as u64,
+        )
+    };
+
+    // `resolved` is the return, because the shim's body cannot have one: the
+    // handler returns normally so the CPU retries the faulting instruction.
+    let _ = context.resolved;
+}
+
+#[repr(C)]
+struct PageFaultContext<'a> {
+    frame: &'a InterruptStackFrame,
+    error_code: PageFaultErrorCode,
+    resolved: bool,
+}
+
+extern "C" fn page_fault_body(context: u64) {
     use x86_64::registers::control::Cr2;
+
+    let context = unsafe { &mut *(context as *mut PageFaultContext) };
+    let frame = context.frame;
+    let error_code = context.error_code;
 
     let accessed = Cr2::read();
 
@@ -155,7 +317,10 @@ pub extern "x86-interrupt" fn page_fault_handler(
         && accessed.as_u64() < crate::syscall::uaccess::USER_ADDRESS_LIMIT
     {
         match crate::memory::paging::resolve_cow(accessed.as_u64()) {
-            Ok(true) => return,
+            Ok(true) => {
+                context.resolved = true;
+                return;
+            }
             Ok(false) => {}
             Err(e) => {
                 serial_println!();
@@ -171,7 +336,10 @@ pub extern "x86-interrupt" fn page_fault_handler(
         && accessed.as_u64() < crate::syscall::uaccess::USER_ADDRESS_LIMIT
     {
         match crate::memory::paging::resolve_demand(accessed.as_u64()) {
-            Ok(true) => return,
+            Ok(true) => {
+                context.resolved = true;
+                return;
+            }
             Ok(false) => {}
             Err(e) => {
                 serial_println!();
@@ -222,10 +390,13 @@ pub extern "x86-interrupt" fn page_fault_handler(
         serial_println!("  action           : ring 3 fault — terminating the process");
         serial_println!("  rip              : 0x{:016x}", frame.instruction_pointer.as_u64());
         serial_println!("====================================================");
-        crate::task::exit_current();
+        // Same exit code every killed process gets, so a waiting parent sees one
+        // thing for "the kernel stopped it" regardless of which vector did.
+        crate::task::kill_current(crate::task::EXIT_KILLED);
     }
 
-    fault(14, "#PF Page Fault", Some(error_code.bits()), &frame)
+    dump(14, "#PF Page Fault", Some(error_code.bits()), frame);
+    halt()
 }
 
 // --- double fault ----------------------------------------------------------
@@ -237,7 +408,11 @@ pub extern "x86-interrupt" fn double_fault_handler(
     serial_println!();
     serial_println!("A second exception fired while handling the first.");
     serial_println!("Common causes: kernel stack overflow, or a fault inside a handler.");
-    fault(8, "#DF Double Fault", Some(error_code), &frame)
+    // Deliberately halts even from ring 3. A double fault means the CPU could
+    // not deliver the *first* exception, so the machinery that would kill the
+    // process is exactly the machinery that has already failed once.
+    dump(8, "#DF Double Fault", Some(error_code), &frame);
+    halt()
 }
 
 // --- resumable -------------------------------------------------------------

--- a/kernel/src/platform/devports.rs
+++ b/kernel/src/platform/devports.rs
@@ -1,0 +1,149 @@
+//! Which ports a named device is.
+//!
+//! The `SYS_REQUEST_DEVICE` system call takes a *device name*, not a port range.
+//! That is the whole point: a driver that could ask for arbitrary ports could
+//! ask for 0x20 and mask the timer, or 0x64 and reset the CPU through the
+//! keyboard controller. Naming a device means the kernel decides what that
+//! device consists of, and the answer lives here, in one table, where it can be
+//! read.
+//!
+//! The table is deliberately short. Every entry is a promise that handing those
+//! ports to an unprivileged process is survivable, and that is a claim worth
+//! making one device at a time.
+
+use spin::Mutex;
+
+use crate::serial_println;
+
+/// A contiguous run of ports: `(base, count)`.
+pub type PortRange = (u16, u16);
+
+/// Ports that make up a device, and who may currently drive it.
+pub struct Device {
+    pub name: &'static str,
+    /// At most two runs — a command block and a control block, which is the
+    /// shape of every legacy device that is split at all.
+    pub ranges: [Option<PortRange>; 2],
+    pub description: &'static str,
+}
+
+/// The devices a ring-3 driver may be given.
+///
+/// Notably absent: the PIC (0x20/0xA0), the PIT (0x40), the keyboard controller
+/// (0x60/0x64), the CMOS/NMI gate (0x70) and COM1 (0x3F8). The first three can
+/// stop the scheduler, the fourth can mask NMIs, and the last is where every
+/// diagnostic in this system goes. None of them are things a disk driver needs,
+/// so none of them are in the table, so no capability can name them.
+pub static DEVICES: &[Device] = &[
+    Device {
+        name: "ata0",
+        // 0x1F0..0x1F7 is the command block; 0x3F6 is the device control and
+        // alternate status register, which is a *separate* range on the ISA bus
+        // and is why this table has room for two.
+        ranges: [Some((0x1F0, 8)), Some((0x3F6, 1))],
+        description: "primary IDE channel",
+    },
+    Device {
+        name: "ata1",
+        ranges: [Some((0x170, 8)), Some((0x376, 1))],
+        description: "secondary IDE channel",
+    },
+];
+
+/// Index of a device by name.
+pub fn index_of(name: &str) -> Option<usize> {
+    DEVICES.iter().position(|d| d.name == name)
+}
+
+/// A grant is a bitmask of [`DEVICES`] indices. `0` means no ports at all, which
+/// is what every thread starts with.
+pub const NO_GRANT: u32 = 0;
+
+pub fn grant_bit(index: usize) -> u32 {
+    1u32 << index
+}
+
+/// Every port range a grant covers, for the bitmap writer.
+pub fn ports_for_grant(grant: u32) -> impl Iterator<Item = PortRange> {
+    DEVICES
+        .iter()
+        .enumerate()
+        .filter(move |(i, _)| grant & grant_bit(*i) != 0)
+        .flat_map(|(_, d)| d.ranges.iter().flatten().copied())
+}
+
+/// Human-readable form of a grant, for the log.
+pub fn describe_grant(grant: u32) -> &'static str {
+    if grant == NO_GRANT {
+        return "none";
+    }
+    // One name, because nothing yet holds two devices; when something does this
+    // wants to be a formatter, not a lookup.
+    DEVICES
+        .iter()
+        .enumerate()
+        .find(|(i, _)| grant & grant_bit(*i) != 0)
+        .map(|(_, d)| d.name)
+        .unwrap_or("?")
+}
+
+// ---------------------------------------------------------------------------
+// Claims
+// ---------------------------------------------------------------------------
+
+/// Which thread, if any, currently drives each device.
+///
+/// This exists because the kernel still contains an ATA driver of its own, at
+/// `block/ata.rs`, which `fs/fat32.rs` reads through. Two drivers polling the
+/// same status register interleave: one writes the LBA registers, the other
+/// issues its command, and both then read the wrong sector — intermittently, and
+/// only when both happen to be active.
+///
+/// So a device has one driver at a time. While a ring-3 process holds `ata0`,
+/// the kernel's own block layer refuses that channel; when the driver exits, the
+/// claim is released and the kernel can read the disk again. That is a temporary
+/// arrangement and it is visible in the log rather than assumed: the alternative
+/// to two drivers coexisting badly is one of them going away, which is what the
+/// next phase does to the in-kernel one.
+static CLAIMS: Mutex<[Option<usize>; 4]> = Mutex::new([None; 4]);
+
+/// Give `thread` exclusive use of device `index`.
+pub fn claim(index: usize, thread: usize) -> Result<(), &'static str> {
+    let mut claims = CLAIMS.lock();
+    let Some(slot) = claims.get_mut(index) else {
+        return Err("no such device");
+    };
+    match *slot {
+        Some(owner) if owner != thread => Err("device already claimed"),
+        _ => {
+            *slot = Some(thread);
+            Ok(())
+        }
+    }
+}
+
+/// Drop every claim held by `thread`. Called when a thread exits, so a driver
+/// that crashes does not take its disk with it.
+pub fn release_all(thread: usize) {
+    let mut claims = CLAIMS.lock();
+    for (i, slot) in claims.iter_mut().enumerate() {
+        if *slot == Some(thread) {
+            *slot = None;
+            serial_println!(
+                "  released device '{}' held by thread {}",
+                DEVICES.get(i).map(|d| d.name).unwrap_or("?"),
+                thread
+            );
+        }
+    }
+}
+
+/// Whether a named device is currently driven from ring 3.
+///
+/// The kernel's own drivers consult this before touching hardware.
+pub fn is_claimed(name: &str) -> bool {
+    match index_of(name) {
+        Some(i) => CLAIMS.lock().get(i).copied().flatten().is_some(),
+        None => false,
+    }
+}

--- a/kernel/src/platform/mod.rs
+++ b/kernel/src/platform/mod.rs
@@ -7,6 +7,7 @@
 use core::fmt;
 
 pub mod traits;
+pub mod devports;
 #[cfg(target_arch = "x86_64")]
 pub mod rtc;
 pub mod x86_64;

--- a/kernel/src/syscall/dispatcher.rs
+++ b/kernel/src/syscall/dispatcher.rs
@@ -96,6 +96,8 @@ pub fn dispatch_syscall(
         SYS_DRIVER_UNREGISTER => sys_driver_unregister(process_id, args),
         SYS_DRIVER_REQUEST => sys_driver_request(process_id, args),
         SYS_DRIVER_RESPONSE => sys_driver_response(process_id, args),
+        SYS_REQUEST_DEVICE => sys_request_device(process_id, args),
+        SYS_RELEASE_DEVICE => sys_release_device(process_id, args),
         
         // System information
         SYS_GETDENTS => crate::syscall::files::sys_getdents(args),
@@ -911,6 +913,101 @@ fn sys_driver_response(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
     
     // TODO: Implement driver response
     Err(SyscallError::NotSupported)
+}
+
+/// Longest device name `request_device` will look at.
+const MAX_DEVICE_NAME: usize = 16;
+
+/// Read a device name out of userspace and find it in the table.
+fn device_arg(args: [u64; 6]) -> Result<usize, SyscallError> {
+    let len = args[1] as usize;
+    if len == 0 || len > MAX_DEVICE_NAME {
+        return Err(SyscallError::InvalidArgument);
+    }
+
+    let mut buf = [0u8; MAX_DEVICE_NAME];
+    crate::syscall::uaccess::copy_from_user(args[0], &mut buf[..len])
+        .map_err(|_| SyscallError::InvalidArgument)?;
+
+    let name = core::str::from_utf8(&buf[..len]).map_err(|_| SyscallError::InvalidArgument)?;
+    crate::platform::devports::index_of(name).ok_or(SyscallError::NotFound)
+}
+
+/// `request_device(name_ptr, name_len)` -> 0
+///
+/// Three things have to be true, and each refuses differently:
+///
+/// 1. the name is a device the kernel is willing to hand out at all — the table
+///    in `platform::devports` is the entire list, and it does not contain the
+///    interrupt controller, the timer or the serial port;
+/// 2. the caller holds `DeviceAccess` for it, which is granted at spawn to boot
+///    modules the kernel recognises as drivers;
+/// 3. nobody else is driving it, because two drivers polling one status register
+///    is a corruption bug that only shows up under load.
+///
+/// On success the thread's ports appear in the TSS I/O permission bitmap
+/// immediately, not at the next context switch — the `in` on the line after this
+/// call would otherwise still fault.
+fn sys_request_device(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
+    use crate::ipc::capability::{check_capability, CapabilityType, ResourceId};
+    use crate::platform::devports;
+
+    let index = device_arg(args)?;
+    let device = &devports::DEVICES[index];
+
+    if !check_capability(
+        process_id,
+        CapabilityType::DeviceAccess,
+        &ResourceId::Device(alloc::string::String::from(device.name)),
+    ) {
+        serial_println!(
+            "  process {} asked for '{}' without a DeviceAccess capability — refused",
+            process_id.0,
+            device.name
+        );
+        return Err(SyscallError::PermissionDenied);
+    }
+
+    devports::claim(index, process_id.0 as usize).map_err(|_| SyscallError::Busy)?;
+    crate::task::grant_io_device(index);
+
+    serial_println!(
+        "  process {} now drives '{}' ({}) — ports in ring 3",
+        process_id.0,
+        device.name,
+        device.description
+    );
+
+    // A claim nothing enforces is a comment. Check it here, at the moment the
+    // claim is taken, rather than trusting that `block/ata.rs` consults the
+    // table: `probe` refuses before it touches a single port, so asking is safe
+    // even with a driver mid-command.
+    #[cfg(target_arch = "x86_64")]
+    if device.name == "ata0" {
+        use crate::block::ata::{AtaDisk, Channel, Drive};
+        use crate::block::BlockError;
+        match AtaDisk::probe(Channel::Primary, Drive::Master) {
+            Err(BlockError::ClaimedByUserspace) => {
+                serial_println!("  the kernel's own ATA driver now refuses ata0")
+            }
+            _ => serial_println!("  WARNING: the kernel's ATA driver still drives ata0"),
+        }
+    }
+
+    Ok(0)
+}
+
+/// `release_device(name_ptr, name_len)` -> 0
+///
+/// Only the claim is dropped here, not the bitmap: the ports go away when the
+/// thread exits or is next scheduled with a smaller grant. That asymmetry is on
+/// purpose — a driver handing a disk back should not be able to keep half-issued
+/// commands in flight, so `claim` is what the kernel's own block layer consults.
+fn sys_release_device(process_id: ProcessId, args: [u64; 6]) -> SyscallResult {
+    let index = device_arg(args)?;
+    crate::platform::devports::release_all(process_id.0 as usize);
+    let _ = index;
+    Ok(0)
 }
 
 // System information system calls

--- a/kernel/src/syscall/error.rs
+++ b/kernel/src/syscall/error.rs
@@ -38,6 +38,10 @@ pub enum SyscallError {
     ResourceExhausted,
     /// Internal kernel error
     InternalError,
+    /// The resource is in use by someone else. Distinct from `AlreadyExists`,
+    /// which is about a name: a device that is claimed exists and is fine, it
+    /// just already has a driver.
+    Busy,
 }
 
 impl SyscallError {
@@ -61,6 +65,7 @@ impl SyscallError {
             SyscallError::TimedOut => -110,          // ETIMEDOUT
             SyscallError::ResourceExhausted => -105, // ENOBUFS
             SyscallError::InternalError => -5,       // EIO
+            SyscallError::Busy => -16,               // EBUSY
         }
     }
     
@@ -84,6 +89,7 @@ impl SyscallError {
             SyscallError::TimedOut => "Operation timed out",
             SyscallError::ResourceExhausted => "System resource exhausted",
             SyscallError::InternalError => "Internal kernel error",
+            SyscallError::Busy => "Resource busy",
         }
     }
 }

--- a/kernel/src/syscall/numbers.rs
+++ b/kernel/src/syscall/numbers.rs
@@ -50,6 +50,17 @@ pub const SYS_DRIVER_REGISTER: u64 = 40;
 pub const SYS_DRIVER_UNREGISTER: u64 = 41;
 pub const SYS_DRIVER_REQUEST: u64 = 42;
 pub const SYS_DRIVER_RESPONSE: u64 = 43;
+/// `request_device(name_ptr, name_len)` -> 0
+///
+/// Ask for direct `in`/`out` access to a named device's ports. A *name*, not a
+/// port range: the kernel decides what "ata0" consists of (see
+/// `platform::devports`), so a driver cannot ask for the interrupt controller.
+pub const SYS_REQUEST_DEVICE: u64 = 44;
+/// `release_device(name_ptr, name_len)` -> 0
+///
+/// Give the ports back. Implicit on exit, so this is only for a driver that
+/// wants to hand a disk over while it keeps running.
+pub const SYS_RELEASE_DEVICE: u64 = 45;
 
 /// System information system calls
 pub const SYS_UNAME: u64 = 50;
@@ -137,6 +148,8 @@ pub fn syscall_name(syscall_number: u64) -> &'static str {
         SYS_DRIVER_UNREGISTER => "driver_unregister",
         SYS_DRIVER_REQUEST => "driver_request",
         SYS_DRIVER_RESPONSE => "driver_response",
+        SYS_REQUEST_DEVICE => "request_device",
+        SYS_RELEASE_DEVICE => "release_device",
         
         SYS_GETDENTS => "getdents",
         SYS_UNAME => "uname",

--- a/kernel/src/syscall/validation.rs
+++ b/kernel/src/syscall/validation.rs
@@ -49,6 +49,7 @@ pub fn validate_syscall_args(
         SYS_DRIVER_UNREGISTER => validate_driver_unregister_args(process_id, args),
         SYS_DRIVER_REQUEST => validate_driver_request_args(process_id, args),
         SYS_DRIVER_RESPONSE => validate_driver_response_args(process_id, args),
+        SYS_REQUEST_DEVICE | SYS_RELEASE_DEVICE => validate_device_args(process_id, args),
         
         SYS_UNAME | SYS_SYSINFO | SYS_TIME => validate_info_args(args),
         SYS_CLOCK_GETTIME => validate_clock_gettime_args(args),
@@ -561,6 +562,20 @@ fn validate_list_capabilities_args(args: &[u64; 6]) -> Result<(), SyscallError> 
 }
 
 // Debug syscall validations (only in debug builds)
+/// `request_device` / `release_device` take a device name.
+///
+/// A validator is not optional here. The default arm of `validate_syscall_args`
+/// rejects anything it does not recognise, so a syscall added to the dispatcher
+/// and not to this table is refused with `InvalidSyscall` before its handler is
+/// ever reached — which looks exactly like the syscall not existing.
+fn validate_device_args(process_id: ProcessId, args: &[u64; 6]) -> Result<(), SyscallError> {
+    let len = args[1] as usize;
+    if len == 0 || len > 16 {
+        return Err(SyscallError::InvalidArgument);
+    }
+    validate_user_pointer(process_id, args[0], len, false)
+}
+
 fn validate_debug_print_args(args: &[u64; 6]) -> Result<(), SyscallError> {
     // Debug print can take any arguments
     Ok(())

--- a/kernel/src/task/mod.rs
+++ b/kernel/src/task/mod.rs
@@ -115,6 +115,15 @@ pub struct Thread {
     /// Another thread is in `wait_for` on this one, so `reap_finished` must
     /// leave the slot alone until that waiter has collected the exit code.
     awaited: bool,
+    /// Which I/O devices this thread may drive from ring 3.
+    ///
+    /// A bitmask of `platform::devports::DEVICES` indices, installed into the
+    /// TSS I/O permission bitmap on every switch to this thread. Zero — no
+    /// ports — for everything but a driver, and zero is what a `fork`ed child
+    /// gets too: hardware is not inherited, because two processes polling the
+    /// same status register is exactly the failure the claim table exists to
+    /// prevent.
+    io_grant: u32,
 }
 
 impl Thread {
@@ -214,6 +223,7 @@ pub fn init() {
             address_space: None,
             exit_code: 0,
             awaited: false,
+            io_grant: crate::platform::devports::NO_GRANT,
         });
         sched.current = 0;
     });
@@ -253,6 +263,7 @@ pub fn spawn(name: &'static str, entry: fn(usize), arg: usize) -> Result<usize, 
             address_space: None,
             exit_code: 0,
             awaited: false,
+            io_grant: crate::platform::devports::NO_GRANT,
         });
 
         serial_println!(
@@ -366,6 +377,7 @@ pub fn spawn_forked(
             address_space: Some(space),
             exit_code: 0,
             awaited: false,
+            io_grant: crate::platform::devports::NO_GRANT,
         });
 
         serial_println!(
@@ -490,21 +502,27 @@ pub fn schedule() {
                         .as_ref()
                         .map(|a| a.pml4_phys())
                         .unwrap_or_else(crate::memory::paging::kernel_pml4_phys);
+                    let next_io = sched.threads[next].as_ref().unwrap().io_grant;
                     let prev_rsp = sched.threads[current].as_mut().unwrap().rsp_ptr();
 
-                    Some((prev_rsp, next_rsp, next, next_top, next_cr3))
+                    Some((prev_rsp, next_rsp, next, next_top, next_cr3, next_io))
                 }
             }
         }
         // lock dropped here, before the switch
     };
 
-    if let Some((prev_rsp, next_rsp, next, next_top, next_cr3)) = plan {
+    if let Some((prev_rsp, next_rsp, next, next_top, next_cr3, next_io)) = plan {
         // Before the switch, not after: the incoming thread may resume straight
         // into `sysretq` and be in ring 3 — able to fault or syscall — before
         // any instruction after `kosh_switch_context` in *this* frame runs.
         // Interrupts are off, so publishing early is not visible to anyone else.
         publish_kernel_stack(next as u64, next_top);
+
+        // Same argument, same window: the incoming thread could be executing
+        // `in` before this frame continues. Interrupts are off, which is what
+        // `set_io_grant` requires.
+        unsafe { crate::gdt::set_io_grant(next_io) };
 
         // Switch page tables if the incoming thread lives somewhere else.
         //
@@ -632,6 +650,54 @@ pub fn adopt_address_space(space: AddressSpace) {
         }
     });
 }
+
+/// Give the running thread the ports of device `index`, from now on.
+///
+/// Installs into the live bitmap as well as the thread's record: the thread is
+/// already running, so waiting for the next context switch would mean the `in`
+/// immediately after `request_device` returns still faulting.
+pub fn grant_io_device(index: usize) {
+    without_interrupts(|| {
+        let grant = {
+            let mut sched = SCHEDULER.lock();
+            let current = sched.current;
+            match sched.threads[current].as_mut() {
+                Some(t) => {
+                    t.io_grant |= crate::platform::devports::grant_bit(index);
+                    t.io_grant
+                }
+                None => return,
+            }
+        };
+        unsafe { crate::gdt::set_io_grant(grant) };
+    });
+}
+
+/// Ports the running thread holds, for diagnostics.
+pub fn current_io_grant() -> u32 {
+    without_interrupts(|| {
+        let sched = SCHEDULER.lock();
+        sched.threads[sched.current].as_ref().map(|t| t.io_grant).unwrap_or(0)
+    })
+}
+
+/// Kill the running thread because it did something it is not allowed to.
+///
+/// The distinction from [`exit_current`] is only the exit code, but the code is
+/// the point: a parent's `wait` cannot otherwise tell "the child finished" from
+/// "the child was executing an instruction the CPU refused". `hello`'s
+/// I/O-permission test turns on exactly that difference.
+pub fn kill_current(reason_code: i32) -> ! {
+    set_exit_code(reason_code);
+    exit_current()
+}
+
+/// Exit code a thread gets when the kernel terminates it for a fault.
+///
+/// Negative so it cannot collide with a status a program chose for itself —
+/// `sys_exit` takes an unsigned byte-ish value in practice, and a program that
+/// exits 137 is not the same thing as one that was killed.
+pub const EXIT_KILLED: i32 = -9;
 
 /// Retire the running thread and never come back.
 pub fn exit_current() -> ! {

--- a/kernel/src/usermode.rs
+++ b/kernel/src/usermode.rs
@@ -61,7 +61,7 @@ impl BootModule {
     }
 }
 
-const MAX_BOOT_MODULES: usize = 4;
+const MAX_BOOT_MODULES: usize = 6;
 static BOOT_MODULES: Mutex<[Option<BootModule>; MAX_BOOT_MODULES]> =
     Mutex::new([None; MAX_BOOT_MODULES]);
 
@@ -491,12 +491,55 @@ pub fn register_process(thread: usize, parent: Option<usize>, name: &str) {
             serial_println!("  could not open an IPC channel {}<->{}: {:?}", thread, parent_pid.0, e);
         }
     }
+
+    grant_driver_capabilities(pid, name);
+}
+
+/// Boot modules the kernel is willing to treat as device drivers, and what each
+/// may drive.
+///
+/// This is the weakest link in the chain and it is worth being plain about it.
+/// A capability system wants a *delegation* story: `init` holds the hardware,
+/// grants each driver exactly its device, and the kernel makes no policy
+/// decisions about which program is trusted. What is here instead is the kernel
+/// recognising a boot module by the name on its `module2` line — which is to say
+/// the trust root is "GRUB loaded it from the ISO", the same root that already
+/// decides what code the kernel will run at all.
+///
+/// That is defensible for a boot-time driver and useless for anything loaded
+/// later, which is exactly why it is a table with two entries rather than a rule.
+/// `userspace/init` taking this over is what makes it a real chain.
+const DRIVER_IMAGES: &[(&str, &str)] = &[("ata-driver", "ata0")];
+
+fn grant_driver_capabilities(pid: crate::process::ProcessId, name: &str) {
+    use crate::ipc::capability::{create_capability, CapabilityType, ResourceId};
+
+    for (image, device) in DRIVER_IMAGES {
+        if *image != name {
+            continue;
+        }
+        match create_capability(
+            pid,
+            CapabilityType::DeviceAccess,
+            ResourceId::Device(alloc::string::String::from(*device)),
+            None,
+        ) {
+            Ok(_) => serial_println!("  granted {} DeviceAccess for '{}'", pid.0, device),
+            Err(e) => serial_println!("  could not grant DeviceAccess for '{}': {:?}", device, e),
+        }
+    }
 }
 
 /// Retire a process when its thread exits.
 fn deregister_process(thread: usize) {
     use crate::process::ProcessId;
     let pid = ProcessId::new(thread as u32);
+
+    // Hardware first. A driver that faults still holds its disk otherwise, and
+    // nothing — not the kernel's own block layer, not a replacement driver —
+    // could touch it again until reboot. Surviving a driver crash is most of the
+    // argument for running drivers in ring 3 at all.
+    crate::platform::devports::release_all(thread);
 
     let _ = crate::ipc::queue::remove_message_queue(pid);
     let _ = crate::process::remove_process(pid);

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -69,7 +69,7 @@ echo "==> building userspace programs"
 # libc, and anything that moves a String around needs them.
 USER_STD=(-Z build-std=core,alloc -Z build-std-features=compiler-builtins-mem)
 
-for pkg in kosh-hello kosh-hello2 kosh-shell; do
+for pkg in kosh-hello kosh-hello2 kosh-ata-driver kosh-shell; do
     USER_FLAGS=(--package "$pkg" --target "$TARGET_JSON" "${USER_STD[@]}")
     [ "$PROFILE" = "release" ] && USER_FLAGS+=(--release)
     cargo build "${USER_FLAGS[@]}" -Z json-target-spec 2>/dev/null \
@@ -78,8 +78,9 @@ done
 
 HELLO="$ROOT/target/$TARGET_NAME/$PROFILE/kosh-hello"
 HELLO2="$ROOT/target/$TARGET_NAME/$PROFILE/kosh-hello2"
+ATADRV="$ROOT/target/$TARGET_NAME/$PROFILE/kosh-ata-driver"
 KSH="$ROOT/target/$TARGET_NAME/$PROFILE/ksh"
-for bin in "$HELLO" "$HELLO2" "$KSH"; do
+for bin in "$HELLO" "$HELLO2" "$ATADRV" "$KSH"; do
     [ -f "$bin" ] || { echo "error: userspace binary not found at $bin" >&2; exit 1; }
     echo "==> $(basename "$bin"): entry $(readelf -h "$bin" | awk '/Entry point/ {print $4}')"
 done
@@ -104,6 +105,7 @@ mkdir -p "$ISO_DIR/boot/grub"
 cp "$KERNEL" "$ISO_DIR/boot/kosh-kernel"
 cp "$HELLO" "$ISO_DIR/boot/hello"
 cp "$HELLO2" "$ISO_DIR/boot/hello2"
+cp "$ATADRV" "$ISO_DIR/boot/ata-driver"
 cp "$KSH"   "$ISO_DIR/boot/ksh"
 
 cat > "$ISO_DIR/boot/grub/grub.cfg" <<'EOF'
@@ -123,6 +125,7 @@ menuentry "Kosh" {
     multiboot2 /boot/kosh-kernel
     module2 /boot/hello hello
     module2 /boot/hello2 hello2
+    module2 /boot/ata-driver ata-driver
     module2 /boot/ksh ksh
     boot
 }
@@ -260,6 +263,15 @@ check)
         "recycled pages came back zeroed" \
         "CLOCK_MONOTONIC moves forwards" \
         "debug_print echoed my message" \
+        "I/O bitmap at TSS+" \
+        "ata-driver: got the ata0 ports" \
+        "the kernel's own ATA driver now refuses ata0" \
+        "IDENTIFY succeeded from ring 3" \
+        "a FAT32 boot sector, signature and all" \
+        "a second sector read back different bytes" \
+        "refused a read past the end of the disk" \
+        "driver exited and gave ata0 back" \
+        "killed for touching its ports" \
         "child: I inherited the value my parent set before forking" \
         "child: my copy of the witness is mine" \
         "parent: still writable after the child exited" \
@@ -403,11 +415,17 @@ check-cli)
         type_line "df"
         sleep 1
         echo quit
-    } | timeout 180 qemu-system-x86_64 "${QEMU_ARGS[@]}" \
+    # 240s, not 180: the session now also spawns a disk driver twice and waits
+    # for it to identify a drive and serve four requests each time.
+    } | timeout 240 qemu-system-x86_64 "${QEMU_ARGS[@]}" \
             -serial "file:$SERIAL" -display none -monitor stdio >/dev/null 2>&1 || true
 
     echo "--- console session ---"
-    sed -n '/ksh: the Kosh shell/,$p' "$SERIAL" 2>/dev/null | head -110
+    # `|| true` because `head` closing the pipe sends SIGPIPE to `sed`, and
+    # `set -o pipefail` turns that into a failed script — a failure mode that
+    # only appears once the log grows past the line limit, which is to say on
+    # the day you add output rather than the day you write the line.
+    { sed -n '/ksh: the Kosh shell/,$p' "$SERIAL" 2>/dev/null | head -110; } || true
     echo "-----------------------"
 
     fail=0
@@ -436,6 +454,9 @@ check-cli)
         "background" \
         "hello2 here: exec replaced the whole image" \
         "child: messaging my grandparent was refused" \
+        "the ring-3 driver identified a disk of" \
+        "read LBA 0 in ring 3: a FAT32 boot sector" \
+        "killed for touching its ports" \
         "ksh: exiting" \
         "ksh exited with code 0, falling back to the kernel console" \
         "Kosh console" \

--- a/userspace/ata-driver/Cargo.toml
+++ b/userspace/ata-driver/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "kosh-ata-driver"
+version = "0.1.0"
+edition = "2021"
+
+# The ATA PIO driver, in ring 3.
+#
+# The kernel has one of these too, at kernel/src/block/ata.rs, and this is
+# deliberately close to a transcription of it: the point of the exercise is that
+# the *same* driver logic runs unprivileged, so any difference between the two is
+# a difference the privilege boundary forced, not one the rewrite introduced.
+#
+# It talks to the disk with `in` and `out` directly — no syscall per port — which
+# the TSS I/O permission bitmap makes possible, and answers block-read requests
+# over IPC.
+
+[dependencies]
+
+[[bin]]
+name = "kosh-ata-driver"
+path = "src/main.rs"

--- a/userspace/ata-driver/build.rs
+++ b/userspace/ata-driver/build.rs
@@ -1,0 +1,8 @@
+use std::path::PathBuf;
+
+fn main() {
+    let dir = PathBuf::from(std::env::var("CARGO_MANIFEST_DIR").unwrap());
+    println!("cargo:rustc-link-arg=-T{}", dir.join("user.ld").display());
+    println!("cargo:rerun-if-changed=user.ld");
+    println!("cargo:rerun-if-changed=build.rs");
+}

--- a/userspace/ata-driver/src/main.rs
+++ b/userspace/ata-driver/src/main.rs
@@ -1,0 +1,428 @@
+//! The ATA disk driver, in ring 3.
+//!
+//! `kernel/src/block/ata.rs` does the same job inside the kernel, and this is
+//! close to a transcription of it on purpose. A microkernel's claim is that a
+//! driver does not need privilege to drive hardware — only *access* to that
+//! hardware — and the way to test that claim is to move a driver across the
+//! boundary and see what the move costs. The answer here is: two system calls at
+//! startup and an IPC round trip per request. The register programming, the
+//! status polling and the 256 `in` instructions per sector are identical, and
+//! they are ordinary unprivileged instructions that the CPU permits because the
+//! TSS I/O permission bitmap has 9 bits cleared for this thread and no others.
+//!
+//! What it cannot do is exactly what a driver should not be able to do: touch
+//! the interrupt controller, the timer, the CMOS or the serial port. `ata0` is a
+//! name in a kernel table, and the table decides what ports the name means.
+
+#![no_std]
+#![no_main]
+
+use core::panic::PanicInfo;
+
+const SYS_EXIT: u64 = 1;
+const SYS_WRITE: u64 = 23;
+const SYS_SEND_MESSAGE: u64 = 30;
+const SYS_RECEIVE_MESSAGE: u64 = 31;
+const SYS_REQUEST_DEVICE: u64 = 44;
+
+// --- the block protocol ----------------------------------------------------
+//
+// Fixed-layout little-endian records rather than anything self-describing. Both
+// ends are in this repository and a parser is a thing that can be wrong.
+
+const REQ_MAGIC: u32 = 0x4B42_4C4B; // "KBLK"
+const REP_MAGIC: u32 = 0x4B52_504C; // "KRPL"
+
+const OP_READ: u32 = 0;
+const OP_INFO: u32 = 1;
+const OP_SHUTDOWN: u32 = 2;
+
+/// Request: magic, op, lba, count. 24 bytes.
+const REQ_BYTES: usize = 24;
+/// Reply header: magic, status, len, reserved. 16 bytes, then the payload.
+const REP_HEADER: usize = 16;
+
+/// A message is capped at 4096 bytes by the kernel, so a reply carries at most
+/// (4096 - 16) / 512 = 7 sectors. Four is the advertised limit, which leaves the
+/// header room and makes the arithmetic obvious.
+const MAX_SECTORS: usize = 4;
+const SECTOR: usize = 512;
+
+const STATUS_OK: i32 = 0;
+const STATUS_BAD_REQUEST: i32 = -1;
+const STATUS_DEVICE_ERROR: i32 = -2;
+const STATUS_TIMEOUT: i32 = -3;
+const STATUS_OUT_OF_RANGE: i32 = -4;
+
+// --- syscalls --------------------------------------------------------------
+
+#[inline(always)]
+unsafe fn syscall3(number: u64, a1: u64, a2: u64, a3: u64) -> i64 {
+    let ret: i64;
+    core::arch::asm!(
+        "syscall",
+        inlateout("rax") number => ret,
+        in("rdi") a1,
+        in("rsi") a2,
+        in("rdx") a3,
+        lateout("rcx") _,
+        lateout("r11") _,
+        options(nostack)
+    );
+    ret
+}
+
+fn print(s: &str) {
+    unsafe { syscall3(SYS_WRITE, 1, s.as_ptr() as u64, s.len() as u64) };
+}
+
+fn exit(code: u64) -> ! {
+    unsafe { syscall3(SYS_EXIT, code, 0, 0) };
+    loop {
+        core::hint::spin_loop();
+    }
+}
+
+// --- port I/O --------------------------------------------------------------
+//
+// The whole point. These are the same instructions the kernel's driver uses, in
+// a process with no privilege whatsoever; the CPU checks the bitmap, finds the
+// bit clear, and lets them run. Every one of them is a #GP in any other process
+// on the system.
+
+#[inline(always)]
+unsafe fn inb(port: u16) -> u8 {
+    let value: u8;
+    core::arch::asm!("in al, dx", out("al") value, in("dx") port, options(nomem, nostack, preserves_flags));
+    value
+}
+
+#[inline(always)]
+unsafe fn outb(port: u16, value: u8) {
+    core::arch::asm!("out dx, al", in("dx") port, in("al") value, options(nomem, nostack, preserves_flags));
+}
+
+#[inline(always)]
+unsafe fn inw(port: u16) -> u16 {
+    let value: u16;
+    core::arch::asm!("in ax, dx", out("ax") value, in("dx") port, options(nomem, nostack, preserves_flags));
+    value
+}
+
+// --- the drive -------------------------------------------------------------
+
+const IO_BASE: u16 = 0x1F0;
+const CONTROL_BASE: u16 = 0x3F6;
+
+const STATUS_ERR: u8 = 0x01;
+const STATUS_DRQ: u8 = 0x08;
+const STATUS_DF: u8 = 0x20;
+const STATUS_BSY: u8 = 0x80;
+
+const CMD_READ_SECTORS: u8 = 0x20;
+const CMD_IDENTIFY: u8 = 0xEC;
+
+const POLL_LIMIT: u32 = 10_000_000;
+
+static mut BLOCKS: u64 = 0;
+static mut MODEL: [u8; 41] = [0; 41];
+
+fn status() -> u8 {
+    unsafe { inb(IO_BASE + 7) }
+}
+
+/// ~400 ns, via four reads of the *alternate* status register. Reading the
+/// ordinary one acknowledges a pending interrupt, which a delay should not do.
+fn delay_400ns() {
+    for _ in 0..4 {
+        unsafe {
+            let _ = inb(CONTROL_BASE);
+        }
+    }
+}
+
+fn wait_not_busy() -> Result<(), i32> {
+    for _ in 0..POLL_LIMIT {
+        if status() & STATUS_BSY == 0 {
+            return Ok(());
+        }
+    }
+    Err(STATUS_TIMEOUT)
+}
+
+fn wait_ready_for_data() -> Result<(), i32> {
+    for _ in 0..POLL_LIMIT {
+        let s = status();
+        if s & (STATUS_ERR | STATUS_DF) != 0 {
+            return Err(STATUS_DEVICE_ERROR);
+        }
+        if s & STATUS_BSY == 0 && s & STATUS_DRQ != 0 {
+            return Ok(());
+        }
+    }
+    Err(STATUS_TIMEOUT)
+}
+
+/// IDENTIFY the primary master, filling in [`BLOCKS`] and [`MODEL`].
+fn identify() -> Result<(), i32> {
+    unsafe {
+        // A floating bus reads 0xFF: nothing is driving the lines.
+        if inb(IO_BASE + 7) == 0xFF {
+            return Err(STATUS_DEVICE_ERROR);
+        }
+
+        outb(IO_BASE + 6, 0xA0); // master
+        outb(IO_BASE + 2, 0);
+        outb(IO_BASE + 3, 0);
+        outb(IO_BASE + 4, 0);
+        outb(IO_BASE + 5, 0);
+        outb(IO_BASE + 7, CMD_IDENTIFY);
+
+        if inb(IO_BASE + 7) == 0 {
+            return Err(STATUS_DEVICE_ERROR);
+        }
+
+        wait_not_busy()?;
+
+        // Non-zero LBA mid/high is an ATAPI or SATA device answering a command
+        // it does not implement.
+        if inb(IO_BASE + 4) != 0 || inb(IO_BASE + 5) != 0 {
+            return Err(STATUS_DEVICE_ERROR);
+        }
+
+        wait_ready_for_data()?;
+
+        let mut data = [0u16; 256];
+        for word in data.iter_mut() {
+            *word = inw(IO_BASE);
+        }
+
+        BLOCKS = (data[60] as u64) | ((data[61] as u64) << 16);
+        if BLOCKS == 0 {
+            return Err(STATUS_DEVICE_ERROR);
+        }
+
+        // Words 27..46, byte-swapped within each word.
+        for i in 0..20 {
+            let w = data[27 + i];
+            MODEL[i * 2] = (w >> 8) as u8;
+            MODEL[i * 2 + 1] = (w & 0xFF) as u8;
+        }
+        let mut end = 40;
+        while end > 0 && (MODEL[end - 1] == b' ' || MODEL[end - 1] == 0) {
+            end -= 1;
+        }
+        MODEL[end] = 0;
+    }
+
+    Ok(())
+}
+
+/// Read `count` sectors from `lba` into `out`. One sector per command, as the
+/// kernel's driver does, so a mid-transfer failure names a sector.
+fn read_sectors(lba: u64, count: usize, out: &mut [u8]) -> Result<(), i32> {
+    if unsafe { lba + count as u64 > BLOCKS } {
+        return Err(STATUS_OUT_OF_RANGE);
+    }
+
+    for sector in 0..count {
+        let this = lba + sector as u64;
+        wait_not_busy()?;
+
+        unsafe {
+            // 0xE0 selects LBA mode; the low nibble is LBA bits 24..27.
+            outb(IO_BASE + 6, 0xE0 | (((this >> 24) & 0x0F) as u8));
+            outb(IO_BASE + 1, 0); // features
+            outb(IO_BASE + 2, 1); // one sector
+            outb(IO_BASE + 3, (this & 0xFF) as u8);
+            outb(IO_BASE + 4, ((this >> 8) & 0xFF) as u8);
+            outb(IO_BASE + 5, ((this >> 16) & 0xFF) as u8);
+            delay_400ns();
+            outb(IO_BASE + 7, CMD_READ_SECTORS);
+        }
+
+        wait_ready_for_data()?;
+
+        let base = sector * SECTOR;
+        let mut i = 0;
+        while i < SECTOR {
+            let word = unsafe { inw(IO_BASE) };
+            out[base + i] = (word & 0xFF) as u8;
+            out[base + i + 1] = (word >> 8) as u8;
+            i += 2;
+        }
+    }
+
+    Ok(())
+}
+
+// --- serving ---------------------------------------------------------------
+
+static mut REQUEST: [u8; 64] = [0; 64];
+static mut REPLY: [u8; REP_HEADER + MAX_SECTORS * SECTOR] = [0; REP_HEADER + MAX_SECTORS * SECTOR];
+
+fn read_u32(buf: &[u8], at: usize) -> u32 {
+    u32::from_le_bytes([buf[at], buf[at + 1], buf[at + 2], buf[at + 3]])
+}
+
+fn read_u64(buf: &[u8], at: usize) -> u64 {
+    let mut v = [0u8; 8];
+    v.copy_from_slice(&buf[at..at + 8]);
+    u64::from_le_bytes(v)
+}
+
+fn write_u32(buf: &mut [u8], at: usize, value: u32) {
+    buf[at..at + 4].copy_from_slice(&value.to_le_bytes());
+}
+
+fn write_u64(buf: &mut [u8], at: usize, value: u64) {
+    buf[at..at + 8].copy_from_slice(&value.to_le_bytes());
+}
+
+/// Fill the reply header and send `payload_len` bytes after it.
+fn reply(to: u32, status: i32, payload_len: usize) {
+    unsafe {
+        let reply = &mut *core::ptr::addr_of_mut!(REPLY);
+        write_u32(reply, 0, REP_MAGIC);
+        write_u32(reply, 4, status as u32);
+        write_u32(reply, 8, payload_len as u32);
+        write_u32(reply, 12, 0);
+
+        syscall3(
+            SYS_SEND_MESSAGE,
+            to as u64,
+            reply.as_ptr() as u64,
+            (REP_HEADER + payload_len) as u64,
+        );
+    }
+}
+
+/// Handle one request. Returns false when told to shut down.
+fn serve_one() -> bool {
+    let received = unsafe {
+        let request = &mut *core::ptr::addr_of_mut!(REQUEST);
+        syscall3(
+            SYS_RECEIVE_MESSAGE,
+            request.as_mut_ptr() as u64,
+            request.len() as u64,
+            1, // blocking: park the thread, do not spin
+        )
+    };
+
+    if received < 0 {
+        print("  ata-driver: receive failed, stopping\n");
+        return false;
+    }
+
+    let sender = (received as u64 >> 32) as u32;
+    let len = (received as u64 & 0xFFFF_FFFF) as usize;
+
+    let request = unsafe { &*core::ptr::addr_of!(REQUEST) };
+
+    if len < REQ_BYTES || read_u32(request, 0) != REQ_MAGIC {
+        reply(sender, STATUS_BAD_REQUEST, 0);
+        return true;
+    }
+
+    let op = read_u32(request, 4);
+    let lba = read_u64(request, 8);
+    let count = read_u32(request, 16) as usize;
+
+    match op {
+        OP_INFO => {
+            unsafe {
+                let reply_buf = &mut *core::ptr::addr_of_mut!(REPLY);
+                write_u64(reply_buf, REP_HEADER, BLOCKS);
+                let model = &*core::ptr::addr_of!(MODEL);
+                reply_buf[REP_HEADER + 8..REP_HEADER + 8 + 41].copy_from_slice(model);
+            }
+            reply(sender, STATUS_OK, 8 + 41);
+            true
+        }
+        OP_READ => {
+            if count == 0 || count > MAX_SECTORS {
+                reply(sender, STATUS_BAD_REQUEST, 0);
+                return true;
+            }
+            let result = unsafe {
+                let reply_buf = &mut *core::ptr::addr_of_mut!(REPLY);
+                read_sectors(lba, count, &mut reply_buf[REP_HEADER..])
+            };
+            match result {
+                Ok(()) => reply(sender, STATUS_OK, count * SECTOR),
+                Err(status) => reply(sender, status, 0),
+            }
+            true
+        }
+        OP_SHUTDOWN => {
+            reply(sender, STATUS_OK, 0);
+            false
+        }
+        _ => {
+            reply(sender, STATUS_BAD_REQUEST, 0);
+            true
+        }
+    }
+}
+
+// --- entry -----------------------------------------------------------------
+
+core::arch::global_asm!(
+    r#"
+.section .text._start, "ax"
+.global _start
+.type _start, @function
+_start:
+    xorq    %rbp, %rbp
+    andq    $-16, %rsp
+    call    ata_driver_main
+1:
+    jmp     1b
+"#,
+    options(att_syntax)
+);
+
+#[no_mangle]
+pub extern "C" fn ata_driver_main() -> ! {
+    print("  ata-driver: starting in ring 3\n");
+
+    // The two system calls that make the rest of this program legal. Everything
+    // after them is `in` and `out` on a disk, executed by an unprivileged
+    // process with its own page tables and no way to reach the kernel's.
+    let device = "ata0";
+    let granted = unsafe {
+        syscall3(
+            SYS_REQUEST_DEVICE,
+            device.as_ptr() as u64,
+            device.len() as u64,
+            0,
+        )
+    };
+
+    if granted < 0 {
+        print("  ata-driver: request_device('ata0') was refused\n");
+        exit(1);
+    }
+    print("  ata-driver: got the ata0 ports\n");
+
+    if let Err(_) = identify() {
+        print("  ata-driver: IDENTIFY failed\n");
+        exit(2);
+    }
+
+    print("  ata-driver: IDENTIFY succeeded from ring 3\n");
+
+    // Serve until told to stop. The parent sends OP_SHUTDOWN when it is done,
+    // which releases `ata0` and lets the kernel's own block layer have the disk
+    // back — see `platform::devports`.
+    while serve_one() {}
+
+    print("  ata-driver: shutting down, releasing ata0\n");
+    exit(0)
+}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    print("  ata-driver panic\n");
+    exit(3)
+}

--- a/userspace/ata-driver/user.ld
+++ b/userspace/ata-driver/user.ld
@@ -1,0 +1,23 @@
+/* Link at 8 MiB, like every other program here.
+ *
+ * A driver is an ordinary process. It gets no special address, no reserved
+ * region and no mapping the kernel would not give `hello` — the only thing it
+ * has that others do not is a set of bits in the TSS I/O permission bitmap,
+ * which is invisible from the linker's point of view. That is the property
+ * worth preserving: if a driver needed a special link address, "driver" would
+ * be a kind of program rather than a capability a program holds.
+ */
+
+ENTRY(_start)
+
+SECTIONS
+{
+    . = 0x800000;
+
+    .text ALIGN(4K) : { *(.text .text.*) }
+    .rodata ALIGN(4K) : { *(.rodata .rodata.*) }
+    .data ALIGN(4K) : { *(.data .data.*) }
+    .bss ALIGN(4K) : { *(COMMON) *(.bss .bss.*) }
+
+    /DISCARD/ : { *(.comment) *(.eh_frame) *(.eh_frame_hdr) *(.note .note.*) }
+}

--- a/userspace/hello/src/main.rs
+++ b/userspace/hello/src/main.rs
@@ -31,6 +31,7 @@ const SYS_MUNMAP: u64 = 11;
 const SYS_WRITE: u64 = 23;
 const SYS_CLOCK_GETTIME: u64 = 53;
 const SYS_DEBUG_PRINT: u64 = 100;
+const SYS_SPAWN: u64 = 9;
 
 /// mmap protection bits, as the kernel reads them.
 const PROT_READ: u64 = 0x1;
@@ -161,6 +162,10 @@ fn receive_message(buf: &mut [u8], blocking: bool) -> i64 {
 
 fn exec(name: &str) -> i64 {
     unsafe { syscall3(SYS_EXEC, name.as_ptr() as u64, name.len() as u64, 0) }
+}
+
+fn spawn(name: &str) -> i64 {
+    unsafe { syscall3(SYS_SPAWN, name.as_ptr() as u64, name.len() as u64, 0) }
 }
 
 fn exit(code: u64) -> ! {
@@ -389,6 +394,12 @@ pub extern "C" fn kosh_main() -> ! {
         print("  debug_print echoed my message\n");
     }
 
+    // A driver in ring 3, driving a real disk.
+    drive_a_disk();
+
+    // ...and a process that has no business touching that disk.
+    port_permission_negative_control();
+
     // fork, and the copy-on-write behaviour underneath it.
     //
     // The sequencing is deliberate and not racy: `fork` returns *in the parent*
@@ -529,6 +540,195 @@ pub extern "C" fn kosh_main() -> ! {
 
     print("  exiting cleanly\n");
     exit(0)
+}
+
+// ---------------------------------------------------------------------------
+// A disk driver that is not in the kernel
+// ---------------------------------------------------------------------------
+
+const REQ_MAGIC: u32 = 0x4B42_4C4B; // "KBLK"
+const REP_MAGIC: u32 = 0x4B52_504C; // "KRPL"
+const OP_READ: u32 = 0;
+const OP_INFO: u32 = 1;
+const OP_SHUTDOWN: u32 = 2;
+const REP_HEADER: usize = 16;
+
+static mut BLOCK_REQUEST: [u8; 24] = [0; 24];
+static mut BLOCK_REPLY: [u8; 1024] = [0; 1024];
+
+fn put_u32(buf: &mut [u8], at: usize, v: u32) {
+    buf[at..at + 4].copy_from_slice(&v.to_le_bytes());
+}
+
+fn put_u64(buf: &mut [u8], at: usize, v: u64) {
+    buf[at..at + 8].copy_from_slice(&v.to_le_bytes());
+}
+
+fn get_u32(buf: &[u8], at: usize) -> u32 {
+    u32::from_le_bytes([buf[at], buf[at + 1], buf[at + 2], buf[at + 3]])
+}
+
+/// Send one request to `driver` and block for its reply.
+///
+/// Returns `(status, payload_len)`, with the payload left in `BLOCK_REPLY`
+/// starting at `REP_HEADER`.
+fn block_request(driver: i64, op: u32, lba: u64, count: u32) -> (i32, usize) {
+    unsafe {
+        let request = &mut *core::ptr::addr_of_mut!(BLOCK_REQUEST);
+        put_u32(request, 0, REQ_MAGIC);
+        put_u32(request, 4, op);
+        put_u64(request, 8, lba);
+        put_u32(request, 16, count);
+        put_u32(request, 20, 0);
+
+        if send_message(driver, request) < 0 {
+            return (-100, 0);
+        }
+
+        let reply = &mut *core::ptr::addr_of_mut!(BLOCK_REPLY);
+        let got = receive_message(reply, true);
+        if got < 0 {
+            return (-101, 0);
+        }
+
+        let len = (got & 0xFFFF_FFFF) as usize;
+        if len < REP_HEADER || get_u32(reply, 0) != REP_MAGIC {
+            return (-102, 0);
+        }
+
+        (get_u32(reply, 4) as i32, get_u32(reply, 8) as usize)
+    }
+}
+
+/// Spawn the ring-3 ATA driver, read the disk through it, and shut it down.
+///
+/// The evidence that this is real and not a stub is the content: the driver
+/// returns the FAT32 boot sector `mkfs.vfat` wrote into `build/disk.img`, and
+/// the checks below are on bytes nobody in this program chose — the 0xEB jump
+/// opcode, the "mkfs.fat" OEM name at offset 3, the "FAT32" type string at 82
+/// and the 0x55AA signature at 510. A driver that could not talk to the disk
+/// could not produce any of them.
+fn drive_a_disk() {
+    let driver = spawn("ata-driver");
+    if driver < 0 {
+        print("  WARNING: could not spawn the ata-driver\\n");
+        return;
+    }
+
+    let (status, len) = block_request(driver, OP_INFO, 0, 0);
+    if status != 0 || len < 8 {
+        print("  WARNING: the driver could not identify the disk\\n");
+    } else {
+        let blocks = unsafe {
+            let reply = &*core::ptr::addr_of!(BLOCK_REPLY);
+            let mut v = [0u8; 8];
+            v.copy_from_slice(&reply[REP_HEADER..REP_HEADER + 8]);
+            u64::from_le_bytes(v)
+        };
+        print("  the ring-3 driver identified a disk of ");
+        print_i64(blocks as i64);
+        print(" sectors\\n");
+    }
+
+    let (status, len) = block_request(driver, OP_READ, 0, 1);
+    if status != 0 || len != 512 {
+        print("  WARNING: reading LBA 0 through the driver failed, status ");
+        print_i64(status as i64);
+        print("\\n");
+    } else {
+        let sector = unsafe {
+            let reply = &*core::ptr::addr_of!(BLOCK_REPLY);
+            &reply[REP_HEADER..REP_HEADER + 512]
+        };
+
+        let signature = sector[510] == 0x55 && sector[511] == 0xAA;
+        let jump = sector[0] == 0xEB || sector[0] == 0xE9;
+        let oem = &sector[3..11] == b"mkfs.fat";
+        let fat32 = &sector[82..87] == b"FAT32";
+
+        if signature && jump && oem && fat32 {
+            print("  read LBA 0 in ring 3: a FAT32 boot sector, signature and all\\n");
+        } else {
+            print("  WARNING: LBA 0 does not look like the test disk\\n");
+        }
+    }
+
+    // A sector that is not the boot sector, so "the driver returns one canned
+    // buffer" is not an explanation that survives.
+    let (status, len) = block_request(driver, OP_READ, 32, 1);
+    if status == 0 && len == 512 {
+        let differs = unsafe {
+            let reply = &*core::ptr::addr_of!(BLOCK_REPLY);
+            reply[REP_HEADER + 510] != 0x55 || reply[REP_HEADER + 511] != 0xAA
+        };
+        if differs {
+            print("  a second sector read back different bytes\\n");
+        } else {
+            print("  WARNING: LBA 32 looks identical to LBA 0\\n");
+        }
+    }
+
+    // Out of range: the driver has to refuse rather than wedge on a status
+    // register that never becomes ready.
+    let (status, _) = block_request(driver, OP_READ, 1 << 40, 1);
+    if status != 0 {
+        print("  the driver refused a read past the end of the disk\\n");
+    } else {
+        print("  WARNING: the driver accepted an impossible LBA\\n");
+    }
+
+    block_request(driver, OP_SHUTDOWN, 0, 0);
+
+    let mut status: i32 = 0;
+    wait(driver, &mut status);
+    if status == 0 {
+        print("  the driver exited and gave ata0 back\\n");
+    } else {
+        print("  WARNING: the driver exited with ");
+        print_i64(status as i64);
+        print("\\n");
+    }
+}
+
+/// Exit code the kernel gives a process it terminates for a fault.
+const EXIT_KILLED: i32 = -9;
+
+/// Prove that the ports the driver used are not simply open to everyone.
+///
+/// Done in a forked child because the expected outcome is death: this process
+/// has no `ata0` grant, so the `in` below raises #GP, and the kernel's job is to
+/// kill the process and leave the rest of the system running. The parent
+/// surviving to print the result *is* the second half of the test — before this
+/// phase every exception except a page fault halted the machine.
+fn port_permission_negative_control() {
+    let child = fork();
+    if child < 0 {
+        print("  WARNING: could not fork for the port-permission test\\n");
+        return;
+    }
+
+    if child == 0 {
+        // 0x1F7 is the ATA status register: the exact port the driver just read
+        // hundreds of times, from a process that was granted it.
+        let value: u8;
+        unsafe {
+            core::arch::asm!("in al, dx", out("al") value, in("dx") 0x1F7u16, options(nomem, nostack));
+        }
+        print("  WARNING: read an ATA port without a capability, value ");
+        print_i64(value as i64);
+        print("\\n");
+        exit(0);
+    }
+
+    let mut status: i32 = 0;
+    wait(child, &mut status);
+    if status == EXIT_KILLED {
+        print("  a process without the ata0 grant was killed for touching its ports\\n");
+    } else {
+        print("  WARNING: the unprivileged port read was not stopped, status ");
+        print_i64(status as i64);
+        print("\\n");
+    }
 }
 
 fn print_hex(mut value: u64) {


### PR DESCRIPTION
kernel/src/block/ata.rs is 334 lines that read eight I/O ports and poll a status register. Nothing about that needs privilege, and every phase so far has said the point of a microkernel is that such things run outside the kernel. This moves one.

userspace/ata-driver is the same driver as an ordinary unprivileged process: its own address space, linked at 8 MiB like hello and ksh, loaded by the same ELF loader. It IDENTIFYs the primary master, serves block reads over IPC and exits. The only thing it has that they do not is nine bits in a bitmap.

A ring-3 driver has to execute in and out, and there are three ways to allow it. A port-I/O syscall is safe and unusable — a 512-byte sector is 256 port reads, so one sector becomes 256 round trips through the syscall stub. IOPL=3 is one bit and grants every port, including the PIC at 0x20 and the keyboard controller at 0x64; a disk driver that can stop the scheduler is not isolated in any sense that matters. The TSS I/O permission bitmap is one bit per port, checked by the CPU, so a granted port is free and a denied one is a #GP. gdt.rs now carries one: 128 bytes covering ports 0..1023, all ones by default.

Two things had to change to get it. TaskStateSegment has an iomap_base field and no room after it, and Descriptor::tss_segment hard-codes the limit to size_of::<TaskStateSegment>() - 1 — a bitmap past the limit reads as all ones, which is a fine default and not a bitmap. So the TSS is wrapped in a packed struct with the bitmap and its mandatory 0xFF terminator, and the descriptor is built by hand. The bitmap is per-task in the hardware's sense, so it is rewritten on context switch from the incoming thread's grant, cached, alongside RSP0 and for the same reason: forget one and a thread lands on another's kernel stack, forget the other and it inherits another's hardware.

SYS_REQUEST_DEVICE takes a device *name*. platform/devports.rs decides what the name means — ata0 is 0x1F0..0x1F7 and 0x3F6, ata1 the secondary pair, and that is the whole table. The PIC, the PIT, the keyboard controller, the CMOS and COM1 are deliberately absent: a driver cannot ask for them because there is no name for them. The capability check is the existing DeviceAccess scoped to Device("ata0").

What grants that capability is the weak link and is written as a table to say so: DRIVER_IMAGES recognises a boot module by the name on its module2 line. The trust root is "GRUB loaded it from the ISO", which is defensible for a boot-time driver and useless for anything later. init delegating is what makes it a chain.

The kernel still has an ATA driver, and fat32 reads through it. Two drivers polling one register set do not race loudly — one writes the LBA registers, the other writes its own, and the next command reads whichever sector the last writer named. So devports keeps a claim, checked on every entry point of block/ata.rs rather than once at probe time, and released from deregister_process before the message queue: a driver that crashes must not take its disk with it.

hello checks bytes it did not choose — the 0xEB jump opcode, the mkfs.fat OEM name at 3, FAT32 at 82, 0x55AA at 510 — then a second sector, so "returns one canned buffer" does not survive, then a read past the end of the disk, which has to be refused rather than spin. Then the negative control, in a forked child because the expected outcome is death: no ata0 grant, in on 0x1F7, killed. Removing task::grant_io_device while keeping the capability and the claim turns the driver's first in into a #GP at rip 0x800073.

Ring-3 faults stop being fatal to the machine. The page-fault handler has killed ring-3 threads since Phase 5; every other handler halted, so the argument applied only to the one exception a program was expected to cause. fault() now decides from the saved CS's RPL, for every vector. Ring 0 still halts, and #DF and #MC halt regardless — a double fault means the CPU could not deliver the first exception, so the machinery that would kill the process has already failed once.

That uncovered a bug five phases old. An exception with an error code pushes six quadwords onto a stack the CPU already aligned to 16, so the handler starts with RSP % 16 == 0; the SysV ABI says a function starts at 8. LLVM's x86-interrupt convention does not reconcile them, so every frame below the handler is eight bytes off and the first movaps to an aligned stack slot faults. It never fired because the only handler doing real work was the page-fault one and the only process it killed was a demo with no message queue — killing a *registered* process reaches BTreeMap::remove, which spills SSE registers to aligned slots.

Two wrong diagnoses first. Instrumenting the handlers showed #PF and #GP at the same alignment, which proves nothing without a baseline. Instrumenting on_thread_exit — one function, reached from both the normal exit and the kill — showed 0 from one and 8 from the other.

kosh_call_aligned fixes it, and two things about it are load-bearing. It is global_asm!, not inline asm!: an inline block with a call must declare clobber_abi("C"), which in an x86-interrupt function states that the handler clobbers xmm0-15, so LLVM preserves them with movaps into aligned slots in the handler's own prologue — the handler then re-faults on entry forever and surfaces as a double fault from stack exhaustion. And the old rsp is parked in a stack slot rather than a callee-saved register, because clobber_abi covers only the caller-saved set and the allocator will happily hand an argument r15.

62 boot markers and 35 console markers pass.


Claude-Session: https://claude.ai/code/session_01P1GdpYMiKP5Gj1Jmub59gw